### PR TITLE
Setup GraphQL queries and mutations for applicants

### DIFF
--- a/lib/applicants/errors.ts
+++ b/lib/applicants/errors.ts
@@ -1,0 +1,12 @@
+import { ApolloError } from 'apollo-server-errors';
+
+/**
+ * Applicant with same email already exists
+ */
+export class ApplicantAlreadyExistsError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'APPLICANT_ALREADY_EXISTS');
+
+    Object.defineProperty(this, 'name', { value: 'ApplicantAlreadyExistsError' });
+  }
+}

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -1,0 +1,43 @@
+import { ApolloError } from 'apollo-server-errors'; // Apollo error
+import { Resolver } from '@lib/resolvers'; // Resolver type
+import { ApplicantAlreadyExistsError } from '@lib/applicants/errors'; // Employee errors
+import { DBErrorCode } from '@lib/db/errors'; // Database errors
+
+/**
+ * Query all the RCD applicants in the internal-facing app
+ * @returns All RCD applicants
+ */
+export const applicants: Resolver = async (_parent, _args, { prisma }) => {
+  const applicants = await prisma.applicant.findMany();
+  return applicants;
+};
+
+/**
+ * Create an applicant
+ * @returns Status of operation (ok, error)
+ */
+export const createApplicant: Resolver = async (_, args, { prisma }) => {
+  const {
+    input: { email },
+  } = args;
+
+  let applicant;
+  try {
+    applicant = await prisma.applicant.create({
+      data: { ...args.input },
+    });
+  } catch (err) {
+    if (err.code === DBErrorCode.UniqueConstraintFailed && err.meta.target.includes('email')) {
+      throw new ApplicantAlreadyExistsError(`Applicant with email ${email} already exists`);
+    }
+  }
+
+  // Throw internal server error if applicant was not created
+  if (!applicant) {
+    throw new ApolloError('Applicant was unable to be created');
+  }
+
+  return {
+    ok: true,
+  };
+};

--- a/lib/applicants/schema.graphql
+++ b/lib/applicants/schema.graphql
@@ -1,0 +1,46 @@
+# TODO: Integrate commented out types (ApplicantStatus, Application, Guardian, MedicalInformation, Permit)
+
+type Applicant {
+  id: ID!
+  firstName: String!
+  middleName: String
+  lastName: String!
+  dateOfBirth: Date!
+  gender: Gender!
+  email: String
+  phone: String!
+  province: Province!
+  city: String!
+  address: String!
+  postalCode: String!
+  rcdUserId: Int
+  # status: ApplicantStatus
+  # applications: [Application!]
+  # guardian: Guardian
+  # medicalInformation: MedicalInformation
+  # permits: [Permit!]
+}
+
+input CreateApplicantInput {
+  firstName: String!
+  middleName: String
+  lastName: String!
+  dateOfBirth: Date!
+  gender: Gender!
+  email: String
+  phone: String!
+  province: Province!
+  city: String!
+  address: String!
+  postalCode: String!
+  rcdUserId: Int
+  # status: ApplicantStatus
+  # applications: [Application!]
+  # guardian: Guardian
+  # medicalInformation: MedicalInformation
+  # permits: [Permit!]
+}
+
+type CreateApplicantResult {
+  ok: Boolean!
+}

--- a/lib/employees/schema.graphql
+++ b/lib/employees/schema.graphql
@@ -1,4 +1,5 @@
 type Employee {
+  id: ID!
   firstName: String!
   lastName: String!
   email: String!

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -1,7 +1,9 @@
 import { meta } from '@lib/meta/resolvers'; // Metadata resolvers
 import { employees, createEmployee } from '@lib/employees/resolvers'; // Employee resolvers
+import { applicants, createApplicant } from '@lib/applicants/resolvers'; // Applicant resolvers
 import { IFieldResolver } from 'graphql-tools'; // GraphQL field resolver
 import { Context } from '@lib/context'; // Context type
+import { dateScalar } from '@lib/scalars'; // Custom date scalar implementation
 
 // Resolver type
 export type Resolver<P = undefined> = IFieldResolver<P, Context>;
@@ -9,11 +11,14 @@ export type Resolver<P = undefined> = IFieldResolver<P, Context>;
 const resolvers = {
   Query: {
     meta,
+    applicants,
     employees,
   },
   Mutation: {
+    createApplicant,
     createEmployee,
   },
+  Date: dateScalar,
 };
 
 export default resolvers;

--- a/lib/graphql/scalars.ts
+++ b/lib/graphql/scalars.ts
@@ -1,0 +1,19 @@
+import { GraphQLScalarType, Kind } from 'graphql'; // GraphQL TS types
+
+// Date scalar requires custom implementation: https://www.apollographql.com/docs/apollo-server/schema/custom-scalars/
+export const dateScalar = new GraphQLScalarType({
+  name: 'Date',
+  description: 'Date custom scalar type',
+  serialize(value: Date) {
+    return value.getTime(); // Convert outgoing Date to integer for JSON
+  },
+  parseValue(value: number) {
+    return new Date(value); // Convert incoming integer to Date
+  },
+  parseLiteral(ast: any) {
+    if (ast.kind === Kind.INT) {
+      return new Date(parseInt(ast.value, 10)); // Convert hard-coded AST string to integer and then to Date
+    }
+    return null; // Invalid hard-coded value (not an integer)
+  },
+});

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -6,9 +6,6 @@ type Query {
 
 type Mutation {
   createApplicant(input: CreateApplicantInput!): CreateApplicantResult!
-}
-
-type Mutation {
   createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
 }
 

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,11 +1,18 @@
 type Query {
   meta: Meta!
+  applicants: [Applicant!]
   employees: [Employee!]
+}
+
+type Mutation {
+  createApplicant(input: CreateApplicantInput!): CreateApplicantResult!
 }
 
 type Mutation {
   createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
 }
+
+scalar Date
 
 enum Role {
   ADMIN

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -13,6 +13,8 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /** Date custom scalar type */
+  Date: any;
 };
 
 export enum Aid {
@@ -23,11 +25,48 @@ export enum Aid {
   Walker = 'WALKER',
 }
 
+export type Applicant = {
+  __typename?: 'Applicant';
+  id: Scalars['ID'];
+  firstName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  dateOfBirth: Scalars['Date'];
+  gender: Gender;
+  email?: Maybe<Scalars['String']>;
+  phone: Scalars['String'];
+  province: Province;
+  city: Scalars['String'];
+  address: Scalars['String'];
+  postalCode: Scalars['String'];
+  rcdUserId?: Maybe<Scalars['Int']>;
+};
+
 export enum ApplicantStatus {
   Active = 'ACTIVE',
   Inactive = 'INACTIVE',
   Deceased = 'DECEASED',
 }
+
+export type CreateApplicantInput = {
+  firstName: Scalars['String'];
+  middleName?: Maybe<Scalars['String']>;
+  lastName: Scalars['String'];
+  dateOfBirth: Scalars['Date'];
+  gender: Gender;
+  email?: Maybe<Scalars['String']>;
+  phone: Scalars['String'];
+  province: Province;
+  city: Scalars['String'];
+  address: Scalars['String'];
+  postalCode: Scalars['String'];
+  rcdUserId?: Maybe<Scalars['Int']>;
+};
+
+export type CreateApplicantResult = {
+  __typename?: 'CreateApplicantResult';
+  ok: Scalars['Boolean'];
+};
 
 export type CreateEmployeeInput = {
   firstName: Scalars['String'];
@@ -62,7 +101,12 @@ export type Meta = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  createApplicant: CreateApplicantResult;
   createEmployee: CreateEmployeeResult;
+};
+
+export type MutationCreateApplicantArgs = {
+  input: CreateApplicantInput;
 };
 
 export type MutationCreateEmployeeArgs = {
@@ -108,6 +152,7 @@ export enum Province {
 export type Query = {
   __typename?: 'Query';
   meta: Meta;
+  applicants?: Maybe<Array<Applicant>>;
   employees?: Maybe<Array<Employee>>;
 };
 

--- a/prisma/index.ts
+++ b/prisma/index.ts
@@ -10,6 +10,8 @@ declare const global: CustomNodeJsGlobal;
 
 const prisma = global.prisma || new PrismaClient();
 
-if (process.env.NODE_ENV === 'development') global.prisma = prisma;
+if (process.env.NODE_ENV === 'development') {
+  global.prisma = prisma;
+}
 
 export default prisma;

--- a/prisma/index.ts
+++ b/prisma/index.ts
@@ -1,5 +1,15 @@
 import { PrismaClient } from '@prisma/client'; // Prisma ORM
 
-const prisma = new PrismaClient(); // Declare client
+// add prisma to the NodeJS global type
+interface CustomNodeJsGlobal extends NodeJS.Global {
+  prisma: PrismaClient;
+}
 
-export default prisma; // Export client
+// Prevent multiple instances of Prisma Client in development
+declare const global: CustomNodeJsGlobal;
+
+const prisma = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV === 'development') global.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
- Adds GraphQL Queries + Mutations for Applicants (createApplicant mutation, applicants query)
- Adds Date scalar to GraphQL Schema (e.g. dateOfBirth, certificationDate, etc.)
This date scalar consumes an integer in milliseconds (Unix Time), represents it as a JavaScript Date object on the back-end, and serializes it as an integer in milliseconds (Unix Time)

TODO: Blocked on integrating with other tables (ApplicantStatus, Application, Guardian, MedicalInformation, Permit)