### PR TITLE
[Feature] Add formatting functions for phone number and postal code

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -22,10 +22,12 @@ export const createApplicant: Resolver = async (_, args, { prisma }) => {
 
   let applicant;
   try {
-    input.postalCode = formatPostalCode(input.postalCode);
-    input.phone = formatPhoneNumber(input.phone);
     applicant = await prisma.applicant.create({
-      data: { ...args.input },
+      data: {
+        ...input,
+        postalCode: formatPostalCode(input.postalCode),
+        phone: formatPhoneNumber(input.phone),
+      },
     });
   } catch (err) {
     if (err.code === DBErrorCode.UniqueConstraintFailed && err.meta.target.includes('email')) {

--- a/lib/physicians/resolvers.ts
+++ b/lib/physicians/resolvers.ts
@@ -3,6 +3,7 @@ import { Resolver } from '@lib/resolvers'; // Resolver type
 import { DBErrorCode } from '@lib/db/errors'; // Database errors
 import { PhysicianCreateError } from '@lib/physicians/errors'; // Physician error
 import { Prisma } from '.prisma/client';
+import { formatPhoneNumber, formatPostalCode } from '@lib/utils/format';
 
 /**
  * Query all physicians of RCD applicants
@@ -22,6 +23,8 @@ export const createPhysician: Resolver = async (_, args, { prisma }) => {
 
   let physician;
   try {
+    input.postalCode = formatPostalCode(input.postalCode);
+    input.phone = formatPhoneNumber(input.phone);
     physician = await prisma.physician.create({
       data: { ...input },
     });

--- a/lib/physicians/resolvers.ts
+++ b/lib/physicians/resolvers.ts
@@ -23,10 +23,12 @@ export const createPhysician: Resolver = async (_, args, { prisma }) => {
 
   let physician;
   try {
-    input.postalCode = formatPostalCode(input.postalCode);
-    input.phone = formatPhoneNumber(input.phone);
     physician = await prisma.physician.create({
-      data: { ...input },
+      data: {
+        ...input,
+        postalCode: formatPostalCode(input.postalCode),
+        phone: formatPhoneNumber(input.phone),
+      },
     });
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError) {

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -1,14 +1,16 @@
 /**
- * Format North American phone number.
- * Remove all non-numeric characters.
+ * Format North American phone number by removing all non-numeric characters.
+ * @param {string} phone phone number to be formatted
+ * @returns {string} formatted phone number
  */
 export const formatPhoneNumber = (phone: string): string => {
   return phone?.replace(/\D/g, '');
 };
 
 /**
- * Format Canadian postal code.
- * Remove all non-alphanumeric characters.
+ * Format Canadian postal code by removing all non-alphanumeric characters.
+ * @param {string} postalCode postal code to be formatted
+ * @returns {string} formatted postal code
  */
 export const formatPostalCode = (postalCode: string): string => {
   return postalCode?.replace(/[^A-Za-z\d]/g, '');

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -1,0 +1,15 @@
+/**
+ * Format North American phone number.
+ * Remove all non-numeric characters.
+ */
+export const formatPhoneNumber = (phone: string): string => {
+  return phone?.replace(/\D/g, '');
+};
+
+/**
+ * Format Canadian postal code.
+ * Remove all non-alphanumeric characters.
+ */
+export const formatPostalCode = (postalCode: string): string => {
+  return postalCode?.replace(/[^A-Za-z\d]/g, '');
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Function for formatting db fields](https://www.notion.so/uwblueprintexecs/Function-for-formatting-DB-fields-887ec602da7043539495d87bfa44871f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added formatting functions for phone number and postal codes under `lib/utils/format.ts` which remove extra characters from these fields
* called these functions in applicant and physician resolvers


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Some sort of data validation should probably be done before formatting, didn't put it in this PR to keep things concise 
* any other formatting that should be done before saving?


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
