### PR TITLE
[Feature] Renewal Flow Frontend

### DIFF
--- a/components/applicant/Layout.tsx
+++ b/components/applicant/Layout.tsx
@@ -6,9 +6,9 @@ import Image from 'next/image'; // Optimized images
 import { Box, Flex, Grid, GridItem, Button, Center, Text, Spacer, Divider } from '@chakra-ui/react'; // Chakra UI
 
 type Props = {
-  children: ReactNode;
-  header?: boolean;
-  footer?: boolean;
+  readonly children: ReactNode;
+  readonly header?: boolean;
+  readonly footer?: boolean;
 };
 
 // Applicant Layout component
@@ -18,7 +18,7 @@ export default function Layout({ children, header = true, footer = true }: Props
       <Meta />
       <Flex flexDirection="column" alignItems="center" minHeight="100vh">
         {header && <Header />}
-        <Flex flexGrow={1} width="100%" justifyContent="center">
+        <Flex flexGrow={1} width="100%" justifyContent="center" marginY="64px">
           <ApplicantGrid isContent>{children}</ApplicantGrid>
         </Flex>
         {footer && <Footer />}
@@ -46,13 +46,13 @@ function Meta() {
 // Header
 function Header() {
   return (
-    <Center height={36} width="100%" backgroundColor="#f4f6fc">
+    <Center height="108px" width="100%" backgroundColor="#f4f6fc">
       <ApplicantGrid alignItems="center">
         <GridItem colSpan={1}>
           <Link href="/">
-            <Box cursor="pointer">
-              <Image src="/assets/logo.svg" alt="RCD Logo" height={92} width={82} priority />
-            </Box>
+            <Flex justifyContent="keft" cursor="pointer">
+              <Image src="/assets/logo.svg" alt="RCD Logo" height={68} width={48} priority />
+            </Flex>
           </Link>
         </GridItem>
         <GridItem colSpan={9}>

--- a/components/applicant/renewals/IncompleteSectionAlert.tsx
+++ b/components/applicant/renewals/IncompleteSectionAlert.tsx
@@ -1,0 +1,15 @@
+import { Alert, AlertIcon, AlertTitle } from '@chakra-ui/react'; // Chakra UI
+
+/**
+ * Alert box containing message that user has not fully completed a section of the renewal form
+ */
+export default function IncompleteSectionAlert() {
+  return (
+    <Alert status="error" marginBottom="24px">
+      <AlertIcon />
+      <AlertTitle>
+        {`Please fill this section of the form before continuing to the next section.`}
+      </AlertTitle>
+    </Alert>
+  );
+}

--- a/components/applicant/renewals/ReviewRequestField.tsx
+++ b/components/applicant/renewals/ReviewRequestField.tsx
@@ -1,0 +1,24 @@
+import { Flex, Text } from '@chakra-ui/react'; // Chakra UI
+
+type Props = {
+  readonly name: string;
+  readonly value: string;
+};
+
+/**
+ * Field (eg. First Name: Oustan) in the Review Request section of the renewal/replacement request flow
+ * @param name - The name of the field (eg. First Name)
+ * @param value - The value of the field (eg. Oustan)
+ */
+export default function ReviewRequestField({ name, value }: Props) {
+  return (
+    <Flex justifyContent="flex-start" marginBottom="12px">
+      <Text as="h4" textStyle="body-bold" display="inline" marginRight="8px">
+        {`${name}: `}
+      </Text>
+      <Text as="p" textStyle="body-regular" display="inline">
+        {value}
+      </Text>
+    </Flex>
+  );
+}

--- a/components/applicant/renewals/TOSModal.tsx
+++ b/components/applicant/renewals/TOSModal.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'; // Linking
+import { useInView } from 'react-intersection-observer'; // Detect when DOM element is in viewport
+import {
+  Box,
+  Flex,
+  Text,
+  Button,
+  Divider,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from '@chakra-ui/react'; // Chakra UI
+
+export default function TOSModal() {
+  // Modal state and close callback
+  const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
+
+  // Hook for detecting when the user has fully scrolled over the last paragraph
+  const [lastParagraphRef, finishedTOS] = useInView({
+    threshold: 1, // Last paragraph needs to be fully scrolled over
+    triggerOnce: true, // Only trigger once
+  });
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="3xl"
+      scrollBehavior="inside"
+      closeOnEsc={false}
+      closeOnOverlayClick={false}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle="display-medium-bold">Terms and Conditions</Text>
+        </ModalHeader>
+        <ModalBody>
+          <Text as="p" textStyle="body-bold" marginBottom="12px">
+            {`Please read these terms of use ("terms of use", "agreement") carefully before using The
+            Permit Renewal service website (“website”, "service") operated by the Richmond Centre
+            for Disability ("us", 'we", "our").`}
+          </Text>
+          <TOSSection sectionTitle={`Conditions of use`}>
+            {`By using this website, you certify that you have read and reviewed this Agreement and
+            that you agree to comply with its terms. If you do not want to be bound by the terms of
+            this Agreement, you are advised to leave the website accordingly. Richmond Centre for
+            Disability (RCD) only grants use and access of this website, its products, and its
+            services to those who have accepted its terms.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`Privacy policy`}>
+            {`Before you continue using RCD Parking Permit Self-service portal, we advise you to read
+            our privacy policy [link to privacy policy] regarding our user data collection. It will
+            help you better understand our practices.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`User information`}>
+            {`As a user of this website, you may be asked to provide private information. You are
+            responsible for ensuring the accuracy of this information, and you are responsible for
+            maintaining the safety and security of your identifying information. You are also
+            responsible for all activities that occur under your login.`}
+            {`If you think there are any
+            possible issues regarding the security of your private information on the website,
+            inform us immediately so we may address it accordingly. We reserve all rights to
+            terminate accounts, edit or remove content and cancel orders in their sole discretion.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`Applicable law`}>
+            {`By visiting this website, you agree that the laws of British Columbia province, without
+            regard to principles of conflict laws, will govern these terms and conditions, or any
+            dispute of any sort that might come between Richmond Centre for Disability and you, or
+            its business partners and associates.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`Disputes`}>
+            {`Any dispute related in any way to your visit to this website from us shall be arbitrated
+            by British Columbia province court and you consent to exclusive jurisdiction and venue
+            of such courts.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`Indemnification`}>
+            {`You agree to indemnify RCD and its affiliates and hold RCD harmless against legal claims
+            and demands that may arise from your use or misuse of our services. We reserve the right
+            to select our own legal counsel.`}
+          </TOSSection>
+          <TOSSection sectionTitle={`Limitation on liability`} isLast>
+            {`RCD is not liable for any damages that may occur to you as a result of your misuse of
+            our website. RCD reserves the right to edit, modify, and change this Agreement any time.
+            We shall let our users know of these changes through electronic mail. This Agreement is
+            an understanding between RCD and the user, and this supersedes and replaces all prior
+            agreements regarding the use of this website.`}
+          </TOSSection>
+          {/* TODO: Find a better way of assigning last paragraph ref */}
+          <a ref={lastParagraphRef} />
+        </ModalBody>
+        <ModalFooter>
+          <Box width="100%">
+            <Divider marginBottom="16px" />
+            <Flex width="100%" justifyContent="flex-start" marginBottom="16px">
+              <Text as="p" textStyle="body-bold">
+                Please read to the end to enable ”I Agree” button.
+              </Text>
+            </Flex>
+            <Flex width="100%" justifyContent="flex-end">
+              <Link href="/">
+                <Button variant="outline" marginRight="12px">{`Go Back to Home Page`}</Button>
+              </Link>
+              <Button variant="solid" disabled={!finishedTOS} onClick={onClose}>{`I Agree`}</Button>
+            </Flex>
+          </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+type TOSSectionProps = {
+  readonly sectionTitle: string;
+  readonly children: string | ReadonlyArray<string>;
+  readonly isLast?: boolean;
+};
+
+function TOSSection(props: TOSSectionProps) {
+  const { sectionTitle, children, isLast } = props;
+
+  return (
+    <Box>
+      <Text as="h6" textStyle="body-bold">
+        {sectionTitle}
+      </Text>
+      {typeof children === 'string' ? (
+        <Text as="p" textStyle="body-regular" marginBottom={isLast ? 0 : '27px'}>
+          {children}
+        </Text>
+      ) : (
+        children.map((paragraph, i) => (
+          <Text key={`paragraph-${i}`} as="p" textStyle="body-regular" marginBottom="27px">
+            {paragraph}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/components/applicant/renewals/TOSModal.tsx
+++ b/components/applicant/renewals/TOSModal.tsx
@@ -98,14 +98,14 @@ export default function TOSModal() {
             <Divider marginBottom="16px" />
             <Flex width="100%" justifyContent="flex-start" marginBottom="16px">
               <Text as="p" textStyle="body-bold">
-                Please read to the end to enable ”I Agree” button.
+                Please read to the end to enable ”I agree” button.
               </Text>
             </Flex>
             <Flex width="100%" justifyContent="flex-end">
               <Link href="/">
-                <Button variant="outline" marginRight="12px">{`Go Back to Home Page`}</Button>
+                <Button variant="outline" marginRight="12px">{`Go back to home page`}</Button>
               </Link>
-              <Button variant="solid" disabled={!finishedTOS} onClick={onClose}>{`I Agree`}</Button>
+              <Button variant="solid" disabled={!finishedTOS} onClick={onClose}>{`I agree`}</Button>
             </Flex>
           </Box>
         </ModalFooter>

--- a/components/internal/Layout.tsx
+++ b/components/internal/Layout.tsx
@@ -25,9 +25,9 @@ import Tab from '@components/internal/navbar/Tab'; // Custom Tab component
 import { authorize } from '@tools/authorization';
 
 type Props = {
-  children: ReactNode;
-  header?: boolean;
-  footer?: boolean;
+  readonly children: ReactNode;
+  readonly header?: boolean;
+  readonly footer?: boolean;
 };
 
 // Internal Layout component

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@chakra-ui/icons": "^1.0.13",
+    "@chakra-ui/icons": "^1.0.14",
     "@chakra-ui/react": "^1.6.2",
     "@emotion/react": "11",
     "@emotion/styled": "11",
@@ -26,6 +26,7 @@
     "@graphql-tools/merge": "^6.2.14",
     "@prisma/client": "^2.22.1",
     "apollo-server-micro": "^2.24.1",
+    "chakra-ui-steps": "^1.1.1",
     "framer-motion": "4",
     "graphql": "^15.5.0",
     "next": "^11.0.0",
@@ -34,6 +35,7 @@
     "nodemailer": "^6.6.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-intersection-observer": "^8.32.0",
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Landing() {
 
   return (
     <Layout>
-      <GridItem colSpan={8} colStart={1} mt="64px">
+      <GridItem colSpan={8} colStart={1}>
         <Text as="h1" textStyle="display-xlarge" align="left">
           {t('landing')}
         </Text>
@@ -53,7 +53,7 @@ export default function Landing() {
             <Text as="p">Complete the online form and pay a $26 processing fee</Text>
           </ListItem>
         </UnorderedList>
-        <Link href="#">
+        <Link href="/verify-identity">
           <Button
             colorScheme="primary"
             variant="solid"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,7 +57,7 @@ export default function Landing() {
           <Button
             colorScheme="primary"
             variant="solid"
-            fontWeight="normal"
+            fontWeight="semibold"
             size="lg"
             width="320px"
             height="48px"
@@ -72,7 +72,7 @@ export default function Landing() {
           <Button
             colorScheme="primary"
             variant="solid"
-            fontWeight="normal"
+            fontWeight="semibold"
             size="lg"
             width="320px"
             height="48px"
@@ -103,7 +103,7 @@ export default function Landing() {
           <Button
             colorScheme="primary"
             variant="solid"
-            fontWeight="normal"
+            fontWeight="semibold"
             size="lg"
             width="320px"
             height="48px"
@@ -118,7 +118,7 @@ export default function Landing() {
           <Button
             colorScheme="primary"
             variant="solid"
-            fontWeight="normal"
+            fontWeight="semibold"
             size="lg"
             width="320px"
             height="48px"

--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -22,6 +22,7 @@ import { Step, Steps } from 'chakra-ui-steps'; // Chakra UI Steps
 import Layout from '@components/applicant/Layout'; // Layout component
 import ReviewRequestField from '@components/applicant/renewals/ReviewRequestField'; // Field in Review Request section
 import useSteps from '@tools/components/Steps/useSteps'; // Custom hook for managing steps state
+import IncompleteSectionAlert from '@components/applicant/renewals/IncompleteSectionAlert'; // Alert box for incomplete form section
 
 export default function Renew() {
   // Steps state
@@ -61,7 +62,7 @@ export default function Renew() {
   // Whether each section has invalid inputs
   const invalidPersonalAddress =
     updatedAddress && (!personalAddressLine1 || !personalCity || !personalPostalCode);
-  const invalidContact = updatedContact && (!contactPhoneNumber || !contactEmailAddress);
+  const invalidContact = updatedContact && !contactPhoneNumber && !contactEmailAddress;
   const invalidDoctor =
     updatedDoctor &&
     (!doctorFirstName ||
@@ -156,6 +157,7 @@ export default function Renew() {
                   </FormControl>
                 </Box>
               )}
+              {invalidPersonalAddress && <IncompleteSectionAlert />}
               <Flex width="100%" justifyContent="flex-end">
                 <Link href="/">
                   <Button variant="outline" marginRight="32px">{`Go back to home page`}</Button>
@@ -221,6 +223,7 @@ export default function Renew() {
                   </FormControl>
                 </Box>
               )}
+              {invalidContact && <IncompleteSectionAlert />}
               <Flex width="100%" justifyContent="flex-end">
                 <Button
                   variant="outline"
@@ -336,6 +339,7 @@ export default function Renew() {
                   </FormControl>
                 </Box>
               )}
+              {invalidDoctor && <IncompleteSectionAlert />}
               <Flex width="100%" justifyContent="flex-end">
                 <Button
                   variant="outline"

--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'; // React
+import Link from 'next/link'; // Next Link
 import {
   Flex,
   Box,
@@ -15,18 +16,57 @@ import {
   Checkbox,
   NumberInput,
   NumberInputField,
+  Divider,
 } from '@chakra-ui/react'; // Chakra UI
-import { Step, Steps, useSteps } from 'chakra-ui-steps'; // Chakra UI Steps
+import { Step, Steps } from 'chakra-ui-steps'; // Chakra UI Steps
 import Layout from '@components/applicant/Layout'; // Layout component
+import ReviewRequestField from '@components/applicant/renewals/ReviewRequestField'; // Field in Review Request section
+import useSteps from '@tools/components/Steps/useSteps'; // Custom hook for managing steps state
 
 export default function Renew() {
   // Steps state
-  const { nextStep, prevStep, activeStep } = useSteps({ initialStep: 0 });
+  const { nextStep, prevStep, activeStep, goToStep } = useSteps({ initialStep: 0 });
 
-  // Form state
+  // Whether each section was updated
   const [updatedAddress, setUpdatedAddress] = useState(false); // Whether address was updated
   const [updatedContact, setUpdatedContact] = useState(false); // Whether contact info was updated
   const [updatedDoctor, setUpdatedDoctor] = useState(false); // Whether doctor info was updated
+
+  // Personal address information state
+  const [personalAddressLine1, setPersonalAddressLine1] = useState('');
+  const [personalAddressLine2, setPersonalAddressLine2] = useState('');
+  const [personalCity, setPersonalCity] = useState('');
+  const [personalPostalCode, setPersonalPostalCode] = useState('');
+
+  // Contact information state
+  const [contactPhoneNumber, setContactPhoneNumber] = useState('');
+  const [contactEmailAddress, setContactEmailAddress] = useState('');
+
+  // Doctor information state
+  const [doctorFirstName, setDoctorFirstName] = useState('');
+  const [doctorLastName, setDoctorLastName] = useState('');
+  const [doctorMspNumber, setDoctorMspNumber] = useState('');
+  const [doctorAddressLine1, setDoctorAddressLine1] = useState('');
+  const [doctorAddressLine2, setDoctorAddressLine2] = useState('');
+  const [doctorCity, setDoctorCity] = useState('');
+  const [doctorPostalCode, setDoctorPostalCode] = useState('');
+  const [doctorPhoneNumber, setDoctorPhoneNumber] = useState('');
+
+  // Confirmation/certification state
+  const [certified, setCertified] = useState(false);
+
+  const invalidPersonalAddress =
+    updatedAddress && (!personalAddressLine1 || !personalCity || !personalPostalCode);
+  const invalidContact = updatedContact && (!contactPhoneNumber || !contactEmailAddress);
+  const invalidDoctor =
+    updatedDoctor &&
+    (!doctorFirstName ||
+      !doctorLastName ||
+      !doctorMspNumber ||
+      !doctorAddressLine1 ||
+      !doctorCity ||
+      !doctorPostalCode ||
+      !doctorPhoneNumber);
 
   return (
     <Layout>
@@ -66,27 +106,46 @@ export default function Renew() {
                   >{`Note that your address must be in British Columbia, Canada to qualify for a permit.`}</Text>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Address Line 1`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={personalAddressLine1}
+                      onChange={event => setPersonalAddressLine1(event.target.value)}
+                    />
                     <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Address Line 2`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={personalAddressLine2}
+                      onChange={event => setPersonalAddressLine2(event.target.value)}
+                    />
                     <FormHelperText>{`Apartment, suite, unit, building, floor, etc`}</FormHelperText>
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`City`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={personalCity}
+                      onChange={event => setPersonalCity(event.target.value)}
+                    />
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Postal Code`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={personalPostalCode}
+                      onChange={event => setPersonalPostalCode(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. X0X 0X0`}</FormHelperText>
                   </FormControl>
                 </Box>
               )}
               <Flex width="100%" justifyContent="flex-end">
-                <Button variant="solid" onClick={nextStep}>{`Continue`}</Button>
+                <Link href="/">
+                  <Button variant="outline" marginRight="32px">{`Go Back to Home Page`}</Button>
+                </Link>
+                <Button
+                  variant="solid"
+                  onClick={nextStep}
+                  disabled={invalidPersonalAddress}
+                >{`Continue`}</Button>
               </Flex>
             </Box>
           </Step>
@@ -119,12 +178,19 @@ export default function Renew() {
                   >{`Please fill out at least one of the following:`}</Text>
                   <FormControl marginBottom="24px">
                     <FormLabel>{`Phone Number`}</FormLabel>
-                    <Input type="tel" />
+                    <Input
+                      type="tel"
+                      value={contactPhoneNumber}
+                      onChange={event => setContactPhoneNumber(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. 555-555-5555`}</FormHelperText>
                   </FormControl>
                   <FormControl marginBottom="24px">
                     <FormLabel>{`Email Address`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={contactEmailAddress}
+                      onChange={event => setContactEmailAddress(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. example@gmail.com`}</FormHelperText>
                   </FormControl>
                   <FormControl textAlign="left">
@@ -140,7 +206,11 @@ export default function Renew() {
                   onClick={prevStep}
                   marginRight="32px"
                 >{`Previous`}</Button>
-                <Button variant="solid" onClick={nextStep}>{`Next`}</Button>
+                <Button
+                  variant="solid"
+                  onClick={nextStep}
+                  disabled={invalidContact}
+                >{`Next`}</Button>
               </Flex>
             </Box>
           </Step>
@@ -174,17 +244,26 @@ export default function Renew() {
                   <Flex marginBottom="24px">
                     <FormControl isRequired marginRight="48px">
                       <FormLabel>{`First Name`}</FormLabel>
-                      <Input />
+                      <Input
+                        value={doctorFirstName}
+                        onChange={event => setDoctorFirstName(event.target.value)}
+                      />
                     </FormControl>
                     <FormControl isRequired>
                       <FormLabel>{`Last Name`}</FormLabel>
-                      <Input />
+                      <Input
+                        value={doctorLastName}
+                        onChange={event => setDoctorLastName(event.target.value)}
+                      />
                     </FormControl>
                   </Flex>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Your Doctor's Medical Services Plan (MSP) Number`}</FormLabel>
                     <NumberInput width="184px">
-                      <NumberInputField />
+                      <NumberInputField
+                        value={doctorMspNumber}
+                        onChange={event => setDoctorMspNumber(event.target.value)}
+                      />
                     </NumberInput>
                     <FormHelperText>
                       {`Your Doctor has a unique Medical Services Plan Number. If you do not know
@@ -193,27 +272,43 @@ export default function Renew() {
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Address Line 1`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={doctorAddressLine1}
+                      onChange={event => setDoctorAddressLine1(event.target.value)}
+                    />
                     <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Address Line 2`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={doctorAddressLine2}
+                      onChange={event => setDoctorAddressLine2(event.target.value)}
+                    />
                     <FormHelperText>{`Apartment, suite, unit, building, floor, etc`}</FormHelperText>
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`City`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={doctorCity}
+                      onChange={event => setDoctorCity(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. Vancouver`}</FormHelperText>
                   </FormControl>
                   <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Postal Code`}</FormLabel>
-                    <Input />
+                    <Input
+                      value={doctorPostalCode}
+                      onChange={event => setDoctorPostalCode(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. X0X 0X0`}</FormHelperText>
                   </FormControl>
                   <FormControl marginBottom="24px">
                     <FormLabel>{`Phone Number`}</FormLabel>
-                    <Input type="tel" />
+                    <Input
+                      type="tel"
+                      value={doctorPhoneNumber}
+                      onChange={event => setDoctorPhoneNumber(event.target.value)}
+                    />
                     <FormHelperText>{`e.g. 555-555-5555`}</FormHelperText>
                   </FormControl>
                 </Box>
@@ -224,11 +319,109 @@ export default function Renew() {
                   onClick={prevStep}
                   marginRight="32px"
                 >{`Previous`}</Button>
-                <Button variant="solid" onClick={nextStep}>{`Continue`}</Button>
+                <Button
+                  variant="solid"
+                  onClick={nextStep}
+                  disabled={invalidDoctor}
+                >{`Continue`}</Button>
               </Flex>
             </Box>
           </Step>
-          <Step label={`Review Request`}></Step>
+          <Step label={`Review Request`}>
+            <Box marginTop="24px" marginBottom="40px">
+              <Flex minWidth="700px" justifyContent="space-between">
+                <Text as="h3" textStyle="heading">{`Address Information`}</Text>
+                <Button variant="outline" onClick={() => goToStep(0)}>{`Edit`}</Button>
+              </Flex>
+              {updatedAddress ? (
+                <>
+                  <ReviewRequestField
+                    name={`Address`}
+                    value={`${personalAddressLine1} ${personalAddressLine2}`}
+                  />
+                  <ReviewRequestField name={`City`} value={personalCity} />
+                  <ReviewRequestField name={`Postal Code`} value={personalPostalCode} />
+                </>
+              ) : (
+                <Text
+                  as="p"
+                  textStyle="body-regular"
+                  textAlign="left"
+                >{`Has not changed since last renewal.`}</Text>
+              )}
+            </Box>
+            <Divider />
+            <Box marginTop="24px" marginBottom="40px">
+              <Flex minWidth="700px" justifyContent="space-between">
+                <Text as="h3" textStyle="heading">{`Contact Information`}</Text>
+                <Button variant="outline" onClick={() => goToStep(1)}>{`Edit`}</Button>
+              </Flex>
+              {updatedContact ? (
+                <>
+                  <ReviewRequestField name={`Phone Number`} value={contactPhoneNumber} />
+                  <ReviewRequestField name={`Email Address`} value={contactEmailAddress} />
+                </>
+              ) : (
+                <Text
+                  as="p"
+                  textStyle="body-regular"
+                  textAlign="left"
+                >{`Has not changed since last renewal.`}</Text>
+              )}
+            </Box>
+            <Divider />
+            <Box marginTop="24px" marginBottom="40px">
+              <Flex minWidth="700px" justifyContent="space-between">
+                <Text as="h3" textStyle="heading">{`Doctor's Information`}</Text>
+                <Button variant="outline" onClick={() => goToStep(2)}>{`Edit`}</Button>
+              </Flex>
+              {updatedDoctor ? (
+                <>
+                  <ReviewRequestField name={`First Name`} value={doctorFirstName} />
+                  <ReviewRequestField name={`Last Name`} value={doctorLastName} />
+                  <ReviewRequestField name={`MSP Number`} value={doctorMspNumber} />
+                  <ReviewRequestField
+                    name={`Address`}
+                    value={`${doctorAddressLine1} ${doctorAddressLine2}`}
+                  />
+                  <ReviewRequestField name={`City`} value={doctorCity} />
+                  <ReviewRequestField name={`Postal Code`} value={doctorPostalCode} />
+                  <ReviewRequestField name={`Phone Number`} value={doctorPhoneNumber} />
+                </>
+              ) : (
+                <Text
+                  as="p"
+                  textStyle="body-regular"
+                  textAlign="left"
+                >{`Has not changed since last renewal.`}</Text>
+              )}
+            </Box>
+            <Box marginTop="24px" marginBottom="40px">
+              <Text
+                as="h4"
+                textStyle="body-bold"
+                textAlign="left"
+                marginBottom="12px"
+              >{`Please check to confirm the following statements before you proceed:`}</Text>
+              <Checkbox
+                textAlign="left"
+                isChecked={certified}
+                onChange={event => setCertified(event.target.checked)}
+              >
+                {`I certify that I am the holder of the accessible parking pass for which this
+                application for renewal is submitted, and that I have personally provided all of the
+                information required in this application.`}
+              </Checkbox>
+            </Box>
+            <Flex width="100%" justifyContent="flex-end">
+              <Button variant="outline" onClick={prevStep} marginRight="32px">{`Previous`}</Button>
+              <Button
+                variant="solid"
+                onClick={nextStep}
+                disabled={!certified || invalidPersonalAddress || invalidContact || invalidDoctor}
+              >{`Proceed to Payment`}</Button>
+            </Flex>
+          </Step>
         </Steps>
       </GridItem>
     </Layout>

--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'; // React
+import { useState, useEffect } from 'react'; // React
 import Link from 'next/link'; // Next Link
 import {
   Flex,
@@ -55,6 +55,10 @@ export default function Renew() {
   // Confirmation/certification state
   const [certified, setCertified] = useState(false);
 
+  // Whether user is reviewing the form
+  const [isReviewing, setIsReviewing] = useState(false);
+
+  // Whether each section has invalid inputs
   const invalidPersonalAddress =
     updatedAddress && (!personalAddressLine1 || !personalCity || !personalPostalCode);
   const invalidContact = updatedContact && (!contactPhoneNumber || !contactEmailAddress);
@@ -67,6 +71,21 @@ export default function Renew() {
       !doctorCity ||
       !doctorPostalCode ||
       !doctorPhoneNumber);
+
+  /**
+   * Go to the review step (last step)
+   * Used when user needs to go to previous step to review information
+   */
+  const goToReview = () => {
+    goToStep(3);
+  };
+
+  // When the user arrives on the last step, they are in review mode
+  useEffect(() => {
+    if (activeStep === 3) {
+      setIsReviewing(true);
+    }
+  }, [activeStep, isReviewing]);
 
   return (
     <Layout>
@@ -112,8 +131,8 @@ export default function Renew() {
                     />
                     <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
                   </FormControl>
-                  <FormControl isRequired marginBottom="24px">
-                    <FormLabel>{`Address Line 2`}</FormLabel>
+                  <FormControl marginBottom="24px">
+                    <FormLabel>{`Address Line 2 (optional)`}</FormLabel>
                     <Input
                       value={personalAddressLine2}
                       onChange={event => setPersonalAddressLine2(event.target.value)}
@@ -139,13 +158,15 @@ export default function Renew() {
               )}
               <Flex width="100%" justifyContent="flex-end">
                 <Link href="/">
-                  <Button variant="outline" marginRight="32px">{`Go Back to Home Page`}</Button>
+                  <Button variant="outline" marginRight="32px">{`Go back to home page`}</Button>
                 </Link>
                 <Button
                   variant="solid"
-                  onClick={nextStep}
+                  onClick={isReviewing ? goToReview : nextStep}
                   disabled={invalidPersonalAddress}
-                >{`Continue`}</Button>
+                >
+                  {isReviewing ? `Review request` : `Next`}
+                </Button>
               </Flex>
             </Box>
           </Step>
@@ -208,9 +229,11 @@ export default function Renew() {
                 >{`Previous`}</Button>
                 <Button
                   variant="solid"
-                  onClick={nextStep}
+                  onClick={isReviewing ? goToReview : nextStep}
                   disabled={invalidContact}
-                >{`Next`}</Button>
+                >
+                  {isReviewing ? `Review request` : `Next`}
+                </Button>
               </Flex>
             </Box>
           </Step>
@@ -278,8 +301,8 @@ export default function Renew() {
                     />
                     <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
                   </FormControl>
-                  <FormControl isRequired marginBottom="24px">
-                    <FormLabel>{`Address Line 2`}</FormLabel>
+                  <FormControl marginBottom="24px">
+                    <FormLabel>{`Address Line 2 (optional)`}</FormLabel>
                     <Input
                       value={doctorAddressLine2}
                       onChange={event => setDoctorAddressLine2(event.target.value)}
@@ -321,9 +344,11 @@ export default function Renew() {
                 >{`Previous`}</Button>
                 <Button
                   variant="solid"
-                  onClick={nextStep}
+                  onClick={isReviewing ? goToReview : nextStep}
                   disabled={invalidDoctor}
-                >{`Continue`}</Button>
+                >
+                  {isReviewing ? `Review request` : `Next`}
+                </Button>
               </Flex>
             </Box>
           </Step>
@@ -419,7 +444,7 @@ export default function Renew() {
                 variant="solid"
                 onClick={nextStep}
                 disabled={!certified || invalidPersonalAddress || invalidContact || invalidDoctor}
-              >{`Proceed to Payment`}</Button>
+              >{`Proceed to payment`}</Button>
             </Flex>
           </Step>
         </Steps>

--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react'; // React
+import {
+  Flex,
+  Box,
+  Stack,
+  GridItem,
+  Text,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  RadioGroup,
+  Radio,
+  FormHelperText,
+  Checkbox,
+  NumberInput,
+  NumberInputField,
+} from '@chakra-ui/react'; // Chakra UI
+import { Step, Steps, useSteps } from 'chakra-ui-steps'; // Chakra UI Steps
+import Layout from '@components/applicant/Layout'; // Layout component
+
+export default function Renew() {
+  // Steps state
+  const { nextStep, prevStep, activeStep } = useSteps({ initialStep: 0 });
+
+  // Form state
+  const [updatedAddress, setUpdatedAddress] = useState(false); // Whether address was updated
+  const [updatedContact, setUpdatedContact] = useState(false); // Whether contact info was updated
+  const [updatedDoctor, setUpdatedDoctor] = useState(false); // Whether doctor info was updated
+
+  return (
+    <Layout>
+      <GridItem colSpan={10} colStart={2}>
+        <Text as="h1" textStyle="display-xlarge" textAlign="left" marginBottom="48px">
+          Renewal Form
+        </Text>
+        <Steps orientation="vertical" activeStep={activeStep}>
+          <Step label={`Personal Address Information`}>
+            <Box marginLeft="8px">
+              {/* Check whether applicant has updated address */}
+              <FormControl isRequired textAlign="left">
+                <FormLabel>{`Has your address changed since you received your last parking pass?`}</FormLabel>
+                <RadioGroup
+                  value={updatedAddress ? '0' : '1'}
+                  onChange={value => setUpdatedAddress(value === '0' ? true : false)}
+                >
+                  <Stack direction="row">
+                    <Radio value="0">{`Yes, it has`}</Radio>
+                    <Radio value="1">{`No, it has not`}</Radio>
+                  </Stack>
+                </RadioGroup>
+              </FormControl>
+              {/* Conditionally render form based on whether address was updated */}
+              {updatedAddress && (
+                <Box marginY="16px">
+                  <Text
+                    as="p"
+                    textAlign="left"
+                    textStyle="body-bold"
+                  >{`Please fill out the form below:`}</Text>
+                  <Text
+                    as="p"
+                    textAlign="left"
+                    textStyle="body-bold"
+                    marginBottom="24px"
+                  >{`Note that your address must be in British Columbia, Canada to qualify for a permit.`}</Text>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Address Line 1`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Address Line 2`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`Apartment, suite, unit, building, floor, etc`}</FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`City`}</FormLabel>
+                    <Input />
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Postal Code`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`e.g. X0X 0X0`}</FormHelperText>
+                  </FormControl>
+                </Box>
+              )}
+              <Flex width="100%" justifyContent="flex-end">
+                <Button variant="solid" onClick={nextStep}>{`Continue`}</Button>
+              </Flex>
+            </Box>
+          </Step>
+          <Step label={`Personal Contact Information`}>
+            <Box marginLeft="8px">
+              {/* Check whether applicant has updated contact info */}
+              <FormControl isRequired textAlign="left">
+                <FormLabel>
+                  {`Have you changed your contact information since you received or renewed your last
+                  parking pass?`}
+                </FormLabel>
+                <RadioGroup
+                  value={updatedContact ? '0' : '1'}
+                  onChange={value => setUpdatedContact(value === '0' ? true : false)}
+                >
+                  <Stack direction="row">
+                    <Radio value="0">{`Yes, I have`}</Radio>
+                    <Radio value="1">{`No, I have not`}</Radio>
+                  </Stack>
+                </RadioGroup>
+              </FormControl>
+              {/* Conditionally render form based on whether contact info was updated */}
+              {updatedContact && (
+                <Box marginY="16px">
+                  <Text
+                    as="p"
+                    textAlign="left"
+                    textStyle="body-bold"
+                    marginBottom="24px"
+                  >{`Please fill out at least one of the following:`}</Text>
+                  <FormControl marginBottom="24px">
+                    <FormLabel>{`Phone Number`}</FormLabel>
+                    <Input type="tel" />
+                    <FormHelperText>{`e.g. 555-555-5555`}</FormHelperText>
+                  </FormControl>
+                  <FormControl marginBottom="24px">
+                    <FormLabel>{`Email Address`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`e.g. example@gmail.com`}</FormHelperText>
+                  </FormControl>
+                  <FormControl textAlign="left">
+                    <Checkbox>
+                      {`I would like to receive notifications to renew my permit through email`}
+                    </Checkbox>
+                  </FormControl>
+                </Box>
+              )}
+              <Flex width="100%" justifyContent="flex-end">
+                <Button
+                  variant="outline"
+                  onClick={prevStep}
+                  marginRight="32px"
+                >{`Previous`}</Button>
+                <Button variant="solid" onClick={nextStep}>{`Next`}</Button>
+              </Flex>
+            </Box>
+          </Step>
+          <Step label={`Doctor's Information`}>
+            <Box marginLeft="8px">
+              {/* Check whether applicant has updated doctor info */}
+              <FormControl isRequired textAlign="left">
+                <FormLabel>
+                  {`Have you changed your doctor since you last received or renewed your parking
+                  permit?`}
+                </FormLabel>
+                <RadioGroup
+                  value={updatedDoctor ? '0' : '1'}
+                  onChange={value => setUpdatedDoctor(value === '0' ? true : false)}
+                >
+                  <Stack direction="row">
+                    <Radio value="0">{`Yes, I have`}</Radio>
+                    <Radio value="1">{`No, I have not`}</Radio>
+                  </Stack>
+                </RadioGroup>
+              </FormControl>
+              {/* Conditionally render form based on whether doctor info was updated */}
+              {updatedDoctor && (
+                <Box marginY="16px">
+                  <Text
+                    as="p"
+                    textAlign="left"
+                    textStyle="body-bold"
+                    marginBottom="24px"
+                  >{`Please fill out your doctor's information:`}</Text>
+                  <Flex marginBottom="24px">
+                    <FormControl isRequired marginRight="48px">
+                      <FormLabel>{`First Name`}</FormLabel>
+                      <Input />
+                    </FormControl>
+                    <FormControl isRequired>
+                      <FormLabel>{`Last Name`}</FormLabel>
+                      <Input />
+                    </FormControl>
+                  </Flex>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Your Doctor's Medical Services Plan (MSP) Number`}</FormLabel>
+                    <NumberInput width="184px">
+                      <NumberInputField />
+                    </NumberInput>
+                    <FormHelperText>
+                      {`Your Doctor has a unique Medical Services Plan Number. If you do not know
+                      where to find it, please contact your doctor.`}
+                    </FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Address Line 1`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`Street Address, P. O. Box, Company Name, c/o`}</FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Address Line 2`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`Apartment, suite, unit, building, floor, etc`}</FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`City`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`e.g. Vancouver`}</FormHelperText>
+                  </FormControl>
+                  <FormControl isRequired marginBottom="24px">
+                    <FormLabel>{`Postal Code`}</FormLabel>
+                    <Input />
+                    <FormHelperText>{`e.g. X0X 0X0`}</FormHelperText>
+                  </FormControl>
+                  <FormControl marginBottom="24px">
+                    <FormLabel>{`Phone Number`}</FormLabel>
+                    <Input type="tel" />
+                    <FormHelperText>{`e.g. 555-555-5555`}</FormHelperText>
+                  </FormControl>
+                </Box>
+              )}
+              <Flex width="100%" justifyContent="flex-end">
+                <Button
+                  variant="outline"
+                  onClick={prevStep}
+                  marginRight="32px"
+                >{`Previous`}</Button>
+                <Button variant="solid" onClick={nextStep}>{`Continue`}</Button>
+              </Flex>
+            </Box>
+          </Step>
+          <Step label={`Review Request`}></Step>
+        </Steps>
+      </GridItem>
+    </Layout>
+  );
+}

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -19,7 +19,7 @@ import TOSModal from '@components/applicant/renewals/TOSModal'; // TOS Modal
 export default function IdentityVerificationForm() {
   const [userId, setUserId] = useState('');
   const [phoneNumberSuffix, setPhoneNumberSuffix] = useState('');
-  const [dateOfBirth, setDateOfBirth] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState(new Date().toISOString().substring(0, 10));
 
   return (
     <Layout footer={false}>
@@ -56,7 +56,12 @@ export default function IdentityVerificationForm() {
             </FormControl>
             <FormControl isRequired textAlign="left" marginBottom="56px">
               <FormLabel>{`Date of Birth`}</FormLabel>
-              <Input type="date" width="184px" value={dateOfBirth} setValue={setDateOfBirth} />
+              <Input
+                type="date"
+                width="184px"
+                value={dateOfBirth}
+                onChange={event => setDateOfBirth(event.target.value)}
+              />
               <FormHelperText>
                 {`Please enter your date of birth in YYYY/MM/DD format. For example, if you were born on
             20th August 1950, you would enter 20/08/1950`}
@@ -67,13 +72,16 @@ export default function IdentityVerificationForm() {
                 <Button variant="outline" marginRight="12px">{`Go Back to Home Page`}</Button>
               </Link>
               <Link href="/renew">
-                <Button variant="solid">{`Continue`}</Button>
+                <Button
+                  variant="solid"
+                  disabled={!userId || !phoneNumberSuffix || !dateOfBirth}
+                >{`Continue`}</Button>
               </Link>
             </Flex>
           </Flex>
         </Flex>
         <TOSModal />
-      </GridItem>{' '}
+      </GridItem>
     </Layout>
   );
 }

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -63,13 +63,13 @@ export default function IdentityVerificationForm() {
                 onChange={event => setDateOfBirth(event.target.value)}
               />
               <FormHelperText>
-                {`Please enter your date of birth in YYYY/MM/DD format. For example, if you were born on
-            20th August 1950, you would enter 20/08/1950`}
+                {`Please enter your date of birth in YYYY-MM-DD format. For example, if you were born on
+            20th August 1950, you would enter 20-08-1950`}
               </FormHelperText>
             </FormControl>
             <Flex width="100%" justifyContent="flex-end">
               <Link href="/">
-                <Button variant="outline" marginRight="12px">{`Go Back to Home Page`}</Button>
+                <Button variant="outline" marginRight="12px">{`Go back to home page`}</Button>
               </Link>
               <Link href="/renew">
                 <Button

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'; // React
+import Link from 'next/link'; // Link
+import {
+  GridItem,
+  Flex,
+  Text,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  FormHelperText,
+  NumberInput,
+  NumberInputField,
+} from '@chakra-ui/react'; // Chakra UI
+import { InfoOutlineIcon } from '@chakra-ui/icons'; // Chakra UI Icons
+import Layout from '@components/applicant/Layout'; // Layout component
+import TOSModal from '@components/applicant/renewals/TOSModal'; // TOS Modal
+
+export default function IdentityVerificationForm() {
+  const [userId, setUserId] = useState('');
+  const [phoneNumberSuffix, setPhoneNumberSuffix] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState('');
+
+  return (
+    <Layout footer={false}>
+      <GridItem colSpan={8} colStart={3}>
+        <Flex width="100%" justifyContent="flex-start">
+          <Flex width="100%" flexFlow="column" alignItems="flex-start">
+            <Text
+              as="h1"
+              textStyle="display-xlarge"
+              marginBottom="20px"
+            >{`Verify your Identity`}</Text>
+            <Text as="p" textStyle="body-bold" textAlign="left" marginBottom="20px">
+              {`You must have a record with Richmond Centre for Disability before proceeding. Please fill
+        out the information below so we may validate your identity:`}
+            </Text>
+            <FormControl isRequired textAlign="left" marginBottom="48px">
+              <FormLabel>{`User ID number`}</FormLabel>
+              <NumberInput width="184px" min={1} value={userId} onChange={setUserId}>
+                <NumberInputField />
+              </NumberInput>
+              <Flex alignItems="center">
+                <InfoOutlineIcon marginRight="8px" />
+                <FormHelperText>
+                  {`You can find your user ID on the back of your wallet card. If you cannot find your
+              wallet card, please call RCD at 604-232-2404.`}
+                </FormHelperText>
+              </Flex>
+            </FormControl>
+            <FormControl isRequired textAlign="left" marginBottom="48px">
+              <FormLabel>{`Last 4 digits of your phone number`}</FormLabel>
+              <NumberInput width="184px" value={phoneNumberSuffix} onChange={setPhoneNumberSuffix}>
+                <NumberInputField />
+              </NumberInput>
+            </FormControl>
+            <FormControl isRequired textAlign="left" marginBottom="56px">
+              <FormLabel>{`Date of Birth`}</FormLabel>
+              <Input type="date" width="184px" value={dateOfBirth} setValue={setDateOfBirth} />
+              <FormHelperText>
+                {`Please enter your date of birth in YYYY/MM/DD format. For example, if you were born on
+            20th August 1950, you would enter 20/08/1950`}
+              </FormHelperText>
+            </FormControl>
+            <Flex width="100%" justifyContent="flex-end">
+              <Link href="/">
+                <Button variant="outline" marginRight="12px">{`Go Back to Home Page`}</Button>
+              </Link>
+              <Link href="/renew">
+                <Button variant="solid">{`Continue`}</Button>
+              </Link>
+            </Flex>
+          </Flex>
+        </Flex>
+        <TOSModal />
+      </GridItem>{' '}
+    </Layout>
+  );
+}

--- a/tools/components/Steps/useSteps.ts
+++ b/tools/components/Steps/useSteps.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react'; // React state
+
+// useSteps initial parameters
+type UseSteps = {
+  readonly initialStep?: number;
+};
+
+// useSteps return type
+type UseStepsReturnType = {
+  readonly activeStep: number;
+  readonly reset: () => void;
+  readonly nextStep: () => void;
+  readonly prevStep: () => void;
+  readonly goToStep: (step: number) => void;
+};
+
+/**
+ * Custom hook for managing Steps state
+ * @param initialStep - Initial step (default 0)
+ * @returns active step, reset function (to step 0), next step function, previous step function, function for going to specific step
+ */
+export default function useSteps({ initialStep = 0 }: UseSteps): UseStepsReturnType {
+  const [activeStep, setActiveStep] = useState(initialStep);
+
+  /**
+   * Reset active step to step 0
+   */
+  const reset = (): void => {
+    setActiveStep(0);
+  };
+
+  /**
+   * Go to next step
+   */
+  const nextStep = (): void => {
+    setActiveStep(activeStep + 1);
+  };
+
+  /**
+   * Go to previous step
+   */
+  const prevStep = (): void => {
+    setActiveStep(activeStep - 1);
+  };
+
+  /**
+   * Go to a step number
+   * @param step - The step number to go to
+   */
+  const goToStep = (step: number): void => {
+    setActiveStep(step);
+  };
+
+  return { activeStep, reset, nextStep, prevStep, goToStep };
+}

--- a/tools/theme/components/alert.ts
+++ b/tools/theme/components/alert.ts
@@ -28,6 +28,7 @@ const Alert: ComponentMultiStyleConfig = {
           bg: `background.${colorScheme}`,
           border: '1px solid',
           borderColor: `border.${colorScheme}`,
+          borderRadius: '4px',
         },
         icon: {
           color: `secondary.${colorScheme}`,

--- a/tools/theme/index.ts
+++ b/tools/theme/index.ts
@@ -13,13 +13,14 @@ import Checkbox from '@tools/theme/components/checkbox'; // Checkbox styles
 import Alert from '@tools/theme/components/alert'; // Alert styles (shared by Toast)
 import Tabs from '@tools/theme/components/tabs'; // Tabs styles
 import Badge from '@tools/theme/components/badge'; // Badge styles
+import { StepsStyleConfig as Steps } from 'chakra-ui-steps'; // Steps styles (imported from chakra-ui-steps)
 
 const theme = extendTheme({
   colors,
   ...typography,
   space,
   shadows,
-  components: { Button, Form, FormLabel, Checkbox, Alert, Tabs, Badge },
+  components: { Button, Form, FormLabel, Checkbox, Alert, Tabs, Badge, Steps },
   textStyles,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,6 +779,13 @@
     compute-scroll-into-view "1.0.14"
     copy-to-clipboard "3.3.1"
 
+"@chakra-ui/icon@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.10.tgz#fe7bb96f3b8162d90e85e347b3e2f8203733f44a"
+  integrity sha512-AZ2dKCHKT6dI4K9NXizHsNZSwPuBP0i1BZ4ZPoXGMOfNt7bD3yKBLoZfyO+NmAubMHanVASztikSNAmy2Rvczg==
+  dependencies:
+    "@chakra-ui/utils" "1.8.1"
+
 "@chakra-ui/icon@1.1.9":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.9.tgz#fbd6e82abf58b890f5bcc728bb75dda25d7b6c63"
@@ -786,12 +793,12 @@
   dependencies:
     "@chakra-ui/utils" "1.8.0"
 
-"@chakra-ui/icons@^1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-1.0.13.tgz#d8eb04479b048d8023ae90d76205cd4a0bf7dd79"
-  integrity sha512-twDpFz2uPVboMTEI4QA2y3EJND3G4+/9AVs730fgnnfhTw4EOJt0Lhfm4Spq1qi1LgHF16x4/Lao1E2imB5lWw==
+"@chakra-ui/icons@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-1.0.14.tgz#8d402074dabdb410af36e6f1af047bb186973053"
+  integrity sha512-VM21FkQc4rWcES1D6ddNIq6VYaCnTwWBIaqM9GRQZ7FpsLeVNk6UFYiE8MMtGWVIXq3k9jEYLbQHm7YdEF9yLQ==
   dependencies:
-    "@chakra-ui/icon" "1.1.9"
+    "@chakra-ui/icon" "1.1.10"
     "@types/react" "^17.0.0"
 
 "@chakra-ui/image@1.0.15":
@@ -1155,6 +1162,16 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.8.0.tgz#f7aad8175cc5a26a1d2795dc78691bbc21fd539e"
   integrity sha512-BWIhKcXnLbOIwCTKeNcOStNwk9RyYVA9xRRFPGK6Kp3EhrxP0rDwAbu4D3o3qAc+yhIDhGmPaIj1jRXHB5DTfg==
+  dependencies:
+    "@types/lodash.mergewith" "4.6.6"
+    css-box-model "1.2.1"
+    framesync "5.3.0"
+    lodash.mergewith "4.6.2"
+
+"@chakra-ui/utils@1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.8.1.tgz#9778e4e8776da0ed4dc0051755d79002d2f21ec2"
+  integrity sha512-v0xL9U2ozDbHCl2kQTdJNOjUGT7ZjyFwEYuMW02ZaLkmLPj2w3G592iOsJ9Z9sBemQgoOrZGyTWqdxm6rhxJug==
   dependencies:
     "@types/lodash.mergewith" "4.6.6"
     css-box-model "1.2.1"
@@ -2323,9 +2340,9 @@
     csstype "^3.0.2"
 
 "@types/react@^17.0.0":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.13.tgz#6b7c9a8f2868586ad87d941c02337c6888fb874f"
-  integrity sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
+  version "17.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
+  integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3533,6 +3550,11 @@ cardinal@^2.1.1:
   dependencies:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
+
+chakra-ui-steps@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chakra-ui-steps/-/chakra-ui-steps-1.1.1.tgz#507627da3f9ef6f908d45ad9b29b051a653743eb"
+  integrity sha512-niczIkrueHzmLw42UkqCwcklT9LnXQwfT+JgoLCWjgiSQ+U6TH6Tp8vt8BdMA286hs7fgm138WjTNMsLH9QW9A==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -7698,6 +7720,11 @@ react-i18next@^11.8.13:
   dependencies:
     "@babel/runtime" "^7.13.6"
     html-parse-stringify "^3.0.1"
+
+react-intersection-observer@^8.32.0:
+  version "8.32.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.0.tgz#47249332e12e8bb99ed35a10bb7dd10446445a7b"
+  integrity sha512-RlC6FvS3MFShxTn4FHAy904bVjX5Nn4/eTjUkurW0fHK+M/fyQdXuyCy9+L7yjA+YMGogzzSJNc7M4UtfSKvtw==
 
 react-is@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Build-TOS-User-Validation-Renewal-Form-b6d27633acfe44fd9cd948dee8fc0554)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created frontend UI with basic UX for applicant renewal flow
* Created a reusable `ReviewRequestField` component to for the "review request" section - this can also be used for the replacement flow in the near future
* The provided `useSteps` hook for controlling the stepper stake lacked a "go to step" function, which we need for jumping to previous steps to edit them. I made a custom `useSteps` hook in `tools/components/Steps/useSteps.ts` which is very similar to the hook provided by `chakra-ui-steps`, but with this extra functionality


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* This ticket only includes the frontend building of the applicant renewal flow. There is no form submission or validation. Also, there are some design inaccuracies that are not worth the time sink, so they will be addressed post-MVP or depending on time


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
