### PR TITLE
[Improvement] Add Table sorting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,12 @@
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": 0
       }
+    },
+    {
+      "files": ["types/*.d.ts"],
+      "rules": {
+        "@typescript-eslint/no-empty-interface": 0
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ applicant-facing application portal and an internal user/APP management portal.
 ├── public
 │   ├── assets # Assets
 │   └── locales # Translations
-├── tools # Frontend tools
+├── tools # Tools that are not central to an app module (more frontend-heavy)
 │   ├── pages # Tools for pages
 │   └── components # Tools for components
 # Misc individual files

--- a/components/internal/Table.tsx
+++ b/components/internal/Table.tsx
@@ -1,20 +1,43 @@
-import { Box, Table as ChakraTable, Th, Td, Thead, Tbody, Tr } from '@chakra-ui/react'; // Chakra UI
-import { useTable, Column } from 'react-table'; // React Table
+import { useEffect } from 'react'; // React
+import { Box, Flex, Table as ChakraTable, Th, Td, Thead, Tbody, Tr } from '@chakra-ui/react'; // Chakra UI
+import { ArrowUpIcon, ArrowDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
+import { useTable, useSortBy, Column } from 'react-table'; // React Table
+import { SortOptions } from '@tools/types'; // Sorting types
+import { getSortOptions } from '@tools/components/internal/table'; // Get the sort options from the React Table sortBy state
 
 // Table Props
 type Props = {
   readonly columns: Array<Column<any>>; // Depends on shape of data
   readonly data: Array<any>; // Depends on shape of data
+  readonly onChangeSortOrder?: (sort: SortOptions) => unknown; // Callback after changing sorting
 };
 
 export default function Table(props: Props) {
-  const { columns, data } = props;
+  const { columns, data, onChangeSortOrder } = props;
 
   // Table rendering functions
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable({
-    columns,
-    data,
-  });
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    state: { sortBy },
+  } = useTable(
+    {
+      columns,
+      data,
+      manualSortBy: true,
+    },
+    useSortBy
+  );
+
+  // Call onChangeSortOrder function when sorting changes
+  useEffect(() => {
+    if (onChangeSortOrder !== undefined) {
+      onChangeSortOrder(getSortOptions(sortBy));
+    }
+  }, [onChangeSortOrder, sortBy]);
 
   return (
     <Box>
@@ -26,12 +49,26 @@ export default function Table(props: Props) {
                 <Th
                   height="40px"
                   paddingX="0"
+                  paddingY="8px"
                   fontSize="18px"
                   color="text.secondary"
-                  {...column.getHeaderProps()}
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
                   key={column.id}
                 >
-                  {column.render('Header')}
+                  <Flex>
+                    <Box height="24px" display="inline">
+                      {column.render('Header')}
+                    </Box>
+                    <Box height="24px" display="inline" marginLeft="4px">
+                      {column.isSorted ? (
+                        column.isSortedDesc ? (
+                          <ArrowDownIcon aria-label="sorted descending" />
+                        ) : (
+                          <ArrowUpIcon aria-label="sorted ascending" />
+                        )
+                      ) : null}
+                    </Box>
+                  </Flex>
                 </Th>
               ))}
             </Tr>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -22,6 +22,7 @@ import { authorize } from '@tools/authorization'; // Page authorization
 import Table from '@components/internal/Table'; // Table component
 
 // Placeholder columns
+// TODO: accessors should be the accessors for these fields in the DB
 const COLUMNS = [
   {
     Header: 'Name',
@@ -34,14 +35,17 @@ const COLUMNS = [
   {
     Header: 'Permit Type',
     accessor: 'permitType',
+    disableSortBy: true,
   },
   {
     Header: 'Request Type',
     accessor: 'requestType',
+    disableSortBy: true,
   },
   {
     Header: 'Status',
     accessor: 'status',
+    disableSortBy: true,
   },
 ];
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,7 +199,7 @@ enum Aid {
   SCOOTER
   WALKER
 
-   @@map("aid")
+  @@map("aid")
 }
 
 enum ApplicantStatus {
@@ -207,7 +207,7 @@ enum ApplicantStatus {
   INACTIVE
   DECEASED
 
-   @@map("applicantstatus")
+  @@map("applicantstatus")
 }
 
 enum Gender {
@@ -215,7 +215,7 @@ enum Gender {
   FEMALE
   OTHER
 
-   @@map("gender")
+  @@map("gender")
 }
 
 enum PaymentType {
@@ -227,7 +227,7 @@ enum PaymentType {
   DEBIT
   MONEY_ORDER
 
-   @@map("paymenttype")
+  @@map("paymenttype")
 }
 
 enum PhysicianStatus {
@@ -239,7 +239,7 @@ enum PhysicianStatus {
   TEMPORARILY_INACTIVE
   RELOCATED
 
-   @@map("physicianstatus")
+  @@map("physicianstatus")
 }
 
 enum Province {
@@ -257,7 +257,7 @@ enum Province {
   NT
   YT
 
-   @@map("province")
+  @@map("province")
 }
 
 enum Role {
@@ -265,5 +265,5 @@ enum Role {
   ACCOUNTING
   SECRETARY
 
-   @@map("role")
+  @@map("role")
 }

--- a/tools/components/internal/table.ts
+++ b/tools/components/internal/table.ts
@@ -1,0 +1,15 @@
+import { SortingRule } from 'react-table'; // React Table types
+import { SortOrder } from '@tools/types'; // Sort order enum
+
+// Function type of getSortOptions - Disable eslint preventing `object` from being used
+// eslint-disable-next-line
+type GetSortOptions = (sortBy: SortingRule<object>[]) => ReadonlyArray<[string, SortOrder]>;
+
+/**
+ * Convert the sortBy sort options to an array of tuples to be used by GQL APIs
+ * @param sortBy - sortBy state provided by React Table
+ * @returns array of tuples to be used by GQL APIs - every tuple is of form [string, SortOrder]
+ */
+export const getSortOptions: GetSortOptions = sortBy => {
+  return sortBy.map(sortField => [sortField.id, sortField.desc ? SortOrder.DESC : SortOrder.ASC]);
+};

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -1,0 +1,11 @@
+// Generic types used in the platform
+
+// SortOrder type
+// Note: 'asc' and 'desc' are the values used for Prisma sorting order
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+// Sort options type that contains an array of tuples of the field being sorted and the order
+export type SortOptions = ReadonlyArray<[string, SortOrder]>;

--- a/types/react-table-config.d.ts
+++ b/types/react-table-config.d.ts
@@ -1,0 +1,23 @@
+// Override React Table types
+import {
+  UseSortByOptions,
+  UseSortByColumnOptions,
+  UseSortByColumnProps,
+  UseSortByState,
+} from 'react-table'; // React Table types
+
+declare module 'react-table' {
+  // Add sorting options to table initialization
+  export interface TableOptions<D extends Record<string, unknown>> extends UseSortByOptions<D> {}
+
+  // Add sorting state to table state
+  export interface TableState<D extends Record<string, unknown>> extends UseSortByState<D> {}
+
+  // Add sorting options to table column interface
+  export interface ColumnInterface<D extends Record<string, unknown> = Record<string, unknown>>
+    extends UseSortByColumnOptions<D> {}
+
+  // Add sorting options to table column instance
+  export interface ColumnInstance<D extends Record<string, unknown> = Record<string, unknown>>
+    extends UseSortByColumnProps<D> {}
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Add-Table-sorting-94f1d6e461fc49cf800d6305e8b50d12)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added sorting frontend to `Table` component (on clicking header, render the arrow)
* Added `onChangeSortOrder` callback function prop to the `Table` component
* Added `getSortOptions` function that takes the `sortBy` state returned by React Table and returns an array of `[<column value>, SortOrder]` tuples that we will use in our GQL APIs


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Needed to implement `react-table-config.d.ts` declaration file to add sorting types to React Table initialization options


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
