### PR TITLE
[Feature] Create upsertPhysician GQL API

### DIFF
--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -1,7 +1,7 @@
 import { meta } from '@lib/meta/resolvers'; // Metadata resolvers
 import { employees, createEmployee } from '@lib/employees/resolvers'; // Employee resolvers
 import { applicant, applicants, createApplicant } from '@lib/applicants/resolvers'; // Applicant resolvers
-import { physicians, createPhysician } from '@lib/physicians/resolvers'; // Physician resolvers
+import { physicians, createPhysician, upsertPhysician } from '@lib/physicians/resolvers'; // Physician resolvers
 import { applications, createApplication } from '@lib/applications/resolvers';
 import { permits, createPermit } from '@lib/permits/resolvers';
 import { IFieldResolver } from 'graphql-tools'; // GraphQL field resolver
@@ -41,6 +41,7 @@ const resolvers = {
     createApplicant: authorize(createApplicant, [Role.Secretary]),
     createEmployee: authorize(createEmployee),
     createPhysician: authorize(createPhysician, [Role.Secretary]),
+    upsertPhysician: authorize(upsertPhysician, [Role.Secretary]),
     createApplication: authorize(createApplication, [Role.Secretary]),
     createPermit: authorize(createPermit, [Role.Secretary]),
   },

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -12,6 +12,7 @@ type Mutation {
   createApplicant(input: CreateApplicantInput!): CreateApplicantResult!
   createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
   createPhysician(input: CreatePhysicianInput!): CreatePhysicianResult!
+  upsertPhysician(input: UpsertPhysicianInput!): UpsertPhysicianResult!
   createApplication(input: CreateApplicationInput!): CreateApplicationResult!
   createPermit(input: CreatePermitInput!): CreatePermitResult!
 }

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -308,6 +308,7 @@ export type Mutation = {
   createApplicant: CreateApplicantResult;
   createEmployee: CreateEmployeeResult;
   createPhysician: CreatePhysicianResult;
+  upsertPhysician: UpsertPhysicianResult;
   createApplication: CreateApplicationResult;
   createPermit: CreatePermitResult;
 };
@@ -322,6 +323,10 @@ export type MutationCreateEmployeeArgs = {
 
 export type MutationCreatePhysicianArgs = {
   input: CreatePhysicianInput;
+};
+
+export type MutationUpsertPhysicianArgs = {
+  input: UpsertPhysicianInput;
 };
 
 export type MutationCreateApplicationArgs = {
@@ -400,11 +405,11 @@ export type Query = {
   __typename?: 'Query';
   meta: Meta;
   applicants?: Maybe<Array<Applicant>>;
+  applicant?: Maybe<Applicant>;
   employees?: Maybe<Array<Employee>>;
   physicians?: Maybe<Array<Physician>>;
   applications?: Maybe<Array<Application>>;
   permits?: Maybe<Array<Permit>>;
-  applicant?: Maybe<Applicant>;
 };
 
 export type QueryApplicantArgs = {
@@ -420,3 +425,22 @@ export enum Role {
   Accounting = 'ACCOUNTING',
   Secretary = 'SECRETARY',
 }
+
+export type UpsertPhysicianInput = {
+  mspNumber: Scalars['Int'];
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  addressLine1: Scalars['String'];
+  addressLine2?: Maybe<Scalars['String']>;
+  city: Scalars['String'];
+  province: Province;
+  postalCode: Scalars['String'];
+  phone: Scalars['String'];
+  status: PhysicianStatus;
+  notes?: Maybe<Scalars['String']>;
+};
+
+export type UpsertPhysicianResult = {
+  __typename?: 'UpsertPhysicianResult';
+  ok: Scalars['Boolean'];
+};

--- a/lib/physicians/schema.graphql
+++ b/lib/physicians/schema.graphql
@@ -1,31 +1,49 @@
 type Physician {
-    firstName: String!
-    lastName: String!
-    mspNumber: Int!
-    addressLine1: String!
-    addressLine2: String
-    city: String!
-    province: Province!
-    postalCode: String!
-    phone: String!
-    status: PhysicianStatus!
-    notes: String
+  firstName: String!
+  lastName: String!
+  mspNumber: Int!
+  addressLine1: String!
+  addressLine2: String
+  city: String!
+  province: Province!
+  postalCode: String!
+  phone: String!
+  status: PhysicianStatus!
+  notes: String
 }
 
 input CreatePhysicianInput {
-    firstName: String!
-    lastName: String!
-    mspNumber: Int!
-    addressLine1: String!
-    addressLine2: String
-    city: String!
-    province: Province!
-    postalCode: String!
-    phone: String!
-    status: PhysicianStatus!
-    notes: String
+  firstName: String!
+  lastName: String!
+  mspNumber: Int!
+  addressLine1: String!
+  addressLine2: String
+  city: String!
+  province: Province!
+  postalCode: String!
+  phone: String!
+  status: PhysicianStatus!
+  notes: String
 }
 
 type CreatePhysicianResult {
+  ok: Boolean!
+}
+
+input UpsertPhysicianInput {
+  mspNumber: Int!
+  firstName: String!
+  lastName: String!
+  addressLine1: String!
+  addressLine2: String
+  city: String!
+  province: Province!
+  postalCode: String!
+  phone: String!
+  status: PhysicianStatus!
+  notes: String
+}
+
+type UpsertPhysicianResult {
   ok: Boolean!
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,7 +199,7 @@ enum Aid {
   SCOOTER
   WALKER
 
-   @@map("aid")
+  @@map("aid")
 }
 
 enum ApplicantStatus {
@@ -207,7 +207,7 @@ enum ApplicantStatus {
   INACTIVE
   DECEASED
 
-   @@map("applicantstatus")
+  @@map("applicantstatus")
 }
 
 enum Gender {
@@ -215,7 +215,7 @@ enum Gender {
   FEMALE
   OTHER
 
-   @@map("gender")
+  @@map("gender")
 }
 
 enum PaymentType {
@@ -227,7 +227,7 @@ enum PaymentType {
   DEBIT
   MONEY_ORDER
 
-   @@map("paymenttype")
+  @@map("paymenttype")
 }
 
 enum PhysicianStatus {
@@ -239,7 +239,7 @@ enum PhysicianStatus {
   TEMPORARILY_INACTIVE
   RELOCATED
 
-   @@map("physicianstatus")
+  @@map("physicianstatus")
 }
 
 enum Province {
@@ -257,7 +257,7 @@ enum Province {
   NT
   YT
 
-   @@map("province")
+  @@map("province")
 }
 
 enum Role {
@@ -265,5 +265,5 @@ enum Role {
   ACCOUNTING
   SECRETARY
 
-   @@map("role")
+  @@map("role")
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Create-upsertPhysician-GQL-API-85d6344d27d540fb89702f9dfa413d45)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added the `upsertPhysician` GraphQL API for upserting physicians
* This will be useful for processing the physician input in completed applications. We want to upsert the physician upon application completion.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
