### PR TITLE
[Feature] Build GQL APIs for updating applicant data, improve GQL API for creating applicant

### DIFF
--- a/components/internal/PermitHolderInfoCard.tsx
+++ b/components/internal/PermitHolderInfoCard.tsx
@@ -29,7 +29,7 @@ export default function PermitHolderInfoCard(props: PermitHolderInfoCardProps) {
       {...props}
     >
       <Flex w="100%" justifyContent="flex-start" alignItems="center">
-        {typeof header == 'string' ? (
+        {typeof header === 'string' ? (
           <Text as="h5" textStyle="display-small-semibold">
             {header}
           </Text>

--- a/lib/applicants/errors.ts
+++ b/lib/applicants/errors.ts
@@ -10,3 +10,25 @@ export class ApplicantAlreadyExistsError extends ApolloError {
     Object.defineProperty(this, 'name', { value: 'ApplicantAlreadyExistsError' });
   }
 }
+
+/**
+ * Applicant with same RCD user ID already exists (must be unique)
+ */
+export class RcdUserIdAlreadyExistsError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'RCD_USER_ID_ALREADY_EXISTS');
+
+    Object.defineProperty(this, 'name', { value: 'RcdUserIdAlreadyExistsError' });
+  }
+}
+
+/**
+ * Applicant with provided ID was not found in the DB
+ */
+export class ApplicantNotFoundError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'APPLICANT_NOT_FOUND');
+
+    Object.defineProperty(this, 'name', { value: 'ApplicantNotFoundError' });
+  }
+}

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -89,7 +89,7 @@ export const createApplicant: Resolver = async (_, args, { prisma }) => {
 };
 
 /**
- * Update an applicant (including guardian, medical information)
+ * Update an applicant
  * @returns Status of operation (ok)
  */
 export const updateApplicant: Resolver = async (_, args, { prisma }) => {

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -1,8 +1,13 @@
 import { ApolloError } from 'apollo-server-errors'; // Apollo error
 import { Resolver } from '@lib/resolvers'; // Resolver type
-import { ApplicantAlreadyExistsError } from '@lib/applicants/errors'; // Employee errors
+import {
+  ApplicantAlreadyExistsError,
+  ApplicantNotFoundError,
+  RcdUserIdAlreadyExistsError,
+} from '@lib/applicants/errors'; // Applicant errors
 import { DBErrorCode } from '@lib/db/errors'; // Database errors
-import { formatPhoneNumber, formatPostalCode } from '@lib/utils/format';
+import { MspNumberDoesNotExistError } from '@lib/physicians/errors'; // Physician errors
+import { formatPhoneNumber, formatPostalCode } from '@lib/utils/format'; // Formatting utils
 
 /**
  * Query all the RCD applicants in the internal-facing app
@@ -14,19 +19,57 @@ export const applicants: Resolver = async (_parent, _args, { prisma }) => {
 };
 
 /**
+ * Query an applicant based on ID
+ * @returns Applicant with given ID
+ */
+export const applicant: Resolver = async (_parent, args, { prisma }) => {
+  const applicant = await prisma.applicant.findUnique({
+    where: {
+      id: parseInt(args.id),
+    },
+  });
+  return applicant;
+};
+
+/**
  * Create an applicant
- * @returns Status of operation (ok, error)
+ * @returns Status of operation (ok)
  */
 export const createApplicant: Resolver = async (_, args, { prisma }) => {
   const { input } = args;
+  const {
+    medicalInformation: { physicianMspNumber, ...medicalInformation },
+    guardian,
+    ...rest
+  } = input;
+
+  // Get physician record with physicianMspNumber
+  const physician = await prisma.physician.findUnique({
+    where: {
+      mspNumber: physicianMspNumber,
+    },
+  });
+
+  // If physician doesn't exist, throw an error
+  if (!physician) {
+    throw new MspNumberDoesNotExistError(
+      `Physician with MSP number ${physicianMspNumber} could not be found`
+    );
+  }
 
   let applicant;
   try {
     applicant = await prisma.applicant.create({
       data: {
-        ...input,
+        ...rest,
         postalCode: formatPostalCode(input.postalCode),
         phone: formatPhoneNumber(input.phone),
+        medicalInformation: {
+          create: { ...medicalInformation, physicianId: physician.id },
+        },
+        guardian: {
+          create: guardian,
+        },
       },
     });
   } catch (err) {
@@ -46,14 +89,45 @@ export const createApplicant: Resolver = async (_, args, { prisma }) => {
 };
 
 /**
- * Query an applicant based on ID
- * @returns Applicant with given ID
+ * Update an applicant (including guardian, medical information)
+ * @returns Status of operation (ok)
  */
-export const applicant: Resolver = async (_parent, args, { prisma }) => {
-  const applicant = await prisma.applicant.findUnique({
-    where: {
-      id: parseInt(args.id),
-    },
-  });
-  return applicant;
+export const updateApplicant: Resolver = async (_, args, { prisma }) => {
+  const { input } = args;
+  const { id, ...rest } = input;
+  const formattedApplicantData = {
+    ...rest,
+    phone: formatPhoneNumber(input.phone),
+    postalCode: formatPostalCode(input.postalCode),
+  };
+
+  let updatedApplicant;
+  try {
+    updatedApplicant = await prisma.applicant.update({
+      where: {
+        id: parseInt(id),
+      },
+      data: formattedApplicantData,
+    });
+  } catch (err) {
+    if (err.code === DBErrorCode.RecordNotFound) {
+      throw new ApplicantNotFoundError(`Applicant with ID ${id} not found`);
+    }
+    if (err.code === DBErrorCode.UniqueConstraintFailed && err.meta.target.includes('email')) {
+      throw new ApplicantAlreadyExistsError(`Applicant with email ${input.email} already exists`);
+    }
+    if (err.code === DBErrorCode.UniqueConstraintFailed && err.meta.target.includes('rcdUserId')) {
+      throw new RcdUserIdAlreadyExistsError(
+        `Applicant with RCD user ID ${input.rcdUserId} already exists`
+      );
+    }
+  }
+
+  if (!updatedApplicant) {
+    throw new ApolloError('Applicant was unable to be updated');
+  }
+
+  return {
+    ok: true,
+  };
 };

--- a/lib/applicants/schema.graphql
+++ b/lib/applicants/schema.graphql
@@ -39,6 +39,8 @@ input CreateApplicantInput {
   postalCode: String!
   rcdUserId: Int
   acceptedTOC: Date
+  medicalInformation: CreateMedicalInformationInput!
+  guardian: CreateGuardianInput!
 }
 
 type CreateApplicantResult {
@@ -48,4 +50,26 @@ type CreateApplicantResult {
 type MedicalHistory {
   applicationId: ID!
   physician: Physician!
+}
+
+input UpdateApplicantInput {
+  id: ID!
+  firstName: String
+  middleName: String
+  lastName: String
+  dateOfBirth: Date
+  gender: Gender
+  customGender: String
+  email: String
+  phone: String
+  province: Province
+  city: String
+  addressLine1: String
+  addressLine2: String
+  postalCode: String
+  rcdUserId: Int
+}
+
+type UpdateApplicantResult {
+  ok: Boolean!
 }

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -4,7 +4,7 @@ import {
   ShopifyConfirmationNumberAlreadyExistsError,
   ApplicantIdDoesNotExistError,
   ApplicationFieldTooLongError,
-} from '@lib/applications/errors'; // Employee errors
+} from '@lib/applications/errors'; // Application errors
 import { DBErrorCode } from '@lib/db/errors'; // Database errors
 
 /**

--- a/lib/db/errors.ts
+++ b/lib/db/errors.ts
@@ -5,4 +5,5 @@ export enum DBErrorCode {
   LengthConstraintFailed = 'P2000',
   UniqueConstraintFailed = 'P2002',
   ForeignKeyConstraintFailed = 'P2003',
+  RecordNotFound = 'P2025',
 }

--- a/lib/graphql/authorization.ts
+++ b/lib/graphql/authorization.ts
@@ -14,7 +14,7 @@ export const authorize =
     const userRole = context.session?.role as Role;
 
     // If user is an Admin or has the necessary permissions, allow the query or mutation to go through.
-    if (userRole && (userRole == Role.Admin || authorizedRoles.includes(userRole))) {
+    if (userRole && (userRole === Role.Admin || authorizedRoles.includes(userRole))) {
       return resolver(root, args, context, info);
     }
 

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -1,6 +1,6 @@
 import { meta } from '@lib/meta/resolvers'; // Metadata resolvers
 import { employees, createEmployee } from '@lib/employees/resolvers'; // Employee resolvers
-import { applicant, applicants, createApplicant } from '@lib/applicants/resolvers'; // Applicant resolvers
+import { applicant, applicants, createApplicant, updateApplicant } from '@lib/applicants/resolvers'; // Applicant resolvers
 import { physicians, createPhysician, upsertPhysician } from '@lib/physicians/resolvers'; // Physician resolvers
 import { applications, createApplication } from '@lib/applications/resolvers';
 import { permits, createPermit } from '@lib/permits/resolvers';
@@ -8,20 +8,22 @@ import { IFieldResolver } from 'graphql-tools'; // GraphQL field resolver
 import { Context } from '@lib/context'; // Context type
 import { dateScalar } from '@lib/scalars'; // Custom date scalar implementation
 import { authorize } from '@lib/authorization';
-import { Role } from '@lib/types';
+import { Role } from '@lib/types'; // Role type
 import {
   applicantApplicationsResolver,
   applicantPermitsResolver,
   applicantGuardianResolver,
   applicantMedicalInformationResolver,
   applicantMedicalHistoryResolver,
-} from '@lib/applicants/field-resolvers';
+} from '@lib/applicants/field-resolvers'; // Applicant field resolvers
 import {
   applicationApplicantResolver,
   applicationPermitResolver,
-} from '@lib/applications/field-resolvers';
-import { medicalInformationPhysicianResolver } from '@lib/medicalInformation/field-resolvers';
-import { permitApplicantResolver, permitApplicationResolver } from '@lib/permits/field-resolvers';
+} from '@lib/applications/field-resolvers'; // Application field resolvers
+import { permitApplicantResolver, permitApplicationResolver } from '@lib/permits/field-resolvers'; // Permit field resolvers
+import { updateMedicalInformation } from '@lib/medicalInformation/resolvers'; // Medical information resolvers
+import { medicalInformationPhysicianResolver } from '@lib/medicalInformation/field-resolvers'; // Medical information field resolvers
+import { updateGuardian } from '@lib/guardian/resolvers'; // Guardian resolvers
 
 // Resolver type
 export type Resolver<P = undefined> = IFieldResolver<P, Context>;
@@ -39,11 +41,14 @@ const resolvers = {
   },
   Mutation: {
     createApplicant: authorize(createApplicant, [Role.Secretary]),
+    updateApplicant: authorize(updateApplicant, [Role.Secretary]),
     createEmployee: authorize(createEmployee),
     createPhysician: authorize(createPhysician, [Role.Secretary]),
     upsertPhysician: authorize(upsertPhysician, [Role.Secretary]),
     createApplication: authorize(createApplication, [Role.Secretary]),
     createPermit: authorize(createPermit, [Role.Secretary]),
+    updateMedicalInformation: authorize(updateMedicalInformation, [Role.Secretary]),
+    updateGuardian: authorize(updateGuardian, [Role.Secretary]),
   },
   Date: dateScalar,
   Applicant: {

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -10,11 +10,14 @@ type Query {
 
 type Mutation {
   createApplicant(input: CreateApplicantInput!): CreateApplicantResult!
+  updateApplicant(input: UpdateApplicantInput!): UpdateApplicantResult!
   createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
   createPhysician(input: CreatePhysicianInput!): CreatePhysicianResult!
   upsertPhysician(input: UpsertPhysicianInput!): UpsertPhysicianResult!
   createApplication(input: CreateApplicationInput!): CreateApplicationResult!
   createPermit(input: CreatePermitInput!): CreatePermitResult!
+  updateMedicalInformation(input: UpdateMedicalInformationInput!): UpdateMedicalInformationResult!
+  updateGuardian(input: UpdateGuardianInput!): UpdateGuardianResult!
 }
 
 scalar Date

--- a/lib/guardian/resolvers.ts
+++ b/lib/guardian/resolvers.ts
@@ -28,6 +28,7 @@ export const updateGuardian: Resolver = async (_, args, { prisma }) => {
   if (!updatedGuardian) {
     throw new ApolloError('Guardian was unable to be updated');
   }
+
   return {
     ok: true,
   };

--- a/lib/guardian/resolvers.ts
+++ b/lib/guardian/resolvers.ts
@@ -1,0 +1,34 @@
+import { ApolloError } from 'apollo-server-errors'; // Apollo error
+import { Resolver } from '@lib/resolvers'; // Resolver type
+import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant errors
+import { DBErrorCode } from '@lib/db/errors'; // Database errors
+
+/**
+ * Update the guardian of an applicant
+ * @returns Status of operation (ok)
+ */
+export const updateGuardian: Resolver = async (_, args, { prisma }) => {
+  const { input } = args;
+  const { applicantId, ...rest } = input;
+
+  let updatedGuardian;
+  try {
+    updatedGuardian = await prisma.guardian.update({
+      where: {
+        applicantId,
+      },
+      data: rest,
+    });
+  } catch (err) {
+    if (err.code === DBErrorCode.RecordNotFound) {
+      throw new ApplicantNotFoundError(`Applicant with ID ${applicantId} does not exist`);
+    }
+  }
+
+  if (!updatedGuardian) {
+    throw new ApolloError('Guardian was unable to be updated');
+  }
+  return {
+    ok: true,
+  };
+};

--- a/lib/guardian/schema.graphql
+++ b/lib/guardian/schema.graphql
@@ -12,3 +12,37 @@ type Guardian {
   relationship: String!
   notes: String
 }
+
+# Fields to specify when creating a guardian record for an applicant
+input CreateGuardianInput {
+  firstName: String!
+  middleName: String
+  lastName: String!
+  addressLine1: String!
+  addressLine2: String
+  city: String!
+  province: Province!
+  postalCode: String!
+  phone: String!
+  relationship: String!
+  notes: String
+}
+
+input UpdateGuardianInput {
+  applicantId: Int!
+  firstName: String
+  middleName: String
+  lastName: String
+  addressLine1: String
+  addressLine2: String
+  city: String
+  province: Province
+  postalCode: String
+  phone: String
+  relationship: String
+  notes: String
+}
+
+type UpdateGuardianResult {
+  ok: Boolean!
+}

--- a/lib/medicalInformation/resolvers.ts
+++ b/lib/medicalInformation/resolvers.ts
@@ -1,0 +1,35 @@
+import { ApolloError } from 'apollo-server-errors'; // Apollo error
+import { Resolver } from '@lib/resolvers'; // Resolver type
+import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant errors
+import { DBErrorCode } from '@lib/db/errors'; // Database errors
+
+/**
+ * Update the medical information of an applicant
+ * @returns Status of operation (ok)
+ */
+export const updateMedicalInformation: Resolver = async (_, args, { prisma }) => {
+  const { input } = args;
+  const { applicantId, ...rest } = input;
+
+  let updatedMedicalInformation;
+  try {
+    updatedMedicalInformation = await prisma.medicalInformation.update({
+      where: {
+        applicantId,
+      },
+      data: rest,
+    });
+  } catch (err) {
+    if (err.code === DBErrorCode.RecordNotFound) {
+      throw new ApplicantNotFoundError(`Applicant with ID ${applicantId} does not exist`);
+    }
+  }
+
+  if (!updatedMedicalInformation) {
+    throw new ApolloError('Medical information was unable to be updated');
+  }
+
+  return {
+    ok: true,
+  };
+};

--- a/lib/medicalInformation/schema.graphql
+++ b/lib/medicalInformation/schema.graphql
@@ -12,3 +12,30 @@ type MedicalInformation {
   physician: Physician!
   physicianId: Int!
 }
+
+# Fields to specify when creating a medical information record for an applicant
+input CreateMedicalInformationInput {
+  disability: String!
+  affectsMobility: Boolean!
+  mobilityAidRequired: Boolean!
+  cannotWalk100m: Boolean!
+  notes: String
+  certificationDate: Date
+  aid: [Aid!]
+  physicianMspNumber: Int!
+}
+
+input UpdateMedicalInformationInput {
+  applicantId: Int!
+  disability: String
+  affectsMobility: Boolean
+  mobilityAidRequired: Boolean
+  cannotWalk100m: Boolean
+  notes: String
+  certificationDate: Date
+  aid: [Aid!]
+}
+
+type UpdateMedicalInformationResult {
+  ok: Boolean!
+}

--- a/lib/permits/resolvers.ts
+++ b/lib/permits/resolvers.ts
@@ -4,7 +4,7 @@ import {
   PermitAlreadyExistsError,
   ApplicantIdDoesNotExistError,
   ApplicationIdDoesNotExistError,
-} from '@lib/permits/errors'; // Employee errors
+} from '@lib/permits/errors'; // Permit errors
 import { DBErrorCode } from '@lib/db/errors'; // Database errors
 
 /**

--- a/lib/physicians/errors.ts
+++ b/lib/physicians/errors.ts
@@ -10,3 +10,14 @@ export class PhysicianCreateError extends ApolloError {
     Object.defineProperty(this, 'name', { value: 'PhysicianCreateError' });
   }
 }
+
+/**
+ * Physician with given MSP number doesn't exist
+ */
+export class MspNumberDoesNotExistError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'MSP_NUMBER_DOES_NOT_EXIST_ERROR');
+
+    Object.defineProperty(this, 'name', { value: 'MspNumberDoesNotExistError' });
+  }
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Create-updateApplicant-GQL-API-65f80cca22394cb48c315452bada044e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Original ticket asks for `updateApplicant` GQL API that also encompasses updating medical information and guardian. However, granularity is preferred as the three categories are edited separately in the user flows. As a result, built the `updateApplicant` (for core applicant data), `updateMedicalInformation` (for applicant medical info) and `updateGuardian` (for applicant guardian) APIs
* Modified the `createApplicant` GQL API to also create the medical information and guardian records for the created applicant. This ensures that every applicant has medical information and guardian records and keeps our data in sync. It is not possible to create a medical information or guardian record on their own, which further enforces this.
* Some small error fixes

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
