### PR TITLE
[Feature] Build view individual permit holder page

### DIFF
--- a/components/internal/PermitHolderInfoCard.tsx
+++ b/components/internal/PermitHolderInfoCard.tsx
@@ -20,7 +20,7 @@ export default function PermitHolderInfoCard(props: PermitHolderInfoCardProps) {
     <GridItem
       display="flex"
       flexDirection="column"
-      alignItems={alignGridItems ? alignGridItems : 'flex-start'}
+      alignItems={alignGridItems || 'flex-start'}
       padding="20px 24px 24px"
       background="white"
       border="1px solid"

--- a/components/internal/PermitHolderInfoCard.tsx
+++ b/components/internal/PermitHolderInfoCard.tsx
@@ -6,6 +6,7 @@ type PermitHolderInfoCardProps = GridItemProps & {
   header: ReactNode;
   updated?: boolean;
   editModal?: ReactNode;
+  alignGridItems?: string;
 };
 
 /**
@@ -14,12 +15,12 @@ type PermitHolderInfoCardProps = GridItemProps & {
  * @returns custom Card.
  */
 export default function PermitHolderInfoCard(props: PermitHolderInfoCardProps) {
-  const { children, header, updated, editModal } = props;
+  const { children, header, updated, editModal, alignGridItems } = props;
   return (
     <GridItem
       display="flex"
       flexDirection="column"
-      alignItems="flex-start"
+      alignItems={alignGridItems ? alignGridItems : 'flex-start'}
       padding="20px 24px 24px"
       background="white"
       border="1px solid"

--- a/components/internal/RequestStatusBadge.tsx
+++ b/components/internal/RequestStatusBadge.tsx
@@ -15,110 +15,118 @@ export default function RequestStatusBadge({ variant }: Props) {
     switch (variant) {
       case 'COMPLETED':
         return (
-          <>
-            <Image
-              src="/assets/completed-icon.svg"
-              alt="Completed Application Icon"
-              height={12}
-              width={12}
-            />
-            <Box as="span" ml="2">
-              Completed
+          <Badge variant={variant} width="127px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/completed-icon.svg"
+                alt="Completed Application Icon"
+                height={12}
+                width={12}
+              />
+              <Box as="span" pl="8px">
+                Completed
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'EXPIRING':
         return (
-          <>
-            <Image
-              src="/assets/expiring-icon.svg"
-              alt="Expiring Application Icon"
-              height={14}
-              width={14}
-            />
-            <Box as="span" ml="2">
-              Expiring &lt; 30 days
+          <Badge variant={variant} width="180px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/expiring-icon.svg"
+                alt="Expiring Application Icon"
+                height={14}
+                width={14}
+              />
+              <Box as="span" pl="8px">
+                Expiring &lt; 30 days
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'EXPIRED':
         return (
-          <>
-            <Image
-              src="/assets/expired-icon.svg"
-              alt="Expired Application Icon"
-              height={15}
-              width={16}
-            />
-            <Box as="span" ml="2">
-              Expired
+          <Badge variant={variant} width="105px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/expired-icon.svg"
+                alt="Expired Application Icon"
+                height={15}
+                width={16}
+              />
+              <Box as="span" pl="8px">
+                Expired
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'PENDING':
         return (
-          <>
-            <Image
-              src="/assets/pending-icon.svg"
-              alt="Pending Application Icon"
-              height={12}
-              width={12}
-            />
-            <Box as="span" ml="2">
-              Pending
+          <Badge variant={variant} width="107px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/pending-icon.svg"
+                alt="Pending Application Icon"
+                height={12}
+                width={12}
+              />
+              <Box as="span" pl="8px">
+                Pending
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'REJECTED':
         return (
-          <>
-            <Image
-              src="/assets/rejected-icon.svg"
-              alt="Rejected Application Icon"
-              height={12}
-              width={12}
-            />
-            <Box as="span" ml="2">
-              Rejected
+          <Badge variant={variant} width="109px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/rejected-icon.svg"
+                alt="Rejected Application Icon"
+                height={12}
+                width={12}
+              />
+              <Box as="span" pl="8px">
+                Rejected
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'INPROGRESS':
         return (
-          <>
-            <Image
-              src="/assets/in-progress-icon.svg"
-              alt="In Progress Application Icon"
-              height={12}
-              width={12}
-            />
-            <Box as="span" ml="2">
-              In progress
+          <Badge variant={variant} width="130px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/in-progress-icon.svg"
+                alt="In Progress Application Icon"
+                height={12}
+                width={12}
+              />
+              <Box as="span" pl="8px">
+                In progress
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
       case 'ACTIVE':
         return (
-          <>
-            <Image
-              src="/assets/active-icon.svg"
-              alt="Active Application Icon"
-              height={12}
-              width={12}
-            />
-            <Box as="span" ml="2">
-              Active
+          <Badge variant={variant} width="89px" height="32px" paddingX="12px" paddingY="4px">
+            <Box mx="0px" px="0px">
+              <Image
+                src="/assets/active-icon.svg"
+                alt="Active Application Icon"
+                height={12}
+                width={12}
+              />
+              <Box as="span" pl="8px">
+                Active
+              </Box>
             </Box>
-          </>
+          </Badge>
         );
     }
   };
 
-  return (
-    <Badge variant={variant}>
-      <Box ml="-4px" mr="8px">
-        {_renderBadgeContent(variant)}
-      </Box>
-    </Badge>
-  );
+  return _renderBadgeContent(variant);
 }

--- a/components/internal/RequestStatusBadge.tsx
+++ b/components/internal/RequestStatusBadge.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box } from '@chakra-ui/react'; // Chakra UI
+import { Badge, Box, Wrap } from '@chakra-ui/react'; // Chakra UI
 import Image from 'next/image'; // Optimized images
 
 type Props = {
@@ -15,118 +15,112 @@ export default function RequestStatusBadge({ variant }: Props) {
     switch (variant) {
       case 'COMPLETED':
         return (
-          <Badge variant={variant} width="127px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/completed-icon.svg"
-                alt="Completed Application Icon"
-                height={12}
-                width={12}
-              />
-              <Box as="span" pl="8px">
-                Completed
-              </Box>
+          <>
+            <Image
+              src="/assets/completed-icon.svg"
+              alt="Completed Application Icon"
+              height={12}
+              width={12}
+            />
+            <Box as="span" pl="8px">
+              Completed
             </Box>
-          </Badge>
+          </>
         );
       case 'EXPIRING':
         return (
-          <Badge variant={variant} width="180px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/expiring-icon.svg"
-                alt="Expiring Application Icon"
-                height={14}
-                width={14}
-              />
-              <Box as="span" pl="8px">
-                Expiring &lt; 30 days
-              </Box>
+          <>
+            <Image
+              src="/assets/expiring-icon.svg"
+              alt="Expiring Application Icon"
+              height={14}
+              width={14}
+            />
+            <Box as="span" pl="8px" pr="13px">
+              {'Expiring < 30 days'}
             </Box>
-          </Badge>
+          </>
         );
       case 'EXPIRED':
         return (
-          <Badge variant={variant} width="105px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/expired-icon.svg"
-                alt="Expired Application Icon"
-                height={15}
-                width={16}
-              />
-              <Box as="span" pl="8px">
-                Expired
-              </Box>
+          <>
+            <Image
+              src="/assets/expired-icon.svg"
+              alt="Expired Application Icon"
+              height={15}
+              width={16}
+            />
+            <Box as="span" pl="8px">
+              Expired
             </Box>
-          </Badge>
+          </>
         );
       case 'PENDING':
         return (
-          <Badge variant={variant} width="107px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/pending-icon.svg"
-                alt="Pending Application Icon"
-                height={12}
-                width={12}
-              />
-              <Box as="span" pl="8px">
-                Pending
-              </Box>
+          <>
+            <Image
+              src="/assets/pending-icon.svg"
+              alt="Pending Application Icon"
+              height={12}
+              width={12}
+            />
+            <Box as="span" pl="8px">
+              Pending
             </Box>
-          </Badge>
+          </>
         );
       case 'REJECTED':
         return (
-          <Badge variant={variant} width="109px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/rejected-icon.svg"
-                alt="Rejected Application Icon"
-                height={12}
-                width={12}
-              />
-              <Box as="span" pl="8px">
-                Rejected
-              </Box>
+          <>
+            <Image
+              src="/assets/rejected-icon.svg"
+              alt="Rejected Application Icon"
+              height={12}
+              width={12}
+            />
+            <Box as="span" pl="8px">
+              Rejected
             </Box>
-          </Badge>
+          </>
         );
       case 'INPROGRESS':
         return (
-          <Badge variant={variant} width="130px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/in-progress-icon.svg"
-                alt="In Progress Application Icon"
-                height={12}
-                width={12}
-              />
-              <Box as="span" pl="8px">
-                In progress
-              </Box>
+          <>
+            <Image
+              src="/assets/in-progress-icon.svg"
+              alt="In Progress Application Icon"
+              height={12}
+              width={12}
+            />
+            <Box as="span" pl="8px">
+              In progress
             </Box>
-          </Badge>
+          </>
         );
       case 'ACTIVE':
         return (
-          <Badge variant={variant} width="89px" height="32px" paddingX="12px" paddingY="4px">
-            <Box mx="0px" px="0px">
-              <Image
-                src="/assets/active-icon.svg"
-                alt="Active Application Icon"
-                height={12}
-                width={12}
-              />
-              <Box as="span" pl="8px">
-                Active
-              </Box>
+          <>
+            <Image
+              src="/assets/active-icon.svg"
+              alt="Active Application Icon"
+              height={12}
+              width={12}
+            />
+            <Box as="span" pl="8px">
+              Active
             </Box>
-          </Badge>
+          </>
         );
     }
   };
 
-  return _renderBadgeContent(variant);
+  return (
+    <Wrap>
+      <Badge variant={variant}>
+        <Box ml="0px" mr="0px">
+          {_renderBadgeContent(variant)}
+        </Box>
+      </Badge>
+    </Wrap>
+  );
 }

--- a/components/internal/modals/EditPermitHolderInformationModal.tsx
+++ b/components/internal/modals/EditPermitHolderInformationModal.tsx
@@ -16,9 +16,15 @@ import {
   Box,
   Divider,
 } from '@chakra-ui/react'; // Chakra UI
-import { useState, SyntheticEvent } from 'react'; // React
+import { useState, SyntheticEvent, ReactNode } from 'react'; // React
 
-export default function EditPermitHolderInformationModal() {
+type EditPermitHolderInformationModalProps = {
+  children: ReactNode;
+};
+
+export default function EditPermitHolderInformationModal({
+  children,
+}: EditPermitHolderInformationModalProps) {
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   // Personal information state
@@ -44,10 +50,7 @@ export default function EditPermitHolderInformationModal() {
 
   return (
     <>
-      {/* Button will be removed before merging */}
-      <Button mt={3} onClick={onOpen}>
-        Open
-      </Button>
+      <Box onClick={onOpen}>{children}</Box>
 
       <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
         <ModalOverlay />

--- a/components/permit-holders/AppHistoryCard.tsx
+++ b/components/permit-holders/AppHistoryCard.tsx
@@ -1,0 +1,111 @@
+import { Box, Link, Text, Wrap, Divider } from '@chakra-ui/react'; // Chakra UI
+import Table from '@components/internal/Table'; // Table component
+import RequestStatusBadge from '@components/internal/RequestStatusBadge';
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard';
+
+// Placeholder data
+
+const DATA = Array(4).fill({
+  rcdPermitId: { rcdPermitId: 354 },
+  isRenewal: 'false',
+  requestStatus: 'EXPIRING',
+  expiryDate: '2021/01/01',
+  applicationId: { applicationId: 1 },
+});
+
+const COLUMNS = [
+  {
+    Header: 'Permit #',
+    accessor: 'rcdPermitId',
+    disableSortBy: true,
+    maxWidth: 140,
+    Cell: _renderPermitId,
+  },
+  {
+    Header: 'Request Type',
+    accessor: 'isRenewal',
+    disableSortBy: true,
+    maxWidth: 140,
+    Cell: _renderRequestType,
+  },
+  {
+    Header: 'Status',
+    accessor: 'requestStatus',
+    disableSortBy: true,
+    maxWidth: 190,
+    Cell: _renderStatusBadge,
+  },
+  {
+    Header: 'Expiry Date',
+    accessor: 'expiryDate',
+    disableSortBy: true,
+    maxWidth: 140,
+  },
+  {
+    accessor: 'applicationId',
+    disableSortBy: true,
+    maxWidth: 140,
+    Cell: _renderAppLink,
+  },
+];
+
+type PermitIdProps = {
+  value: { rcdPermitId: number };
+};
+
+function _renderPermitId({ value }: PermitIdProps) {
+  return (
+    <>
+      <Text as="p">{`#${value.rcdPermitId}`}</Text>
+    </>
+  );
+}
+
+type RequestTypeProps = {
+  value: { isRenewal: boolean };
+};
+
+function _renderRequestType({ value }: RequestTypeProps) {
+  return (
+    <>
+      <Text as="p">{value.isRenewal ? `Renewal` : `Replacement`}</Text>
+    </>
+  );
+}
+
+type StatusProps = {
+  value: 'COMPLETED' | 'INPROGRESS' | 'PENDING' | 'REJECTED' | 'EXPIRING' | 'EXPIRED' | 'ACTIVE';
+};
+
+function _renderStatusBadge({ value }: StatusProps) {
+  return (
+    <Wrap>
+      <RequestStatusBadge variant={value} />
+    </Wrap>
+  );
+}
+
+type appProps = {
+  value: { applicationId: number };
+};
+
+function _renderAppLink({ value }: appProps) {
+  return (
+    <Link href={`/admin/request/${value.applicationId}`} passHref>
+      <Text textStyle="body-regular" textColor="primary" as="a">
+        View APP
+      </Text>
+    </Link>
+  );
+}
+
+export default function AppHistoryCard() {
+  return (
+    <PermitHolderInfoCard colSpan={12} header={`APP History`}>
+      <Divider pt="24px" />
+      <Box padding="20px 24px">
+        <Table columns={COLUMNS} data={DATA} />
+      </Box>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/AppHistoryCard.tsx
+++ b/components/permit-holders/AppHistoryCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Link, Text, Wrap, Divider } from '@chakra-ui/react'; // Chakra UI
 import Table from '@components/internal/Table'; // Table component
-import RequestStatusBadge from '@components/internal/RequestStatusBadge';
-import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard';
+import RequestStatusBadge from '@components/internal/RequestStatusBadge'; // Request status badge component
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
 
 // Placeholder data
 

--- a/components/permit-holders/AppHistoryCard.tsx
+++ b/components/permit-holders/AppHistoryCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Text, Wrap, Divider } from '@chakra-ui/react'; // Chakra UI
+import { Box, Link, Text, Divider } from '@chakra-ui/react'; // Chakra UI
 import Table from '@components/internal/Table'; // Table component
 import RequestStatusBadge from '@components/internal/RequestStatusBadge'; // Request status badge component
 import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
@@ -32,7 +32,7 @@ const COLUMNS = [
     Header: 'Status',
     accessor: 'requestStatus',
     disableSortBy: true,
-    maxWidth: 190,
+    maxWidth: 195,
     Cell: _renderStatusBadge,
   },
   {
@@ -79,9 +79,9 @@ type StatusProps = {
 
 function _renderStatusBadge({ value }: StatusProps) {
   return (
-    <Wrap>
+    <Box pr="10px">
       <RequestStatusBadge variant={value} />
-    </Wrap>
+    </Box>
   );
 }
 

--- a/components/permit-holders/AppHistoryCard.tsx
+++ b/components/permit-holders/AppHistoryCard.tsx
@@ -101,7 +101,7 @@ function _renderAppLink({ value }: appProps) {
 
 export default function AppHistoryCard() {
   return (
-    <PermitHolderInfoCard colSpan={12} header={`APP History`}>
+    <PermitHolderInfoCard header={`APP History`} alignGridItems="normal">
       <Divider pt="24px" />
       <Box padding="20px 24px">
         <Table columns={COLUMNS} data={DATA} />

--- a/components/permit-holders/AttachedFilesCard.tsx
+++ b/components/permit-holders/AttachedFilesCard.tsx
@@ -67,7 +67,7 @@ function _renderFileLink({ value }: downloadFileProps) {
 
 export default function AttachedFilesCard() {
   return (
-    <PermitHolderInfoCard colSpan={12} header={`Attached Files`}>
+    <PermitHolderInfoCard alignGridItems="normal" header={`Attached Files`}>
       <Divider pt="24px" />
       <Box padding="20px 24px">
         <Table columns={COLUMNS} data={DATA} />

--- a/components/permit-holders/AttachedFilesCard.tsx
+++ b/components/permit-holders/AttachedFilesCard.tsx
@@ -1,0 +1,77 @@
+import { Box, Link, Text, Divider } from '@chakra-ui/react'; // Chakra UI
+import Table from '@components/internal/Table'; // Table component
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
+
+// Placeholder data
+
+const DATA = Array(4).fill({
+  fileName: 'test.pdf',
+  associatedApp: { associatedApp: 12345 },
+  dateUploaded: '2021/01/01',
+  fileUrl: { fileUrl: '/' },
+});
+
+const COLUMNS = [
+  {
+    Header: 'File Name',
+    accessor: 'fileName',
+    disableSortBy: true,
+    minWidth: 160,
+  },
+  {
+    Header: 'Associated APP',
+    accessor: 'associatedApp',
+    disableSortBy: true,
+    maxWidth: 220,
+    Cell: _renderAssociatedApp,
+  },
+  {
+    Header: 'Date Uploaded',
+    accessor: 'dateUploaded',
+    disableSortBy: true,
+    maxWidth: 160,
+  },
+  {
+    accessor: 'fileUrl',
+    disableSortBy: true,
+    maxWidth: 140,
+    Cell: _renderFileLink,
+  },
+];
+
+type AssociatedAppProps = {
+  value: { associatedApp: number };
+};
+
+function _renderAssociatedApp({ value }: AssociatedAppProps) {
+  return (
+    <>
+      <Text as="p">{`#${value.associatedApp}`}</Text>
+    </>
+  );
+}
+
+type downloadFileProps = {
+  value: { fileUrl: number };
+};
+
+function _renderFileLink({ value }: downloadFileProps) {
+  return (
+    <Link href={`/${value.fileUrl}`} passHref>
+      <Text textStyle="body-regular" textColor="primary" as="a">
+        Download file
+      </Text>
+    </Link>
+  );
+}
+
+export default function AttachedFilesCard() {
+  return (
+    <PermitHolderInfoCard colSpan={12} header={`Attached Files`}>
+      <Divider pt="24px" />
+      <Box padding="20px 24px">
+        <Table columns={COLUMNS} data={DATA} />
+      </Box>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/DoctorInformationCard.tsx
+++ b/components/permit-holders/DoctorInformationCard.tsx
@@ -1,0 +1,83 @@
+import { Box, Text, Divider, VStack, Button, Flex } from '@chakra-ui/react'; // Chakra UI
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
+import { Physician } from '@lib/graphql/types'; // Physician type
+import EditDoctorInformationModal from '@components/requests/modals/EditDoctorInformationModal'; // Edit modal
+import PreviousDoctorsInformationModal from '@components/permit-holders/modals/PreviousDoctorsInformationModal'; // Previous Doctors' Information Modal
+
+type DoctorInformationProps = {
+  physician: Physician;
+  readonly isUpdated?: boolean;
+};
+
+export default function DoctorInformationCard(props: DoctorInformationProps) {
+  const { physician, isUpdated } = props;
+  return (
+    <PermitHolderInfoCard
+      colSpan={7}
+      header={`Doctor's Information`}
+      updated={isUpdated}
+      editModal={
+        <EditDoctorInformationModal>
+          <Button color="primary" variant="ghost" textDecoration="underline">
+            <Text textStyle="body-bold">Edit</Text>
+          </Button>
+        </EditDoctorInformationModal>
+      }
+    >
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" align="left" paddingTop="24px">
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`${physician.firstName} ${physician.lastName}`}
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`MSP Number: ${physician.mspNumber}`}
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`Phone: ${physician.phone}`}
+          </Text>
+        </Box>
+      </VStack>
+
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" pt="24px" align="left">
+        <Box>
+          <Text as="h4" textStyle="body-bold">
+            Address
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {physician.addressLine1}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {physician.addressLine2}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {`${physician.city} ${physician.province}`}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {`Canada`}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {physician.postalCode}
+          </Text>
+        </Box>
+      </VStack>
+
+      <Flex w="100%" justifyContent="flex-end" paddingTop="8px">
+        <PreviousDoctorsInformationModal>
+          <Button color="primary" variant="ghost" textDecoration="underline">
+            <Text textStyle="body-bold">{'View previous doctors'}</Text>
+          </Button>
+        </PreviousDoctorsInformationModal>
+      </Flex>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/DoctorInformationCard.tsx
+++ b/components/permit-holders/DoctorInformationCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, Divider, VStack, Button, Flex } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
 import { Physician } from '@lib/graphql/types'; // Physician type
-import EditDoctorInformationModal from '@components/requests/modals/EditDoctorInformationModal'; // Edit modal
+import EditDoctorInformationModal from '@components/requests/modals/EditDoctorInformationModal'; // Edit doctor information modal component
 import PreviousDoctorsInformationModal from '@components/permit-holders/modals/PreviousDoctorsInformationModal'; // Previous Doctors' Information Modal
 
 type DoctorInformationProps = {

--- a/components/permit-holders/GuardianInformationCard.tsx
+++ b/components/permit-holders/GuardianInformationCard.tsx
@@ -1,0 +1,70 @@
+import { Box, Text, Divider, VStack, Button } from '@chakra-ui/react'; // Chakra UI
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
+import { Guardian } from '@lib/graphql/types'; // Guardian type
+
+type GuardianInformationProps = {
+  guardian: Guardian;
+};
+
+export default function GuardianInformationCard(props: GuardianInformationProps) {
+  const { guardian } = props;
+  return (
+    <PermitHolderInfoCard
+      colSpan={7}
+      header={`Guardian's Information`}
+      editModal={
+        //   TODO: Create edit guardian modal post-mvp
+        <Button color="primary" variant="ghost" textDecoration="underline">
+          <Text textStyle="body-bold">Edit</Text>
+        </Button>
+      }
+    >
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" align="left" paddingTop="24px">
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`${guardian.firstName} ${guardian.lastName}`}
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`Phone: ${guardian.phone}`}
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {`Relationship: ${guardian.relationship}`}
+          </Text>
+        </Box>
+      </VStack>
+
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" pt="24px" align="left">
+        <Box>
+          <Text as="h4" textStyle="body-bold">
+            Address
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {guardian.addressLine1}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {guardian.addressLine2}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {`${guardian.city} ${guardian.province}`}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {`Canada`}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {guardian.postalCode}
+          </Text>
+        </Box>
+      </VStack>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/GuardianInformationCard.tsx
+++ b/components/permit-holders/GuardianInformationCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Divider, VStack, Button } from '@chakra-ui/react'; // Chakra UI
+import { Box, Text, Divider, VStack } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card Component
 import { Guardian } from '@lib/graphql/types'; // Guardian type
 
@@ -9,16 +9,7 @@ type GuardianInformationProps = {
 export default function GuardianInformationCard(props: GuardianInformationProps) {
   const { guardian } = props;
   return (
-    <PermitHolderInfoCard
-      colSpan={7}
-      header={`Guardian's Information`}
-      editModal={
-        //   TODO: Create edit guardian modal post-mvp
-        <Button color="primary" variant="ghost" textDecoration="underline">
-          <Text textStyle="body-bold">Edit</Text>
-        </Button>
-      }
-    >
+    <PermitHolderInfoCard colSpan={7} header={`Guardian's Information`}>
       <Divider pt="24px" />
 
       <VStack spacing="12px" align="left" paddingTop="24px">

--- a/components/permit-holders/MedicalHistoryCard.tsx
+++ b/components/permit-holders/MedicalHistoryCard.tsx
@@ -34,8 +34,7 @@ const COLUMNS = [
     Header: 'Certification Date',
     accessor: 'dateUploaded',
     disableSortBy: true,
-    // NOTE: Check value
-    minWidth: 200,
+    maxWidth: 200,
   },
   {
     accessor: 'associatedApplicationId',

--- a/components/permit-holders/MedicalHistoryCard.tsx
+++ b/components/permit-holders/MedicalHistoryCard.tsx
@@ -25,7 +25,7 @@ const DATA = Array(4).fill({
 
 const COLUMNS = [
   {
-    Header: 'Disabling Condition(s)',
+    Header: 'Disabling Condition',
     accessor: 'disablingCondition',
     disableSortBy: true,
     minWidth: 250,

--- a/components/permit-holders/MedicalHistoryCard.tsx
+++ b/components/permit-holders/MedicalHistoryCard.tsx
@@ -59,7 +59,7 @@ function _renderConditionDetailsLink() {
 
 export default function MedicalHistoryCard() {
   return (
-    <PermitHolderInfoCard colSpan={12} header={`Medical History`}>
+    <PermitHolderInfoCard alignGridItems="normal" header={`Medical History`}>
       <Divider pt="24px" />
       <Box padding="20px 24px">
         <Table columns={COLUMNS} data={DATA} />

--- a/components/permit-holders/MedicalHistoryCard.tsx
+++ b/components/permit-holders/MedicalHistoryCard.tsx
@@ -1,0 +1,69 @@
+import { Box, Text, Divider, Link } from '@chakra-ui/react'; // Chakra UI
+import Table from '@components/internal/Table'; // Table component
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard';
+import { Aid, MedicalInformation } from '@lib/graphql/types'; // Aid enum & MedicalInformation type
+import MedicalHistoryModal from '@components/permit-holders/modals/MedicalHistoryModal'; // Medical History Modal
+
+// Placeholder data
+const mockMedicalHistory = {
+  disability: 'Condition 1',
+  affectsMobility: true,
+  mobilityAidRequired: true,
+  cannotWalk100m: true,
+  aid: [Aid.Cane, Aid.ElectricChair],
+  notes: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  certificationDate: '2021/01/01',
+};
+
+const DATA = Array(4).fill({
+  disablingCondition: 'Condition 1',
+  associatedApp: { associatedApp: 12345 },
+  dateUploaded: '2021/01/01',
+  fileUrl: { fileUrl: '/' },
+  application: { application: mockMedicalHistory },
+});
+
+const COLUMNS = [
+  {
+    Header: 'Disabling Condition(s)',
+    accessor: 'disablingCondition',
+    disableSortBy: true,
+    minWidth: 250,
+  },
+  {
+    Header: 'Certification Date',
+    accessor: 'dateUploaded',
+    disableSortBy: true,
+    // NOTE: Check value
+    minWidth: 200,
+  },
+  {
+    accessor: 'associatedApplicationId',
+    disableSortBy: true,
+    minWidth: 180,
+    Cell: _renderConditionDetailsLink,
+  },
+];
+
+function _renderConditionDetailsLink() {
+  return (
+    <MedicalHistoryModal medicalInformation={mockMedicalHistory as MedicalInformation}>
+      <Link>
+        <Text as="a" color="primary" textStyle="body-regular">
+          View details
+        </Text>
+      </Link>
+    </MedicalHistoryModal>
+  );
+}
+
+export default function MedicalHistoryCard() {
+  return (
+    <PermitHolderInfoCard colSpan={12} header={`Medical History`}>
+      <Divider pt="24px" />
+      <Box padding="20px 24px">
+        <Table columns={COLUMNS} data={DATA} />
+      </Box>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/PermitHolderHeader.tsx
+++ b/components/permit-holders/PermitHolderHeader.tsx
@@ -1,0 +1,42 @@
+import { Box, Flex, HStack, Text } from '@chakra-ui/react'; // Chakra UI
+import { ChevronLeftIcon } from '@chakra-ui/icons'; // Chakra UI icon
+import Link from 'next/link'; // Link
+import RequestStatusBadge from '@components/internal/RequestStatusBadge'; // Request status badge
+import { Applicant } from '@lib/graphql/types'; // Applicant type
+
+type PermitHolderHeaderProps = {
+  readonly applicant: Applicant;
+  readonly applicationStatus: // TODO: Change this to the enum that we add
+  'COMPLETED' | 'INPROGRESS' | 'PENDING' | 'REJECTED' | 'EXPIRING' | 'EXPIRED' | 'ACTIVE';
+};
+
+export default function PermitHolderHeader({
+  applicant,
+  applicationStatus,
+}: PermitHolderHeaderProps) {
+  return (
+    <Box textAlign="left">
+      <Link href="/admin/permit-holders" passHref>
+        <Text textStyle="button-semibold" textColor="primary" as="a">
+          <ChevronLeftIcon />
+          All permit holders
+        </Text>
+      </Link>
+      <Flex marginTop={5} alignItems="center">
+        <Box>
+          <Flex alignItems="center">
+            <Text textStyle="display-large" as="h1" marginRight={3}>
+              {`${applicant.firstName} ${applicant.lastName}`}
+            </Text>
+            <RequestStatusBadge variant={applicationStatus} />
+          </Flex>
+          <HStack spacing={3} marginTop={3}>
+            <Text textStyle="caption" as="p">
+              ID: #{applicant.rcdUserId}
+            </Text>
+          </HStack>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/components/permit-holders/PersonalInformationCard.tsx
+++ b/components/permit-holders/PersonalInformationCard.tsx
@@ -1,0 +1,95 @@
+import { Box, HStack, VStack, Text, Divider, Link, Button } from '@chakra-ui/react'; // Chakra UI
+import EditUserInformationModal from '@components/permit-holders/modals/EditUserInformationModal'; // Edit User Information Modal
+import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card component
+import { Applicant } from '@lib/graphql/types'; // Applicant type
+
+type PersonalInformationProps = {
+  readonly applicant: Applicant;
+};
+
+export default function PersonalInformationCard(props: PersonalInformationProps) {
+  const { applicant } = props;
+
+  return (
+    <PermitHolderInfoCard
+      colSpan={5}
+      header={
+        <Text as="h4" textStyle="body-bold">
+          Personal Information
+        </Text>
+      }
+      editModal={
+        <EditUserInformationModal>
+          <Button color="primary" variant="ghost" textDecoration="underline">
+            <Text textStyle="body-bold">Edit</Text>
+          </Button>
+        </EditUserInformationModal>
+      }
+    >
+      <VStack spacing="12px" align="left">
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            Date of Birth: {applicant.dateOfBirth}
+          </Text>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            Gender: {applicant.gender.toLowerCase().replace(/^\w/, c => c.toUpperCase())}
+          </Text>
+        </Box>
+      </VStack>
+
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" pt="24px" align="left">
+        <HStack spacing="12px">
+          <Box>
+            <Text as="h4" textStyle="body-bold">
+              Contact Information
+            </Text>
+          </Box>
+        </HStack>
+        <Box>
+          {/* TODO: Make it copy-able */}
+          <Link textStyle="body-regular" color="primary" textDecoration="underline">
+            {applicant.email}
+          </Link>
+        </Box>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {applicant.phone}
+          </Text>
+        </Box>
+      </VStack>
+
+      <Divider pt="24px" />
+
+      <VStack spacing="12px" pt="24px" align="left">
+        <HStack spacing="12px">
+          <Box>
+            <Text as="h4" textStyle="body-bold">
+              Home Address
+            </Text>
+          </Box>
+        </HStack>
+        <Box>
+          <Text as="p" textStyle="body-regular">
+            {applicant.addressLine1}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {applicant.addressLine2}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {applicant.city} {applicant.province}
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            Canada
+          </Text>
+          <Text as="p" textStyle="body-regular">
+            {applicant.postalCode}
+          </Text>
+        </Box>
+      </VStack>
+    </PermitHolderInfoCard>
+  );
+}

--- a/components/permit-holders/PersonalInformationCard.tsx
+++ b/components/permit-holders/PersonalInformationCard.tsx
@@ -1,4 +1,14 @@
-import { Box, HStack, VStack, Text, Divider, Link, Button } from '@chakra-ui/react'; // Chakra UI
+import {
+  Box,
+  HStack,
+  VStack,
+  Text,
+  Divider,
+  Link,
+  Button,
+  Tooltip,
+  useClipboard,
+} from '@chakra-ui/react'; // Chakra UI
 import EditUserInformationModal from '@components/permit-holders/modals/EditUserInformationModal'; // Edit User Information Modal
 import PermitHolderInfoCard from '@components/internal/PermitHolderInfoCard'; // Custom Card component
 import { Applicant } from '@lib/graphql/types'; // Applicant type
@@ -9,6 +19,7 @@ type PersonalInformationProps = {
 
 export default function PersonalInformationCard(props: PersonalInformationProps) {
   const { applicant } = props;
+  const { hasCopied, onCopy } = useClipboard(applicant.email ? applicant.email : '');
 
   return (
     <PermitHolderInfoCard
@@ -50,10 +61,23 @@ export default function PersonalInformationCard(props: PersonalInformationProps)
           </Box>
         </HStack>
         <Box>
-          {/* TODO: Make it copy-able */}
-          <Link textStyle="body-regular" color="primary" textDecoration="underline">
-            {applicant.email}
-          </Link>
+          <Tooltip
+            hasArrow
+            closeOnClick={false}
+            label={hasCopied ? 'Copied to clipboard' : 'Click to copy address'}
+            placement="top"
+            bg="background.grayHover"
+            color="black"
+          >
+            <Link
+              textStyle="body-regular"
+              color="primary"
+              textDecoration="underline"
+              onClick={onCopy}
+            >
+              {applicant.email}
+            </Link>
+          </Tooltip>
         </Box>
         <Box>
           <Text as="p" textStyle="body-regular">

--- a/components/permit-holders/SuccessfulEditAlert.tsx
+++ b/components/permit-holders/SuccessfulEditAlert.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertDescription, AlertIcon, CloseButton } from '@chakra-ui/react'; // Chakra UI
+import { Alert, AlertDescription, AlertIcon } from '@chakra-ui/react'; // Chakra UI
 import { ReactNode } from 'react'; // React
 
 type SuccessfulEditAlertProps = {
@@ -13,7 +13,8 @@ export default function SuccessfulEditAlert({ children }: SuccessfulEditAlertPro
     <Alert variant="solid" status="success">
       <AlertIcon color="alerticon.success" />
       <AlertDescription textStyle="caption">{children}</AlertDescription>
-      <CloseButton />
+      {/* TODO: Make alert closeable */}
+      {/* <CloseButton /> */}
     </Alert>
   );
 }

--- a/components/permit-holders/SuccessfulEditAlert.tsx
+++ b/components/permit-holders/SuccessfulEditAlert.tsx
@@ -1,0 +1,19 @@
+import { Alert, AlertDescription, AlertIcon, CloseButton } from '@chakra-ui/react'; // Chakra UI
+import { ReactNode } from 'react'; // React
+
+type SuccessfulEditAlertProps = {
+  children: ReactNode;
+};
+
+/**
+ * Alert box containing message that user has successfully edited
+ */
+export default function SuccessfulEditAlert({ children }: SuccessfulEditAlertProps) {
+  return (
+    <Alert variant="solid" status="success">
+      <AlertIcon color="alerticon.success" />
+      <AlertDescription textStyle="caption">{children}</AlertDescription>
+      <CloseButton />
+    </Alert>
+  );
+}

--- a/components/permit-holders/modals/EditUserInformationModal.tsx
+++ b/components/permit-holders/modals/EditUserInformationModal.tsx
@@ -17,10 +17,14 @@ import {
   Select,
   Divider,
 } from '@chakra-ui/react'; // Chakra UI
-import { useState, SyntheticEvent } from 'react'; // React
+import { useState, SyntheticEvent, ReactNode } from 'react'; // React
 import { Gender } from '@lib/graphql/types'; // Gender Enum
 
-export default function EditUserInformationModal() {
+type EditUserInformationModalProps = {
+  children: ReactNode;
+};
+
+export default function EditUserInformationModal({ children }: EditUserInformationModalProps) {
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   // Personal information state
@@ -48,10 +52,7 @@ export default function EditUserInformationModal() {
 
   return (
     <>
-      {/* Button will be removed before merging */}
-      <Button mt={3} onClick={onOpen}>
-        Open
-      </Button>
+      <Box onClick={onOpen}>{children}</Box>
 
       <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
         <ModalOverlay />

--- a/components/permit-holders/modals/EditUserInformationModal.tsx
+++ b/components/permit-holders/modals/EditUserInformationModal.tsx
@@ -16,9 +16,11 @@ import {
   Box,
   Select,
   Divider,
+  useToast,
 } from '@chakra-ui/react'; // Chakra UI
 import { useState, SyntheticEvent, ReactNode } from 'react'; // React
 import { Gender } from '@lib/graphql/types'; // Gender Enum
+import SuccessfulEditAlert from '@components/permit-holders/SuccessfulEditAlert'; // Successful edit alert/toast
 
 type EditUserInformationModalProps = {
   children: ReactNode;
@@ -45,9 +47,18 @@ export default function EditUserInformationModal({ children }: EditUserInformati
 
   //   TODO: Add error states for each field (post-mvp)
 
+  const successfulEditToast = useToast();
+
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
     // TODO: Will be addressed in API hookup
+    onClose();
+
+    successfulEditToast({
+      render: () => (
+        <SuccessfulEditAlert>{"User's information has been edited."}</SuccessfulEditAlert>
+      ),
+    });
   };
 
   return (

--- a/components/permit-holders/modals/MedicalHistoryModal.tsx
+++ b/components/permit-holders/modals/MedicalHistoryModal.tsx
@@ -1,0 +1,118 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  useDisclosure,
+  Text,
+  Box,
+  Divider,
+  ListItem,
+  UnorderedList,
+  Badge,
+  HStack,
+} from '@chakra-ui/react'; // Chakra UI
+import { ReactNode } from 'react'; // React
+import { Aid, MedicalInformation } from '@lib/graphql/types'; // MedicalInformation type & Aid enum
+
+type MedicalHistoryModalProps = {
+  medicalInformation: MedicalInformation;
+  children: ReactNode;
+};
+
+export default function MedicalHistoryModal(props: MedicalHistoryModalProps) {
+  const { medicalInformation, children } = props;
+
+  const { isOpen, onClose, onOpen } = useDisclosure();
+
+  const _renderAidsList = (aids: Aid[]): JSX.Element => {
+    return (
+      <UnorderedList paddingLeft="15px">
+        {aids?.map(aid => (
+          <ListItem key={aid} textStyle="body-regular">
+            {aid
+              .toLowerCase()
+              .replace(/^\w/, c => c.toUpperCase())
+              .replace('_', ' ')}
+          </ListItem>
+        ))}
+      </UnorderedList>
+    );
+  };
+
+  return (
+    <>
+      <Box onClick={onOpen}>{children}</Box>
+
+      <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
+        <ModalOverlay />
+        <ModalContent paddingX="36px">
+          <ModalHeader
+            textStyle="display-medium-bold"
+            paddingBottom="22px"
+            paddingTop="24px"
+            paddingX="4px"
+          >
+            <Text as="h2" textStyle="display-medium-bold">
+              {`${medicalInformation.disability} (${medicalInformation.certificationDate})`}
+            </Text>
+          </ModalHeader>
+          <ModalBody paddingTop="0px" paddingBottom="36px" paddingX="4px">
+            {(medicalInformation.affectsMobility ||
+              medicalInformation.mobilityAidRequired ||
+              medicalInformation.cannotWalk100m) && (
+              <HStack paddingBottom="22px" spacing="16px">
+                {medicalInformation.affectsMobility && (
+                  <Badge backgroundColor="background.informative">{'Affects Mobility'}</Badge>
+                )}
+                {medicalInformation.mobilityAidRequired && (
+                  <Badge backgroundColor="background.informative">{'Aid Required'}</Badge>
+                )}
+                {medicalInformation.cannotWalk100m && (
+                  <Badge backgroundColor="background.informative">{'Cannot walk > 100m'}</Badge>
+                )}
+              </HStack>
+            )}
+
+            <Divider borderColor="border.secondary" />
+
+            {medicalInformation.aid && (
+              <Box paddingTop="24px">
+                <Text as="h3" textStyle="heading" paddingBottom="20px">
+                  {'Mobility Aids:'}
+                </Text>
+                {_renderAidsList(medicalInformation.aid)}
+              </Box>
+            )}
+
+            {medicalInformation.notes && (
+              <Box paddingTop="32px">
+                <Text as="h3" textStyle="heading" paddingBottom="20px">
+                  {'Notes: '}
+                </Text>
+                <Text as="p" textStyle="body-regular">
+                  {medicalInformation.notes}
+                </Text>
+              </Box>
+            )}
+          </ModalBody>
+          <ModalFooter paddingTop="0px" paddingBottom="24px" paddingX="4px">
+            <Button
+              colorScheme="gray"
+              variant="solid"
+              onClick={onClose}
+              size="lg"
+              width="93px"
+              height="48px"
+            >
+              {'Back'}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/components/permit-holders/modals/PreviousDoctorsInformationModal.tsx
+++ b/components/permit-holders/modals/PreviousDoctorsInformationModal.tsx
@@ -1,0 +1,114 @@
+import {
+  Box,
+  Link,
+  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  useDisclosure,
+} from '@chakra-ui/react'; // Chakra UI
+import Table from '@components/internal/Table'; // Table component
+import { ReactNode } from 'react'; // React
+
+// Placeholder data
+
+const DATA = Array(4).fill({
+  name: 'Charmaine Wang',
+  phoneNumber: '000-000-000',
+  mspNumber: 'XXXXX',
+  applicationId: { applicationId: 1 },
+});
+
+const COLUMNS = [
+  {
+    Header: 'Name',
+    accessor: 'name',
+    disableSortBy: true,
+    minWidth: 140,
+  },
+  {
+    Header: 'Phone #',
+    accessor: 'phoneNumber',
+    disableSortBy: true,
+    maxWidth: 140,
+  },
+  {
+    Header: 'MSP #',
+    accessor: 'mspNumber',
+    disableSortBy: true,
+    maxWidth: 80,
+  },
+  {
+    accessor: 'applicationId',
+    disableSortBy: true,
+    maxWidth: 200,
+    Cell: _renderAppLink,
+  },
+];
+
+type appProps = {
+  value: { applicationId: number };
+};
+
+function _renderAppLink({ value }: appProps) {
+  return (
+    <Link href={`/admin/request/${value.applicationId}`} passHref>
+      <Text textStyle="body-regular" textColor="primary" as="a">
+        {'View associated APP'}
+      </Text>
+    </Link>
+  );
+}
+
+type PreviousDoctorsInformationModalProps = {
+  children: ReactNode;
+};
+
+export default function PreviousDoctorsInformationModal({
+  children,
+}: PreviousDoctorsInformationModalProps) {
+  const { isOpen, onClose, onOpen } = useDisclosure();
+
+  return (
+    <>
+      <Box onClick={onOpen}>{children}</Box>
+
+      <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
+        <ModalOverlay />
+        <ModalContent paddingX="36px">
+          <ModalHeader
+            textStyle="display-medium-bold"
+            paddingBottom="32px"
+            paddingTop="24px"
+            paddingX="4px"
+          >
+            <Text as="h2" textStyle="display-medium-bold">
+              {"Previous Doctors' Information"}
+            </Text>
+          </ModalHeader>
+          <ModalBody paddingY="0px" paddingX="4px">
+            <Box>
+              <Table columns={COLUMNS} data={DATA} />
+            </Box>
+          </ModalBody>
+          <ModalFooter paddingTop="36px" paddingBottom="40px" paddingX="4px">
+            <Button
+              colorScheme="gray"
+              variant="solid"
+              onClick={onClose}
+              size="lg"
+              width="93px"
+              height="48px"
+            >
+              {'Back'}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/components/requests/modals/EditDoctorInformationModal.tsx
+++ b/components/requests/modals/EditDoctorInformationModal.tsx
@@ -15,7 +15,9 @@ import {
   FormHelperText,
   Box,
   Divider,
+  useToast,
 } from '@chakra-ui/react'; // Chakra UI
+import SuccessFulEditAlert from '@components/permit-holders/SuccessfulEditAlert'; // Successful edit alert/toast
 import { useState, SyntheticEvent, ReactNode } from 'react'; // React
 
 type EditDoctorInformationModalProps = {
@@ -34,11 +36,20 @@ export default function EditDoctorInformationModal({ children }: EditDoctorInfor
   const [city, setCity] = useState('');
   const [postalCode, setPostalCode] = useState('');
 
+  const successfulEditToast = useToast();
+
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
     //  TODO: Will be addressed in API hookup
     onClose();
+
+    successfulEditToast({
+      render: () => (
+        <SuccessFulEditAlert>{'Doctor’s information has been edited.'}</SuccessFulEditAlert>
+      ),
+    });
   };
+
   return (
     <>
       <Box onClick={onOpen}>{children}</Box>
@@ -57,7 +68,7 @@ export default function EditDoctorInformationModal({ children }: EditDoctorInfor
                 {"Edit Doctor's Information"}
               </Text>
             </ModalHeader>
-            <ModalBody paddingY="20px" paddingX="4px">
+            <ModalBody paddingTop="20px" paddingX="4px">
               <Box paddingBottom="32px">
                 <Stack direction="row" spacing="20px" marginBottom="24px">
                   <FormControl isRequired>
@@ -137,7 +148,7 @@ export default function EditDoctorInformationModal({ children }: EditDoctorInfor
                 </Stack>
               </Box>
             </ModalBody>
-            <ModalFooter paddingBottom="24px" paddingTop="0px" paddingX="4px">
+            <ModalFooter paddingBottom="24px" paddingTop="20px" paddingX="4px">
               <Button colorScheme="gray" variant="solid" onClick={onClose}>
                 {'Cancel'}
               </Button>

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -38,7 +38,7 @@ const mockApplication = {
     city: 'Richmond',
     addressLine1: '123 Richmond St.',
     postalCode: 'X0X0X0',
-  } as Applicant,
+  },
   physician: {
     id: 1,
     mspNumber: 123456789,
@@ -78,7 +78,10 @@ export default function PermitHolder() {
   return (
     <Layout>
       <GridItem rowSpan={1} colSpan={12} marginTop={3}>
-        <PermitHolderHeader applicant={applicant} applicationStatus={applicationStatus} />
+        <PermitHolderHeader
+          applicant={applicant as Applicant}
+          applicationStatus={applicationStatus}
+        />
       </GridItem>
       <GridItem rowSpan={12} colSpan={5} marginTop={5} textAlign="left">
         <Stack spacing={5}>

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -85,7 +85,7 @@ export default function PermitHolder() {
       </GridItem>
       <GridItem rowSpan={12} colSpan={5} marginTop={5} textAlign="left">
         <Stack spacing={5}>
-          <PersonalInformationCard applicant={applicant} />
+          <PersonalInformationCard applicant={applicant as unknown as Applicant} />
           <DoctorInformationCard physician={physician} />
           <GuardianInformationCard guardian={guardian} />
         </Stack>

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next'; // Get server side props
 import { getSession } from 'next-auth/client'; // Session management
 import { GridItem, Stack } from '@chakra-ui/react'; // Chakra UI
 import Layout from '@components/internal/Layout'; // Layout component
-import { Role } from '@lib/types'; // Role enum
+import { Applicant, Role } from '@lib/types'; // Role enum and Applicant Type
 import { authorize } from '@tools/authorization'; // Page authorization
 import PermitHolderHeader from '@components/permit-holders/PermitHolderHeader'; // Permit Holder header
 import DoctorInformationCard from '@components/permit-holders/DoctorInformationCard'; // Doctor information card
@@ -38,7 +38,7 @@ const mockApplication = {
     city: 'Richmond',
     addressLine1: '123 Richmond St.',
     postalCode: 'X0X0X0',
-  },
+  } as Applicant,
   physician: {
     id: 1,
     mspNumber: 123456789,

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -79,7 +79,7 @@ export default function PermitHolder() {
     <Layout>
       <GridItem rowSpan={1} colSpan={12} marginTop={3}>
         <PermitHolderHeader
-          applicant={applicant as Applicant}
+          applicant={applicant as unknown as Applicant}
           applicationStatus={applicationStatus}
         />
       </GridItem>

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -1,0 +1,119 @@
+import { GetServerSideProps } from 'next'; // Get server side props
+import { getSession } from 'next-auth/client'; // Session management
+import { GridItem, Stack } from '@chakra-ui/react'; // Chakra UI
+import Layout from '@components/internal/Layout'; // Layout component
+import { Role } from '@lib/types'; // Role enum
+import { authorize } from '@tools/authorization'; // Page authorization
+import PermitHolderHeader from '@components/permit-holders/PermitHolderHeader'; // Permit Holder header
+import DoctorInformationCard from '@components/permit-holders/DoctorInformationCard'; // Doctor information card
+import PersonalInformationCard from '@components/permit-holders/PersonalInformationCard'; // Personal information card
+import { Gender, Province, PhysicianStatus, PaymentType } from '@lib/types'; // Gender, Province, PhysicianStatus, PaymentType Enums
+import GuardianInformationCard from '@components/permit-holders/GuardianInformationCard'; // Guardian Information card
+import AppHistoryCard from '@components/permit-holders/AppHistoryCard'; // APP History card
+import AttachedFilesCard from '@components/permit-holders/AttachedFilesCard'; // Attached Files card
+import MedicalHistoryCard from '@components/permit-holders/MedicalHistoryCard'; // Medical History card
+
+// TEMPORARY MOCK DATA
+
+type ApplicationStatus =
+  | 'COMPLETED'
+  | 'INPROGRESS'
+  | 'PENDING'
+  | 'REJECTED'
+  | 'EXPIRING'
+  | 'EXPIRED'
+  | 'ACTIVE';
+const mockApplication = {
+  applicant: {
+    id: 1,
+    rcdUserId: 1,
+    mostRecentAPP: 12345,
+    firstName: 'Permit Holder',
+    lastName: 'One',
+    gender: Gender.Female,
+    dateOfBirth: 1,
+    email: 'applicantone@email.com',
+    phone: '1234567890',
+    province: Province.Bc,
+    city: 'Richmond',
+    addressLine1: '123 Richmond St.',
+    postalCode: 'X0X0X0',
+  },
+  physician: {
+    id: 1,
+    mspNumber: 123456789,
+    firstName: 'Physician',
+    lastName: 'One',
+    phone: '1234567890',
+    addressLine1: '123 Richmond St.',
+    postalCode: 'X0X0X0',
+    city: 'Richmond',
+    province: Province.Bc,
+    status: PhysicianStatus.Active,
+  },
+  guardian: {
+    id: 1,
+    firstName: 'Guardian',
+    lastName: 'One',
+    phone: '1234567890',
+    addressLine1: '123 Richmond St.',
+    postalCode: 'X0X0X0',
+    city: 'Richmond',
+    province: Province.Bc,
+    relationship: 'Parent',
+  },
+  createdAt: new Date().toDateString(),
+  expirationDate: new Date().toDateString(),
+  isRenewal: true,
+  applicationStatus: 'PENDING' as ApplicationStatus, // Will be updated in the future as we'll be able to reference ApplicationStatus enum in types.ts
+  permitFee: 5,
+  donation: 10,
+  paymentType: PaymentType.Visa,
+};
+
+// Individual permit holder page
+export default function PermitHolder() {
+  const { applicant, physician, guardian, applicationStatus } = mockApplication;
+
+  return (
+    <Layout>
+      <GridItem rowSpan={1} colSpan={12} marginTop={3}>
+        <PermitHolderHeader applicant={applicant} applicationStatus={applicationStatus} />
+      </GridItem>
+      <GridItem rowSpan={12} colSpan={5} marginTop={5} textAlign="left">
+        <Stack spacing={5}>
+          <PersonalInformationCard applicant={applicant} />
+          <DoctorInformationCard physician={physician} />
+          <GuardianInformationCard guardian={guardian} />
+        </Stack>
+      </GridItem>
+
+      <GridItem rowSpan={12} colSpan={7} marginTop={5} textAlign="left">
+        <Stack spacing={5}>
+          <AppHistoryCard />
+          <AttachedFilesCard />
+          <MedicalHistoryCard />
+        </Stack>
+      </GridItem>
+    </Layout>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const session = await getSession(context);
+
+  // Only secretaries and admins can access permit holder information
+  if (authorize(session, [Role.Secretary])) {
+    return {
+      props: {},
+    };
+  }
+
+  // If user is not secretary or admin, redirect to login
+  return {
+    redirect: {
+      destination: '/admin/login',
+      permanent: false,
+    },
+  };
+};

--- a/tools/theme/colors.ts
+++ b/tools/theme/colors.ts
@@ -77,6 +77,9 @@ const colors = {
     active: '#F1F8F5',
     inactive: '#FFF4F4',
   },
+  alerticon: {
+    success: '#009444',
+  },
 };
 
 export default colors;

--- a/tools/theme/components/badge.ts
+++ b/tools/theme/components/badge.ts
@@ -11,7 +11,7 @@ const Badge: ComponentSingleStyleConfig = {
     fontWeight: 'normal',
     fontSize: '16px',
     height: '32px',
-    paddingX: '1rem',
+    paddingX: '12px',
     paddingY: '4px',
   },
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[View individual Permit Holder page](https://www.notion.so/uwblueprintexecs/View-individual-Permit-Holder-page-396f2b4450ee4b30bab184678d5768da)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Demo:
![pr_demo](https://user-images.githubusercontent.com/51224641/128615866-2730dfc2-3eee-4ea8-a83b-90e4fdb55d3d.gif)


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Making guardian information editable has been deprioritized for the MVP and will be addressed post-mvp so the edit guardian  modal was not built (clicking the edit button on the guardian information card does nothing)
* Alerts that pop up at the bottom after editing should be closable, I couldn't figure out how to make it closable and just removed the close button and added a ticket to the task board.
* The way data is handled in the components will likely change to match API response data

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
