### PR TITLE
[Bugfix] Fix Pagination component next button not being disabled when totalCount=0

### DIFF
--- a/components/internal/Pagination.tsx
+++ b/components/internal/Pagination.tsx
@@ -19,10 +19,10 @@ export default function Pagination(props: Props) {
 
   const [pageNumber, setPageNumber] = useState(initialPageNumber); // Current page number
 
-  const totalPages = Math.ceil(totalCount / pageSize); // Total number of pages
+  const totalPages = totalCount === 0 ? 1 : Math.ceil(totalCount / pageSize); // Total number of pages
   const isFirstPage = pageNumber === 0; // Whether current page is first page
   const isLastPage = pageNumber === totalPages - 1; // Whether current page is last page
-  const lowerBound = pageNumber * pageSize + 1; // Lower bound of current page (item #)
+  const lowerBound = totalCount === 0 ? 0 : pageNumber * pageSize + 1; // Lower bound of current page (item #)
   const upperBound = isLastPage ? totalCount : (pageNumber + 1) * pageSize; // Upper bound of current page (item #)
 
   /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
None


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `Pagination` component was broken. The Next button was not being disabled when `totalCount=0`. This was because we calculated as the number of pages as `ceil(totalCount / pageSize)`, which would give 0. When checking whether we were on the last page, we were checking if `pageNumber === lastPage - 1` which was -1 - never possible.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
