### PR TITLE
[Improvement] Replace verify identity page date input with DatePicker component

### DIFF
--- a/components/DatePicker.tsx
+++ b/components/DatePicker.tsx
@@ -1,0 +1,30 @@
+import { ChakraProps, Input } from '@chakra-ui/react'; // Chakra UI
+import ReactDayPickerInput from 'react-day-picker/DayPickerInput'; // React Day Picker Input
+import 'react-day-picker/lib/style.css'; // React Day Picker default styling
+
+// Date Picker props
+type Props = {
+  readonly value: Date; // Date value
+  readonly onDateChange: (day: Date) => void; // Callback on date change
+} & Pick<ChakraProps, 'width'>;
+
+/**
+ * Custom date picker component wrapping React Day Picker
+ * @param date The currently selected date
+ * @param onDateChange Callback on date change
+ * @returns
+ */
+export default function DatePicker(props: Props) {
+  const { width, value, onDateChange } = props;
+
+  return (
+    <>
+      <ReactDayPickerInput
+        component={(props: any) => <Input width={width} {...props} />}
+        formatDate={date => date.toLocaleDateString('en-CA')}
+        value={value}
+        onDayChange={onDateChange}
+      />
+    </>
+  );
+}

--- a/components/DateRangePicker.tsx
+++ b/components/DateRangePicker.tsx
@@ -12,7 +12,7 @@ type DateRangePicker = {
  * that allows selecting a range of dates
  * @param {DateRangePicker} props - Props
  */
-export default function DayPicker(props: DateRangePicker) {
+export default function DateRangePicker(props: DateRangePicker) {
   return (
     <>
       <ReactDayPicker

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -65,7 +65,7 @@ const COLUMNS: Column<any>[] = [
     width: 140,
     maxWidth: 140,
     Cell: ({ value }) => {
-      return <Text>{new Date(value).toLocaleDateString('en-ZA')}</Text>;
+      return <Text>{new Date(value).toLocaleDateString('en-CA')}</Text>;
     },
   },
   {

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   FormControl,
   FormLabel,
-  Input,
   FormHelperText,
   NumberInput,
   NumberInputField,
@@ -27,6 +26,7 @@ import {
 import { InfoOutlineIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import Layout from '@components/applicant/Layout'; // Layout component
 import TOSModal from '@components/applicant/renewals/TOSModal'; // TOS Modal
+import DatePicker from '@components/DatePicker'; // Date picker component
 import {
   VERIFY_IDENTITY_MUTATION,
   VerifyIdentityRequest,
@@ -47,7 +47,7 @@ export default function IdentityVerificationForm() {
 
   const [userId, setUserId] = useState('');
   const [phoneNumberSuffix, setPhoneNumberSuffix] = useState('');
-  const [dateOfBirth, setDateOfBirth] = useState(new Date().toISOString().substring(0, 10));
+  const [dateOfBirth, setDateOfBirth] = useState(new Date());
 
   // Verify identity query
   const [verifyIdentity, { data, loading }] = useMutation<
@@ -77,7 +77,7 @@ export default function IdentityVerificationForm() {
         input: {
           userId: parseInt(userId),
           phoneNumberSuffix,
-          dateOfBirth,
+          dateOfBirth: dateOfBirth.toISOString().substring(0, 10), // Strip time from DOB
           acceptedTos: acceptedTOSTimestamp,
         },
       },
@@ -135,12 +135,7 @@ export default function IdentityVerificationForm() {
             </FormControl>
             <FormControl isRequired textAlign="left" marginBottom="20px">
               <FormLabel>{`Date of Birth`}</FormLabel>
-              <Input
-                type="date"
-                width="184px"
-                value={dateOfBirth}
-                onChange={event => setDateOfBirth(event.target.value)}
-              />
+              <DatePicker width="184px" value={dateOfBirth} onDateChange={setDateOfBirth} />
               <FormHelperText>
                 {`Please enter your date of birth in YYYY-MM-DD format. For example, if you were born on
             20th August 1950, you would enter 20-08-1950`}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Replace-date-picker-on-Verify-Identify-page-with-React-date-picker-component-6e7d21e4985a4d6e9e7597e3d39685bf)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created `DatePicker` component that wraps `DayPickerInput` component from `ReactDayPicker`, replaced date input with this new component in the verify identity page of the renewal flow


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
