### PR TITLE
[Misc] Add sample data to staging database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 
 # Local Netlify folder
 .netlify
+
+# sample data
+*.csv

--- a/components/requests/PersonalInformationCard.tsx
+++ b/components/requests/PersonalInformationCard.tsx
@@ -30,7 +30,7 @@ export default function PersonalInformationCard(props: Props) {
 
   // Personal information card header
   const Header = (
-    <Link href={`/permit-holder/${applicant.id}`}>
+    <Link href={`/admin/permit-holder/${applicant.id}`}>
       <Text
         variant="link"
         textStyle="display-small-semibold"

--- a/lib/applicants/field-resolvers.ts
+++ b/lib/applicants/field-resolvers.ts
@@ -34,7 +34,11 @@ export const applicantPermitsResolver: Resolver<Applicant> = async (parent, _arg
  * @returns Guardian object
  */
 export const applicantGuardianResolver: Resolver<Applicant> = async (parent, _args, { prisma }) => {
-  return await prisma.guardian.findUnique({ where: { id: parent?.guardianId } });
+  if (parent.guardianId === null) {
+    return null;
+  }
+
+  return await prisma.guardian.findUnique({ where: { id: parent.guardianId } });
 };
 
 /**

--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -19,7 +19,7 @@ export default `
     status: ApplicantStatus
     activePermit: Permit
     applications: [Application!]
-    guardianId: Int!
+    guardianId: Int
     guardian: Guardian!
     medicalInformationId: Int!
     medicalInformation: MedicalInformation!

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -46,7 +46,7 @@ export type Applicant = {
   status: Maybe<ApplicantStatus>;
   activePermit: Maybe<Permit>;
   applications: Maybe<Array<Application>>;
-  guardianId: Scalars['Int'];
+  guardianId: Maybe<Scalars['Int']>;
   guardian: Guardian;
   medicalInformationId: Scalars['Int'];
   medicalInformation: MedicalInformation;

--- a/lib/scripts/oneoff/backup/populate-db-09-13-21.ts
+++ b/lib/scripts/oneoff/backup/populate-db-09-13-21.ts
@@ -1,0 +1,260 @@
+/* eslint-disable */
+import csv from 'csv-parser'; // CSV parser
+import fs from 'fs'; // File system
+import {
+  ApplicantStatus,
+  ApplicationStatus,
+  Gender,
+  PaymentType,
+  PhysicianStatus,
+  Province,
+} from '@lib/graphql/types'; // GraphQL types
+import {
+  UpsertApplicant,
+  UpsertApplication,
+  UpsertApplicationProcessing,
+  UpsertGuardian,
+  UpsertMedicalInformation,
+  UpsertPermit,
+  UpsertPhysician,
+} from '@prisma/types'; // Seeding types
+
+// First ID of records to insert
+const STARTING_INDEX = 10;
+
+// Type of JS object parsed from CSV row
+type CsvRow = {
+  userid: string;
+  permit_before: string;
+  initial_apply_org: string;
+  lastname: string;
+  firstname: string;
+  address: string;
+  city: string;
+  prov: string;
+  postal_code: string;
+  telephone: string;
+  email_1: string;
+  email_2: string;
+  DOB: string;
+  gender: string;
+  application_date: string;
+  permit_no: string;
+  fee: string;
+  donation: string;
+  pay_method: string;
+  disability: string;
+  eligibility: string;
+  certification_date: string;
+  'permit expiry': string;
+  receipt: string;
+  'guardian-lastame': string;
+  'guardian-firstName': string;
+  'guardian-address': string;
+  'guardian-unit': string;
+  'guardian-telphone': string;
+  relationship: string;
+  'guardian-notes': string;
+  physician: string;
+  msp_number: string;
+  notes: string;
+  tax_receipt: string;
+  tr_mailing_method: string;
+  tr_firstname: string;
+  tr_lastname: string;
+  tr_address: string;
+  tr_unit: string;
+  tr_city: string;
+  tr_province: string;
+  tr_postalcode: string;
+  tr_tel: string;
+  tr_email: string;
+};
+
+/**
+ * Get payment method based on string
+ * @returns payment method as PaymentType enum
+ */
+function getPaymentMethod(paymentMethod: string): PaymentType {
+  switch (paymentMethod) {
+    case 'MC':
+      return PaymentType.Mastercard;
+    case 'VISA':
+      return PaymentType.Visa;
+    case 'DC':
+      return PaymentType.Debit;
+    case 'CHQ':
+      return PaymentType.Cheque;
+    case 'CASH':
+      return PaymentType.Cash;
+    case 'MO':
+      return PaymentType.MoneyOrder;
+    default:
+      return PaymentType.Cash;
+  }
+}
+
+/**
+ * Populate database with data from CSV file specified in command line arguments
+ * Usage: `ts-node populate-db.ts <CSV filename>`
+ * Created: September 13, 2021
+ */
+function populateDb() {
+  const fileName = process.argv[2];
+
+  if (!fileName) {
+    console.log('Invalid CSV file specified');
+  }
+
+  // Parsed data
+  const applicants: UpsertApplicant[] = [];
+  const permits: UpsertPermit[] = [];
+  const guardians: UpsertGuardian[] = [];
+  const applications: UpsertApplication[] = [];
+  const physicians: UpsertPhysician[] = [];
+  const medicalInformations: UpsertMedicalInformation[] = [];
+  const applicationProcessings: UpsertApplicationProcessing[] = [];
+
+  /**
+   * Extract the relevant fields from a CSV row and insert data into applicants, permits and applications tables
+   * @param data parsed CSV data as a JS object
+   * @param index the index of the row
+   */
+  function parseRow(data: CsvRow, index: number) {
+    const physician: UpsertPhysician = {
+      id: index,
+      name: `Doctor ${data.msp_number}`,
+      mspNumber: parseInt(data.msp_number),
+      addressLine1: `${data.msp_number} Doctor Rd.`,
+      city: 'Richmond',
+      province: Province.Bc,
+      postalCode: 'A1B2C3',
+      phone: '1234567890',
+      status: PhysicianStatus.Active,
+    };
+
+    const medicalInformation: UpsertMedicalInformation = {
+      id: index,
+      disability: data.disability,
+      affectsMobility: data.eligibility.includes('Affected-Mobility'),
+      mobilityAidRequired: data.eligibility.includes('Mobility Aid'),
+      cannotWalk100m: data.eligibility.includes('Cannot-Walk-100m'),
+      physicianId: index,
+    };
+
+    const guardian: UpsertGuardian | null =
+      data['guardian-firstName'] && data['guardian-lastame']
+        ? {
+            id: index,
+            firstName: data['guardian-firstName'],
+            lastName: data['guardian-lastame'],
+            phone: data['guardian-telphone'],
+            province: Province.Bc,
+            city: 'Richmond',
+            addressLine1: data['guardian-address'],
+            postalCode: 'A1B2C3',
+            relationship: data.relationship,
+          }
+        : null;
+
+    const applicant: UpsertApplicant = {
+      id: index,
+      rcdUserId: parseInt(data.userid),
+      firstName: data.firstname,
+      lastName: data.lastname,
+      email: data.email_1 || data.email_2,
+      gender: data.gender === 'Male' ? Gender.Male : Gender.Female,
+      phone: data.telephone,
+      province: data.prov as Province,
+      city: data.city,
+      addressLine1: data.address,
+      postalCode: data.postal_code,
+      guardianId: guardian ? index : null,
+      medicalInformationId: index,
+      status: ApplicantStatus.Active,
+    };
+
+    const applicationProcessing: UpsertApplicationProcessing = {
+      id: index,
+      status: ApplicationStatus.Completed,
+      appNumber: parseInt(data.permit_no),
+      appHolepunched: true,
+      walletCardCreated: true,
+      invoiceNumber: parseInt(data.receipt),
+      documentUrls: [],
+      appMailed: true,
+    };
+
+    const application: UpsertApplication = {
+      id: index,
+      rcdUserId: parseInt(data.userid),
+      firstName: data.firstname,
+      lastName: data.lastname,
+      gender: data.gender as Gender,
+      phone: data.telephone,
+      province: data.prov as Province,
+      city: data.city,
+      addressLine1: data.address,
+      postalCode: data.postal_code,
+      disability: data.eligibility,
+      aid: [],
+      physicianName: `Doctor ${data.msp_number}`,
+      physicianMspNumber: parseInt(data.msp_number),
+      physicianAddressLine1: `${data.msp_number} Doctor Rd.`,
+      physicianCity: 'Richmond',
+      physicianProvince: Province.Bc,
+      physicianPostalCode: 'A1B2C3',
+      physicianPhone: '1234567890',
+      processingFee: parseInt(data.fee),
+      paymentMethod: getPaymentMethod(data.pay_method),
+      shopifyConfirmationNumber: data.receipt,
+      applicantId: index,
+      email: data.email_1 || data.email_2 || null,
+      shippingFullName: `${data.firstname} ${data.lastname}`,
+      shippingAddressLine1: data.address,
+      shippingCity: data.city,
+      shippingProvince: Province.Bc,
+      shippingPostalCode: 'A1B2C3',
+      billingFullName: `${data.firstname} ${data.lastname}`,
+      applicationProcessingId: index,
+    };
+
+    const permit: UpsertPermit = {
+      rcdPermitId: parseInt(data.permit_no),
+      applicantId: index,
+      applicationId: index,
+      expiryDate: new Date(data['permit expiry']),
+      active: new Date().getTime() < new Date(data['permit expiry']).getTime(),
+    };
+
+    physicians.push(physician);
+    medicalInformations.push(medicalInformation);
+    if (guardian) {
+      guardians.push(guardian);
+    }
+    applicants.push(applicant);
+    applicationProcessings.push(applicationProcessing);
+    applications.push(application);
+    permits.push(permit);
+  }
+
+  let rowNumber = 0;
+
+  // Pipe CSV data to `data`
+  fs.createReadStream(fileName)
+    .pipe(csv())
+    .on('data', (data: CsvRow) => {
+      parseRow(data, STARTING_INDEX + rowNumber++);
+    });
+
+  // If no rows were parsed, we are done
+  if (applicants.length === 0) {
+    console.log('Nothing to be done.');
+    return;
+  }
+
+  // Otherwise, upsert data
+  // TODO
+}
+
+populateDb();

--- a/lib/scripts/oneoff/populate-db-09-13-21.js
+++ b/lib/scripts/oneoff/populate-db-09-13-21.js
@@ -181,7 +181,7 @@ function populateDb() {
 
   let rowNumber = 0;
 
-  // Pipe CSV data to `data`
+  // Pipe CSV data to data arrays and populate DB
   fs.createReadStream(fileName)
     .pipe(csv())
     .on('data', data => {

--- a/lib/scripts/oneoff/populate-db-09-13-21.js
+++ b/lib/scripts/oneoff/populate-db-09-13-21.js
@@ -1,0 +1,283 @@
+/* eslint-disable */
+const csv = require('csv-parser'); // CSV parser
+const fs = require('fs'); // File system
+const { PrismaClient } = require('@prisma/client'); // Prisma client
+
+// First ID of records to insert
+const STARTING_INDEX = 100;
+
+// Prisma Client
+const prisma = new PrismaClient();
+
+/**
+ * Get payment method based on string
+ * @returns payment method as PaymentType enum
+ */
+function getPaymentMethod(paymentMethod) {
+  switch (paymentMethod) {
+    case 'MC':
+      return 'MASTERCARD';
+    case 'VISA':
+      return 'VISA';
+    case 'DC':
+      return 'DEBIT';
+    case 'CHQ':
+      return 'CHEQUE';
+    case 'CASH':
+      return 'CASH';
+    case 'MO':
+      return 'MONEY_ORDER';
+    default:
+      return 'CASH';
+  }
+}
+
+/**
+ * Populate database with data from CSV file specified in command line arguments
+ * Usage: `ts-node populate-db.ts <CSV filename>`
+ * Created: September 13, 2021
+ */
+function populateDb() {
+  const fileName = process.argv[2];
+
+  if (!fileName) {
+    console.log('Invalid CSV file specified');
+  }
+
+  // Parsed data
+  const applicants = [];
+  const permits = [];
+  const guardians = [];
+  const applications = [];
+  const physicians = [];
+  const medicalInformations = [];
+  const applicationProcessings = [];
+
+  /**
+   * Extract the relevant fields from a CSV row and insert data into applicants, permits and applications tables
+   * @param data parsed CSV data as a JS object
+   * @param index the index of the row
+   */
+  function parseRow(data, index) {
+    const physician = {
+      id: parseInt(data.msp_number) || 90000 + index,
+      name: `Doctor ${data.msp_number}`,
+      mspNumber: parseInt(data.msp_number) || 90000 + index,
+      addressLine1: `${data.msp_number} Doctor Rd.`,
+      city: 'Richmond',
+      province: 'BC',
+      postalCode: 'A1B2C3',
+      phone: '1234567890',
+      status: 'ACTIVE',
+    };
+
+    const medicalInformation = {
+      id: index,
+      disability: data.disability,
+      affectsMobility: data.eligibility.includes('Affected-Mobility'),
+      mobilityAidRequired: data.eligibility.includes('Mobility Aid'),
+      cannotWalk100m: data.eligibility.includes('Cannot-Walk-100m'),
+      physicianId: parseInt(data.msp_number) || 90000 + index,
+    };
+
+    const guardian =
+      data['guardian-firstName'] && data['guardian-lastame']
+        ? {
+            id: index,
+            firstName: data['guardian-firstName'],
+            lastName: data['guardian-lastame'],
+            phone: data['guardian-telphone'],
+            province: 'BC',
+            city: 'Richmond',
+            addressLine1: data['guardian-address'],
+            postalCode: 'A1B2C3',
+            relationship: data.relationship,
+          }
+        : null;
+
+    const applicant = {
+      id: index,
+      rcdUserId: parseInt(data.userid) || 90000 + index,
+      firstName: data.firstname,
+      lastName: data.lastname,
+      email: data.email_1 || data.email_2 || null,
+      gender: data.gender === 'Male' ? 'MALE' : 'FEMALE',
+      phone: data.telephone,
+      province: data.prov,
+      city: data.city,
+      addressLine1: data.address,
+      postalCode: data.postal_code,
+      guardianId: guardian ? index : null,
+      medicalInformationId: index,
+      status: 'ACTIVE',
+      dateOfBirth: new Date(data.DOB),
+    };
+
+    const applicationProcessing = {
+      id: index,
+      status: 'COMPLETED',
+      appNumber: parseInt(data.permit_no) || 90000 + index,
+      appHolepunched: true,
+      walletCardCreated: true,
+      invoiceNumber: parseInt(data.receipt) || 90000 + index,
+      documentUrls: [],
+      appMailed: true,
+    };
+
+    const application = {
+      id: index,
+      rcdUserId: parseInt(data.userid) || 90000 + index,
+      firstName: data.firstname,
+      lastName: data.lastname,
+      gender: data.gender === 'Male' ? 'MALE' : 'FEMALE',
+      phone: data.telephone,
+      province: data.prov,
+      city: data.city,
+      addressLine1: data.address,
+      postalCode: data.postal_code,
+      disability: data.eligibility,
+      aid: [],
+      physicianName: `Doctor ${data.msp_number}`,
+      physicianMspNumber: parseInt(data.msp_number) || 90000 + index,
+      physicianAddressLine1: `${data.msp_number} Doctor Rd.`,
+      physicianCity: 'Richmond',
+      physicianProvince: 'BC',
+      physicianPostalCode: 'A1B2C3',
+      physicianPhone: '1234567890',
+      processingFee: parseInt(data.fee) || 90000 + index,
+      donationAmount: parseInt(data.donation) || 0,
+      paymentMethod: getPaymentMethod(data.pay_method),
+      shopifyConfirmationNumber: data.receipt,
+      applicantId: index,
+      email: data.email_1 || data.email_2 || null,
+      shippingFullName: `${data.firstname} ${data.lastname}`,
+      shippingAddressLine1: data.address,
+      shippingCity: data.city,
+      shippingProvince: 'BC',
+      shippingPostalCode: 'A1B2C3',
+      billingFullName: `${data.firstname} ${data.lastname}`,
+      applicationProcessingId: index,
+      dateOfBirth: new Date(data.DOB),
+    };
+
+    const permit = {
+      rcdPermitId: parseInt(data.permit_no) || 90000 + index,
+      applicantId: index,
+      applicationId: index,
+      expiryDate: new Date(data['permit expiry']),
+      active: new Date().getTime() < new Date(data['permit expiry']).getTime(),
+    };
+
+    physicians.push(physician);
+    medicalInformations.push(medicalInformation);
+    if (guardian) {
+      guardians.push(guardian);
+    }
+    applicants.push(applicant);
+    applicationProcessings.push(applicationProcessing);
+    applications.push(application);
+    permits.push(permit);
+  }
+
+  let rowNumber = 0;
+
+  // Pipe CSV data to `data`
+  fs.createReadStream(fileName)
+    .pipe(csv())
+    .on('data', data => {
+      parseRow(data, STARTING_INDEX + rowNumber++);
+    })
+    .on('end', async () => {
+      // If no rows were parsed, we are done
+      if (applicants.length === 0) {
+        console.log('Nothing to be done.');
+        return;
+      }
+
+      // Otherwise, upsert data
+      // TODO: Reduce duplicate code and use seeding functions
+      // Upsert physicians
+      for (const physician of physicians) {
+        const { mspNumber, ...rest } = physician;
+        const physicianUpsert = await prisma.physician.upsert({
+          where: { mspNumber },
+          update: { ...rest },
+          create: physician,
+        });
+        console.log({ physicianUpsert });
+      }
+
+      // Upsert medical information
+      for (const medicalInformation of medicalInformations) {
+        const { id, ...rest } = medicalInformation;
+        const medicalInformationUpsert = await prisma.medicalInformation.upsert({
+          where: { id },
+          update: { ...rest },
+          create: medicalInformation,
+        });
+        console.log({ medicalInformationUpsert });
+      }
+
+      // Upsert guardians
+      for (const guardian of guardians) {
+        const { id, ...rest } = guardian;
+        const guardianUpsert = await prisma.guardian.upsert({
+          where: { id },
+          update: { ...rest },
+          create: guardian,
+        });
+        console.log({ guardianUpsert });
+      }
+
+      // Upsert applicants
+      for (const applicant of applicants) {
+        const { rcdUserId, ...rest } = applicant;
+        const applicantUpsert = await prisma.applicant.upsert({
+          where: { rcdUserId },
+          update: rest,
+          create: rest,
+        });
+        console.log({ applicantUpsert });
+      }
+
+      // Upsert application processings
+      for (const applicationProcessing of applicationProcessings) {
+        const { appNumber, ...rest } = applicationProcessing;
+        const applicationProcessingUpsert = await prisma.applicationProcessing.upsert({
+          where: { appNumber },
+          update: rest,
+          create: rest,
+        });
+        console.log({ applicationProcessingUpsert });
+      }
+
+      // Upsert applications
+      for (const application of applications) {
+        const { id, ...rest } = application;
+        const applicationUpsert = await prisma.application.upsert({
+          where: { id },
+          update: { ...rest },
+          create: {
+            id,
+            ...rest,
+          },
+        });
+        console.log({ applicationUpsert });
+      }
+
+      // Upsert permits
+      for (const permit of permits) {
+        const { rcdPermitId, expiryDate = new Date().toISOString(), ...rest } = permit;
+        const permitUpsert = await prisma.permit.upsert({
+          where: { rcdPermitId },
+          update: { ...rest },
+          create: { rcdPermitId, expiryDate, ...rest },
+        });
+        console.log({ permitUpsert });
+      }
+
+      process.exit(0);
+    });
+}
+
+populateDb();

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
     "apollo": "^2.33.2",
+    "csv-parser": "^3.0.0",
     "eslint": "^7.26.0",
     "eslint-config-next": "^11.0.0",
     "eslint-plugin-react": "^7.23.2",

--- a/prisma/dev-seed-utils/applicants.ts
+++ b/prisma/dev-seed-utils/applicants.ts
@@ -2,6 +2,7 @@
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
 import { Gender, Province, ApplicantStatus } from '../../lib/graphql/types'; // GraphQL types
+import { UpsertApplicant } from '../types'; // Seeding types
 
 // Seed data
 const applicants = [
@@ -58,17 +59,16 @@ const applicants = [
 
 /**
  * Upsert applicants
+ * @param data Custom applicant data to be upserted
  */
-export default async function applicantUpsert(): Promise<void> {
-  const applicantUpserts = [];
-  for (const applicant of applicants) {
+export default async function applicantUpsert(data?: UpsertApplicant[]): Promise<void> {
+  for (const applicant of data || applicants) {
     const { id, ...rest } = applicant;
     const applicantUpsert = await prisma.applicant.upsert({
       where: { id },
       update: rest,
       create: { dateOfBirth: new Date().toISOString(), ...rest },
     });
-    applicantUpserts.push(applicantUpsert);
     console.log({ applicantUpsert });
   }
 }

--- a/prisma/dev-seed-utils/application-processings.ts
+++ b/prisma/dev-seed-utils/application-processings.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
+import { UpsertApplicationProcessing } from '../types'; // Seeding types
 
 // Seed data
 const applicationProcessings = [
@@ -17,17 +18,18 @@ const applicationProcessings = [
 
 /**
  * Upsert application processing records
+ * @param data Custom application processing data to be upserted
  */
-export default async function applicationProcessingUpsert(): Promise<void> {
-  const applicationProcessingUpserts = [];
-  for (const applicationProcessing of applicationProcessings) {
+export default async function applicationProcessingUpsert(
+  data?: UpsertApplicationProcessing[]
+): Promise<void> {
+  for (const applicationProcessing of data || applicationProcessings) {
     const { id, ...rest } = applicationProcessing;
     const applicationProcessingUpsert = await prisma.applicationProcessing.upsert({
       where: { id },
       update: { ...rest },
       create: rest,
     });
-    applicationProcessingUpserts.push(applicationProcessingUpsert);
     console.log({ applicationProcessingUpsert });
   }
 }

--- a/prisma/dev-seed-utils/applications.ts
+++ b/prisma/dev-seed-utils/applications.ts
@@ -2,6 +2,7 @@
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
 import { Gender, Province, PaymentType, Aid } from '../../lib/graphql/types'; // GraphQL types
+import { UpsertApplication } from '../types'; // Seeding types
 
 // Seed data
 const applications = [
@@ -94,10 +95,10 @@ const applications = [
 
 /**
  * Upsert applications
+ * @param data Custom application data to be upserted
  */
-export default async function applicationUpsert(): Promise<void> {
-  const applicationUpserts = [];
-  for (const application of applications) {
+export default async function applicationUpsert(data?: UpsertApplication[]): Promise<void> {
+  for (const application of data || applications) {
     const { id, ...rest } = application;
     const applicationUpsert = await prisma.application.upsert({
       where: { id },
@@ -107,7 +108,6 @@ export default async function applicationUpsert(): Promise<void> {
         ...rest,
       },
     });
-    applicationUpserts.push(applicationUpsert);
     console.log({ applicationUpsert });
   }
 }

--- a/prisma/dev-seed-utils/guardians.ts
+++ b/prisma/dev-seed-utils/guardians.ts
@@ -2,6 +2,7 @@
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
 import { Province } from '../../lib/graphql/types'; // GraphQL types
+import { UpsertGuardian } from '../types'; // Seeding types
 
 // Upsert applicant guardians
 const guardians = [
@@ -42,17 +43,16 @@ const guardians = [
 
 /**
  * Upsert guardians
+ * @param data Custom guardian data to be upserted
  */
-export default async function guardianUpsert(): Promise<void> {
-  const guardianUpserts = [];
-  for (const guardian of guardians) {
+export default async function guardianUpsert(data?: UpsertGuardian[]): Promise<void> {
+  for (const guardian of data || guardians) {
     const { id, ...rest } = guardian;
     const guardianUpsert = await prisma.guardian.upsert({
       where: { id },
       update: { ...rest },
       create: guardian,
     });
-    guardianUpserts.push(guardianUpsert);
     console.log({ guardianUpsert });
   }
 }

--- a/prisma/dev-seed-utils/medical-information.ts
+++ b/prisma/dev-seed-utils/medical-information.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
+import { UpsertMedicalInformation } from '../types'; // Seeding types
 
 // Seed data
 const medicalInformationRecords = [
@@ -32,17 +33,18 @@ const medicalInformationRecords = [
 
 /**
  * Upsert medical information records for applicants
+ * @param data Custom medical information data to be upserted
  */
-export default async function medicalInformationUpsert(): Promise<void> {
-  const medicalInformationUpserts = [];
-  for (const medicalInformation of medicalInformationRecords) {
+export default async function medicalInformationUpsert(
+  data?: UpsertMedicalInformation[]
+): Promise<void> {
+  for (const medicalInformation of data || medicalInformationRecords) {
     const { id, ...rest } = medicalInformation;
     const medicalInformationUpsert = await prisma.medicalInformation.upsert({
       where: { id },
       update: { ...rest },
       create: medicalInformation,
     });
-    medicalInformationUpserts.push(medicalInformationUpsert);
     console.log({ medicalInformationUpsert });
   }
 }

--- a/prisma/dev-seed-utils/permits.ts
+++ b/prisma/dev-seed-utils/permits.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
+import { UpsertPermit } from '../types'; // Seeding types
 
 // Seed data
 const permits = [
@@ -28,17 +29,16 @@ const permits = [
 
 /**
  * Upsert permits
+ * @param data Custom permit data to be upserted
  */
-export default async function permitUpsert(): Promise<void> {
-  const permitUpserts = [];
-  for (const permit of permits) {
+export default async function permitUpsert(data?: UpsertPermit[]): Promise<void> {
+  for (const permit of data || permits) {
     const { rcdPermitId, expiryDate = new Date().toISOString(), ...rest } = permit;
     const permitUpsert = await prisma.permit.upsert({
       where: { rcdPermitId },
       update: { ...rest },
       create: { rcdPermitId: rcdPermitId, expiryDate, ...rest },
     });
-    permitUpserts.push(permitUpsert);
     console.log({ permitUpsert });
   }
 }

--- a/prisma/dev-seed-utils/physicians.ts
+++ b/prisma/dev-seed-utils/physicians.ts
@@ -2,6 +2,7 @@
 // Relative paths required, path aliases throw error with seed command
 import prisma from '../index'; // Prisma client
 import { Province, PhysicianStatus } from '../../lib/graphql/types'; // GraphQL types
+import { UpsertPhysician } from '../types'; // Seeding types
 
 // Seed data
 const physicians = [
@@ -31,17 +32,16 @@ const physicians = [
 
 /**
  * Upsert physicians
+ * @param data Custom physician data to be seeded
  */
-export default async function physicianUpsert(): Promise<void> {
-  const physicianUpserts = [];
-  for (const physician of physicians) {
+export default async function physicianUpsert(data?: UpsertPhysician[]): Promise<void> {
+  for (const physician of data || physicians) {
     const { id, ...rest } = physician;
     const physicianUpsert = await prisma.physician.upsert({
       where: { id },
       update: { ...rest },
       create: physician,
     });
-    physicianUpserts.push(physicianUpsert);
     console.log({ physicianUpsert });
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,11 +25,11 @@ model Applicant {
   rcdUserId            Int?               @unique @map("rcd_user_id")
   status               ApplicantStatus?
   acceptedTos          DateTime?          @map("accepted_tos") @db.Timestamptz(6)
-  guardianId           Int                @unique @map("guardian_id")
+  guardianId           Int?               @unique @map("guardian_id")
   medicalInformationId Int                @unique @map("medical_information_id")
   createdAt            DateTime           @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt            DateTime           @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
-  guardian             Guardian           @relation("applicantsToguardians", fields: [guardianId], references: [id])
+  guardian             Guardian?          @relation("applicantsToguardians", fields: [guardianId], references: [id])
   medicalInformation   MedicalInformation @relation("applicantsTomedical_information", fields: [medicalInformationId], references: [id])
   applications         Application[]
   permits              Permit[]

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -136,7 +136,7 @@ CREATE TABLE applicants (
   rcd_user_id               INTEGER UNIQUE,
   status                    ApplicantStatus,
   accepted_tos              TIMESTAMPTZ,
-  guardian_id               INTEGER UNIQUE NOT NULL,
+  guardian_id               INTEGER UNIQUE,
   medical_information_id    INTEGER UNIQUE NOT NULL,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at                TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/prisma/types.ts
+++ b/prisma/types.ts
@@ -1,0 +1,113 @@
+import {
+  Applicant,
+  Application,
+  ApplicationProcessing,
+  Guardian,
+  MedicalInformation,
+  Permit,
+  Physician,
+} from '@lib/graphql/types'; // GraphQL types
+
+// Type of Applicant to upsert in DB
+export type UpsertApplicant = Pick<
+  Applicant,
+  | 'id'
+  | 'rcdUserId'
+  | 'firstName'
+  | 'lastName'
+  | 'email'
+  | 'gender'
+  | 'phone'
+  | 'province'
+  | 'city'
+  | 'addressLine1'
+  | 'postalCode'
+  | 'guardianId'
+  | 'medicalInformationId'
+  | 'status'
+>;
+
+// Type of Permit to upsert in DB
+export type UpsertPermit = Pick<
+  Permit,
+  'rcdPermitId' | 'applicantId' | 'applicationId' | 'expiryDate' | 'active'
+>;
+
+// Type of Guardian to upsert in DB
+export type UpsertGuardian = Pick<
+  Guardian,
+  | 'id'
+  | 'firstName'
+  | 'lastName'
+  | 'phone'
+  | 'province'
+  | 'city'
+  | 'addressLine1'
+  | 'postalCode'
+  | 'relationship'
+>;
+
+// Type of Application to upsert in DB
+export type UpsertApplication = Pick<
+  Application,
+  | 'id'
+  | 'rcdUserId'
+  | 'firstName'
+  | 'lastName'
+  | 'gender'
+  | 'phone'
+  | 'province'
+  | 'city'
+  | 'addressLine1'
+  | 'postalCode'
+  | 'disability'
+  | 'aid'
+  | 'physicianName'
+  | 'physicianMspNumber'
+  | 'physicianAddressLine1'
+  | 'physicianCity'
+  | 'physicianProvince'
+  | 'physicianPostalCode'
+  | 'physicianPhone'
+  | 'processingFee'
+  | 'paymentMethod'
+  | 'shopifyConfirmationNumber'
+  | 'applicantId'
+  | 'email'
+  | 'shippingFullName'
+  | 'shippingAddressLine1'
+  | 'shippingCity'
+  | 'shippingProvince'
+  | 'shippingPostalCode'
+  | 'billingFullName'
+> & {
+  applicationProcessingId: number;
+};
+
+// Type of Physician to upsert in DB
+export type UpsertPhysician = Pick<
+  Physician,
+  'name' | 'mspNumber' | 'addressLine1' | 'city' | 'province' | 'postalCode' | 'phone' | 'status'
+> & {
+  id: number;
+};
+
+// Type of Medical Information to upsert in DB
+export type UpsertMedicalInformation = Pick<
+  MedicalInformation,
+  'id' | 'disability' | 'affectsMobility' | 'mobilityAidRequired' | 'cannotWalk100m' | 'physicianId'
+>;
+
+// Type of Application Processing to upsert in DB
+export type UpsertApplicationProcessing = Pick<
+  ApplicationProcessing,
+  | 'status'
+  | 'appNumber'
+  | 'appHolepunched'
+  | 'walletCardCreated'
+  | 'invoiceNumber'
+  | 'documentUrls'
+  | 'appMailed'
+> & {
+  id: number;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,6 +4129,13 @@ csstype@^3.0.2, csstype@^3.0.6:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
+csv-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/csv-parser/-/csv-parser-3.0.0.tgz#b88a6256d79e090a97a1b56451f9327b01d710e7"
+  integrity sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==
+  dependencies:
+    minimist "^1.2.0"
+
 damerau-levenshtein@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz#64368003512a1a6992593741a09a9d31a836f55d"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Add-sample-data-to-staging-database-1716f8617a7d46f291c2ad62a621afa4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Create data population script
* Small changes to seeding functions (removed unnecessary console logs)
* Overloaded seeding functions to support custom seeding data - this could be useful in the future for our data migration
* Small bug fix for linking request name to permit holder page (it was redirecting to `/permit-holder/...` instead of `/admin/permit-holder/...`
* Populated staging database


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* `ts-node` wasn't working with the script I wrote. In the interest of time, I converted it to JS. This should be okay since it's a oneoff and we can address this in the future
* Staging permit holder table page is down right now - requires merging this ticket to implement new schema changes


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
