### PR TITLE
[Fix] Update physician on permit holder page when MSP is updated

### DIFF
--- a/components/requests/modals/EditDoctorInformationModal.tsx
+++ b/components/requests/modals/EditDoctorInformationModal.tsx
@@ -104,7 +104,7 @@ export default function EditDoctorInformationModal({
                   <FormControl isRequired>
                     <FormLabel>{'Medical Services Plan number'}</FormLabel>
                     <Input
-                      value={mspNumber}
+                      value={mspNumber || ''}
                       onChange={event => setMspNumber(parseInt(event.target.value))}
                     />
                   </FormControl>

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -844,6 +844,7 @@ export type UpsertPhysicianInput = {
 export type UpsertPhysicianResult = {
   __typename?: 'UpsertPhysicianResult';
   ok: Scalars['Boolean'];
+  physicianId: Scalars['Int'];
 };
 
 export enum UserStatus {

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -820,6 +820,7 @@ export type UpdateMedicalInformationInput = {
   notes?: Maybe<Scalars['String']>;
   certificationDate?: Maybe<Scalars['Date']>;
   aid?: Maybe<Array<Aid>>;
+  physicianId?: Maybe<Scalars['Int']>;
 };
 
 export type UpdateMedicalInformationResult = {

--- a/lib/medical-information/resolvers.ts
+++ b/lib/medical-information/resolvers.ts
@@ -11,7 +11,6 @@ import { DBErrorCode } from '@lib/db/errors'; // Database errors
 export const updateMedicalInformation: Resolver = async (_, args, { prisma }) => {
   const { input } = args;
   const { applicantId, ...rest } = input;
-  // console.log("medical info resolver");
 
   let updatedApplicant;
   try {
@@ -32,9 +31,7 @@ export const updateMedicalInformation: Resolver = async (_, args, { prisma }) =>
     ) {
       throw new ApplicantNotFoundError(`Applicant with ID ${applicantId} does not exist`);
     }
-    // console.log(err);
   }
-  // console.log("medical info resolver 2");
 
   if (!updatedApplicant) {
     throw new ApolloError('Medical information was unable to be updated');

--- a/lib/medical-information/resolvers.ts
+++ b/lib/medical-information/resolvers.ts
@@ -11,6 +11,7 @@ import { DBErrorCode } from '@lib/db/errors'; // Database errors
 export const updateMedicalInformation: Resolver = async (_, args, { prisma }) => {
   const { input } = args;
   const { applicantId, ...rest } = input;
+  // console.log("medical info resolver");
 
   let updatedApplicant;
   try {
@@ -31,7 +32,9 @@ export const updateMedicalInformation: Resolver = async (_, args, { prisma }) =>
     ) {
       throw new ApplicantNotFoundError(`Applicant with ID ${applicantId} does not exist`);
     }
+    // console.log(err);
   }
+  // console.log("medical info resolver 2");
 
   if (!updatedApplicant) {
     throw new ApolloError('Medical information was unable to be updated');

--- a/lib/medical-information/schema.ts
+++ b/lib/medical-information/schema.ts
@@ -36,6 +36,7 @@ export default `
     notes: String
     certificationDate: Date
     aid: [Aid!]
+    physicianId: Int
   }
 
   type UpdateMedicalInformationResult {

--- a/lib/physicians/resolvers.ts
+++ b/lib/physicians/resolvers.ts
@@ -97,5 +97,6 @@ export const upsertPhysician: Resolver = async (_, args, { prisma }) => {
 
   return {
     ok: true,
+    physicianId: upsertedPhysician.id,
   };
 };

--- a/lib/physicians/schema.ts
+++ b/lib/physicians/schema.ts
@@ -44,5 +44,6 @@ export default `
 
   type UpsertPhysicianResult {
     ok: Boolean!
+    physicianId: Int!
   }
 `;

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -163,6 +163,8 @@ export default function PermitHolder({ permitHolderId }: Props) {
       });
       const physicianId = result?.data?.upsertPhysician.physicianId;
 
+      // If the physician's MSP number changed, then a new physician is created by submitEditedDoctorInformation.
+      // This updates the physicianId in the applicants medical information to be the new physician's id.
       if (!isErrorOnUpdateDoctor && physicianId && physicianData.mspNumber !== oldDoctorMSP) {
         await submitUpdatedMedicalInformation({
           variables: {

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -34,7 +34,7 @@ import {
   UpdateMedicalInformationRequest,
   UpdateMedicalInformationResponse,
   UPDATE_MEDICAL_INFORMATION_MUTATION,
-} from '@tools/pages/admin/permit-holders/update-medical-information';
+} from '@tools/pages/admin/permit-holders/update-medical-information'; // Medical information types
 
 type Props = {
   readonly permitHolderId: number;
@@ -44,7 +44,6 @@ type Props = {
 export default function PermitHolder({ permitHolderId }: Props) {
   const [permits, setPermits] = useState<PermitData[]>();
   const [medicalHistoryData, setMedicalHistoryData] = useState<MedicalHistoryEntry[]>();
-  const [isErrorOnUpdateDoctor, setIsErrorOnUpdateDoctor] = useState<boolean>(false);
 
   // TODO: uncomment when AWS is setup and we use real files
   // const [attachedFiles, setAttachedFiles] = useState<PermitHolderAttachedFile[]>();
@@ -105,7 +104,6 @@ export default function PermitHolder({ permitHolderId }: Props) {
     UpdateMedicalInformationRequest
   >(UPDATE_MEDICAL_INFORMATION_MUTATION, {
     onError: error => {
-      setIsErrorOnUpdateDoctor(true);
       toast({
         status: 'error',
         description: error.message,
@@ -123,7 +121,6 @@ export default function PermitHolder({ permitHolderId }: Props) {
         status: 'error',
         description: error.message,
       });
-      setIsErrorOnUpdateDoctor(true);
     },
   });
 
@@ -156,12 +153,12 @@ export default function PermitHolder({ permitHolderId }: Props) {
   const handleUpdateDoctorInformation = async (physicianData: UpsertPhysicianInput) => {
     if (data) {
       const oldDoctorMSP = data.applicant.medicalInformation.physician.mspNumber;
-      setIsErrorOnUpdateDoctor(false);
 
       const result = await submitEditedDoctorInformation({
         variables: { input: { ...physicianData } },
       });
       const physicianId = result?.data?.upsertPhysician.physicianId;
+      const isErrorOnUpdateDoctor = result?.data?.upsertPhysician.ok ? false : true;
 
       // If the physician's MSP number changed, then a new physician is created by submitEditedDoctorInformation.
       // This updates the physicianId in the applicants medical information to be the new physician's id.

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -13,7 +13,7 @@ import MedicalHistoryCard from '@components/permit-holders/MedicalHistoryCard'; 
 import { GetPermitHolderRequest, GetPermitHolderResponse } from '@tools/pages/permit-holders/types';
 import { GET_PERMIT_HOLDER } from '@tools/pages/permit-holders/queries'; // Permit holder query
 import { useMutation, useQuery } from '@apollo/client'; // Apollo
-import React, { useState } from 'react'; // React
+import { useState } from 'react'; // React
 import {
   PermitData,
   MedicalHistoryEntry,
@@ -169,7 +169,7 @@ export default function PermitHolder({ permitHolderId }: Props) {
         await submitUpdatedMedicalInformation({
           variables: {
             input: {
-              applicantId: parseInt(data.applicant.id),
+              applicantId: +data.applicant.id,
               physicianId: physicianId,
             },
           },

--- a/pages/admin/permit-holder/[permitHolderId].tsx
+++ b/pages/admin/permit-holder/[permitHolderId].tsx
@@ -154,16 +154,16 @@ export default function PermitHolder({ permitHolderId }: Props) {
     if (data) {
       const oldDoctorMSP = data.applicant.medicalInformation.physician.mspNumber;
 
-      const result = await submitEditedDoctorInformation({
+      const editDoctorResult = await submitEditedDoctorInformation({
         variables: { input: { ...physicianData } },
       });
-      const physicianId = result?.data?.upsertPhysician.physicianId;
-      const isErrorOnUpdateDoctor = result?.data?.upsertPhysician.ok ? false : true;
+      const physicianId = editDoctorResult?.data?.upsertPhysician.physicianId;
+      let isErrorOnUpdateDoctor = editDoctorResult?.data?.upsertPhysician.ok ? false : true;
 
       // If the physician's MSP number changed, then a new physician is created by submitEditedDoctorInformation.
       // This updates the physicianId in the applicants medical information to be the new physician's id.
       if (!isErrorOnUpdateDoctor && physicianId && physicianData.mspNumber !== oldDoctorMSP) {
-        await submitUpdatedMedicalInformation({
+        const updateMedicalInformationResult = await submitUpdatedMedicalInformation({
           variables: {
             input: {
               applicantId: +data.applicant.id,
@@ -171,6 +171,10 @@ export default function PermitHolder({ permitHolderId }: Props) {
             },
           },
         });
+
+        isErrorOnUpdateDoctor = updateMedicalInformationResult?.data?.updateMedicalInformation.ok
+          ? false
+          : true;
       }
 
       if (!isErrorOnUpdateDoctor) {

--- a/tools/pages/admin/permit-holders/update-medical-information.tsx
+++ b/tools/pages/admin/permit-holders/update-medical-information.tsx
@@ -1,0 +1,18 @@
+import { gql } from '@apollo/client'; // gql tag
+import { MutationUpdateMedicalInformationArgs, UpdateMedicalInformationResult } from '@lib/types'; // GraphQL types
+
+export const UPDATE_MEDICAL_INFORMATION_MUTATION = gql`
+  mutation UpdateMedicalInformation($input: UpdateMedicalInformationInput!) {
+    updateMedicalInformation(input: $input) {
+      ok
+    }
+  }
+`;
+
+// Update medical information mutation arguments
+export type UpdateMedicalInformationRequest = MutationUpdateMedicalInformationArgs;
+
+// Update medical information mutation response
+export type UpdateMedicalInformationResponse = {
+  updateMedicalInformation: UpdateMedicalInformationResult;
+};

--- a/tools/pages/admin/permit-holders/upsert-physician.ts
+++ b/tools/pages/admin/permit-holders/upsert-physician.ts
@@ -6,6 +6,7 @@ export const UPSERT_PHYSICIAN_MUTATION = gql`
   mutation UpsertPhysician($input: UpsertPhysicianInput!) {
     upsertPhysician(input: $input) {
       ok
+      physicianId
     }
   }
 `;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Resolve physician update failing in View Permit Holder page](https://www.notion.so/uwblueprintexecs/Resolve-physician-update-failing-in-View-Permit-Holder-page-3dab29ed46204525a7aa9849d5b60ed2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* When the Doctor's MSP number is updated through the edit doctor's information modal on the permit holder page, upset physician will create a new Physician in the DB. We then also call an `updateMedicalInformation` mutation to point the applicant's medical information to the new physician.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Currently the past physicians list from an applicant's medical history is not being updated properly with new physicians. The past physicians are being read from the list of applicant's past applications, so when a new physician is created in through this edit doctor modal, it will not appear in the list of past physicians as it's not associated with an application. This will be addressed in a later ticket.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
