### PR TITLE
[Fix] Fix View Permit Holder page not rendering any cards

### DIFF
--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -1,3 +1,4 @@
+// TODO: `guardian` should be optional in `CreateApplicantInput`
 export default `
   type Applicant {
     id: ID!
@@ -20,7 +21,7 @@ export default `
     activePermit: Permit
     applications: [Application!]
     guardianId: Int
-    guardian: Guardian!
+    guardian: Guardian
     medicalInformationId: Int!
     medicalInformation: MedicalInformation!
     permits: [Permit!]!

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -47,7 +47,7 @@ export type Applicant = {
   activePermit: Maybe<Permit>;
   applications: Maybe<Array<Application>>;
   guardianId: Maybe<Scalars['Int']>;
-  guardian: Guardian;
+  guardian: Maybe<Guardian>;
   medicalInformationId: Scalars['Int'];
   medicalInformation: MedicalInformation;
   permits: Array<Permit>;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/View-Permit-Holder-only-displaying-attached-files-card-3958b57515164eb791d70a7e584e2a90)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The cards weren't rendering because of a schema-related GraphQL error. Recently, we changed the `Applicant` schema such that `guardianId` is nullable, since permit holders don't necessarily need to have guardians. However, `guardian` was still a non-null field but that was not updated in the schema. Our `applicant` resolver was failing on applicants that didn't have guardians.
* The fix was simply to update the `Applicant` schema to make the `guardian` field nullable.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Left a TODO. The `CreateApplicantInput` input schema should have `guardian` be optional. This also requires a resolver update. In the interest of time for MVP handoff, this will be addressed in the future.
* Need to discuss what to display on the View Permit Holder page when a permit holder doesn't have a guardian. Discussion has been forwarded to Design.

**Excluded screenshot due to confidential database information for the failing cases.**

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
