### PR TITLE
[Fix] Fix seeded users not having RCD user ID

### DIFF
--- a/lib/scripts/oneoff/populate-db-09-13-21.js
+++ b/lib/scripts/oneoff/populate-db-09-13-21.js
@@ -201,7 +201,7 @@ function populateDb() {
         const { mspNumber, ...rest } = physician;
         const physicianUpsert = await prisma.physician.upsert({
           where: { mspNumber },
-          update: { ...rest },
+          update: rest,
           create: physician,
         });
         console.log({ physicianUpsert });
@@ -212,7 +212,7 @@ function populateDb() {
         const { id, ...rest } = medicalInformation;
         const medicalInformationUpsert = await prisma.medicalInformation.upsert({
           where: { id },
-          update: { ...rest },
+          update: rest,
           create: medicalInformation,
         });
         console.log({ medicalInformationUpsert });
@@ -223,7 +223,7 @@ function populateDb() {
         const { id, ...rest } = guardian;
         const guardianUpsert = await prisma.guardian.upsert({
           where: { id },
-          update: { ...rest },
+          update: rest,
           create: guardian,
         });
         console.log({ guardianUpsert });
@@ -235,7 +235,7 @@ function populateDb() {
         const applicantUpsert = await prisma.applicant.upsert({
           where: { rcdUserId },
           update: rest,
-          create: rest,
+          create: applicant,
         });
         console.log({ applicantUpsert });
       }
@@ -246,7 +246,7 @@ function populateDb() {
         const applicationProcessingUpsert = await prisma.applicationProcessing.upsert({
           where: { appNumber },
           update: rest,
-          create: rest,
+          create: applicationProcessing,
         });
         console.log({ applicationProcessingUpsert });
       }
@@ -256,11 +256,8 @@ function populateDb() {
         const { id, ...rest } = application;
         const applicationUpsert = await prisma.application.upsert({
           where: { id },
-          update: { ...rest },
-          create: {
-            id,
-            ...rest,
-          },
+          update: rest,
+          create: application,
         });
         console.log({ applicationUpsert });
       }
@@ -270,7 +267,7 @@ function populateDb() {
         const { rcdPermitId, expiryDate = new Date().toISOString(), ...rest } = permit;
         const permitUpsert = await prisma.permit.upsert({
           where: { rcdPermitId },
-          update: { ...rest },
+          update: rest,
           create: { rcdPermitId, expiryDate, ...rest },
         });
         console.log({ permitUpsert });

--- a/prisma/dev-seed-utils/applicants.ts
+++ b/prisma/dev-seed-utils/applicants.ts
@@ -67,7 +67,7 @@ export default async function applicantUpsert(data?: UpsertApplicant[]): Promise
     const applicantUpsert = await prisma.applicant.upsert({
       where: { id },
       update: rest,
-      create: { dateOfBirth: new Date().toISOString(), ...rest },
+      create: { id, dateOfBirth: new Date().toISOString(), ...rest },
     });
     console.log({ applicantUpsert });
   }

--- a/prisma/dev-seed-utils/application-processings.ts
+++ b/prisma/dev-seed-utils/application-processings.ts
@@ -27,8 +27,8 @@ export default async function applicationProcessingUpsert(
     const { id, ...rest } = applicationProcessing;
     const applicationProcessingUpsert = await prisma.applicationProcessing.upsert({
       where: { id },
-      update: { ...rest },
-      create: rest,
+      update: rest,
+      create: applicationProcessing,
     });
     console.log({ applicationProcessingUpsert });
   }

--- a/prisma/dev-seed-utils/applications.ts
+++ b/prisma/dev-seed-utils/applications.ts
@@ -102,8 +102,9 @@ export default async function applicationUpsert(data?: UpsertApplication[]): Pro
     const { id, ...rest } = application;
     const applicationUpsert = await prisma.application.upsert({
       where: { id },
-      update: { ...rest },
+      update: rest,
       create: {
+        id,
         dateOfBirth: new Date().toISOString(),
         ...rest,
       },

--- a/prisma/dev-seed-utils/guardians.ts
+++ b/prisma/dev-seed-utils/guardians.ts
@@ -50,7 +50,7 @@ export default async function guardianUpsert(data?: UpsertGuardian[]): Promise<v
     const { id, ...rest } = guardian;
     const guardianUpsert = await prisma.guardian.upsert({
       where: { id },
-      update: { ...rest },
+      update: rest,
       create: guardian,
     });
     console.log({ guardianUpsert });

--- a/prisma/dev-seed-utils/medical-information.ts
+++ b/prisma/dev-seed-utils/medical-information.ts
@@ -42,7 +42,7 @@ export default async function medicalInformationUpsert(
     const { id, ...rest } = medicalInformation;
     const medicalInformationUpsert = await prisma.medicalInformation.upsert({
       where: { id },
-      update: { ...rest },
+      update: rest,
       create: medicalInformation,
     });
     console.log({ medicalInformationUpsert });

--- a/prisma/dev-seed-utils/permits.ts
+++ b/prisma/dev-seed-utils/permits.ts
@@ -36,8 +36,8 @@ export default async function permitUpsert(data?: UpsertPermit[]): Promise<void>
     const { rcdPermitId, expiryDate = new Date().toISOString(), ...rest } = permit;
     const permitUpsert = await prisma.permit.upsert({
       where: { rcdPermitId },
-      update: { ...rest },
-      create: { rcdPermitId: rcdPermitId, expiryDate, ...rest },
+      update: rest,
+      create: { rcdPermitId, expiryDate, ...rest },
     });
     console.log({ permitUpsert });
   }

--- a/prisma/dev-seed-utils/physicians.ts
+++ b/prisma/dev-seed-utils/physicians.ts
@@ -39,7 +39,7 @@ export default async function physicianUpsert(data?: UpsertPhysician[]): Promise
     const { id, ...rest } = physician;
     const physicianUpsert = await prisma.physician.upsert({
       where: { id },
-      update: { ...rest },
+      update: rest,
       create: physician,
     });
     console.log({ physicianUpsert });

--- a/prisma/dev-seed-utils/replacements.ts
+++ b/prisma/dev-seed-utils/replacements.ts
@@ -24,7 +24,7 @@ export default async function replacementUpsert(): Promise<void> {
     const { id, ...rest } = replacement;
     const replacementUpsert = await prisma.replacement.upsert({
       where: { id },
-      update: { ...rest },
+      update: rest,
       create: replacement,
     });
     replacementUpserts.push(replacementUpsert);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Permit-Holders-Page-not-displaying-user-ID-properly-e738ca3a37ea4b7da231d0cc4ff7c9c3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Please see Notion ticket for screenshot of issue. When seeding data, for the `create` parameter, some of the unique keys were omitted. This caused the seeded data to be missing the unique keys. RCD user ID was one of the missing keys. Also preemptively fixed other potential instances of missing columns.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Need to reseed staging database


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
