### PR TITLE
[Feature] Build confirm delete admin modal

### DIFF
--- a/components/admin-management/ConfirmDeleteAdminModal.tsx
+++ b/components/admin-management/ConfirmDeleteAdminModal.tsx
@@ -36,10 +36,17 @@ export default function ConfirmDeleteAdminModal(props: Props) {
     <AlertDialog isOpen={isOpen} onClose={onClose} leastDestructiveRef={cancelButtonRef} isCentered>
       <AlertDialogOverlay />
       <AlertDialogContent>
-        <AlertDialogHeader>{`Delete ${name}`}</AlertDialogHeader>
-        <AlertDialogBody>{`Are you sure you want to delete ${name}? This action is irreversible`}</AlertDialogBody>
+        <AlertDialogHeader paddingBottom="2px">{`Delete ${name}`}</AlertDialogHeader>
+        <AlertDialogBody>{`Are you sure you want to delete ${name}? This action is irreversible.`}</AlertDialogBody>
         <AlertDialogFooter>
-          <Button ref={cancelButtonRef} onClick={onClose} marginRight="12px">
+          <Button
+            ref={cancelButtonRef}
+            onClick={onClose}
+            marginRight="12px"
+            color="text.default"
+            bg="background.gray"
+            _hover={{ bg: 'background.grayHover' }}
+          >
             Cancel
           </Button>
           <Button

--- a/components/admin-management/ConfirmDeleteAdminModal.tsx
+++ b/components/admin-management/ConfirmDeleteAdminModal.tsx
@@ -33,7 +33,7 @@ export default function ConfirmDeleteAdminModal(props: Props) {
   } = props;
 
   return (
-    <AlertDialog isOpen={isOpen} onClose={onClose} leastDestructiveRef={cancelButtonRef}>
+    <AlertDialog isOpen={isOpen} onClose={onClose} leastDestructiveRef={cancelButtonRef} isCentered>
       <AlertDialogOverlay />
       <AlertDialogContent>
         <AlertDialogHeader>{`Delete ${name}`}</AlertDialogHeader>

--- a/components/admin-management/ConfirmDeleteAdminModal.tsx
+++ b/components/admin-management/ConfirmDeleteAdminModal.tsx
@@ -1,0 +1,56 @@
+import { useRef } from 'react'; // React
+import {
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  Button,
+} from '@chakra-ui/react'; // Chakra UI
+import { UserToDelete } from '@tools/pages/admin-management/types'; // Admin management types
+
+// Props
+type Props = {
+  readonly isOpen: boolean;
+  readonly user: UserToDelete;
+  readonly onClose: () => void;
+  readonly onDelete: (id: number) => void;
+};
+
+/**
+ * Modal for confirming admin deletion
+ */
+export default function ConfirmDeleteAdminModal(props: Props) {
+  // Ref to least destructive element (Cancel button), required for a11y
+  const cancelButtonRef = useRef(null);
+
+  const {
+    isOpen,
+    onClose,
+    user: { id, name },
+    onDelete,
+  } = props;
+
+  return (
+    <AlertDialog isOpen={isOpen} onClose={onClose} leastDestructiveRef={cancelButtonRef}>
+      <AlertDialogOverlay />
+      <AlertDialogContent>
+        <AlertDialogHeader>{`Delete ${name}`}</AlertDialogHeader>
+        <AlertDialogBody>{`Are you sure you want to delete ${name}? This action is irreversible`}</AlertDialogBody>
+        <AlertDialogFooter>
+          <Button ref={cancelButtonRef} onClick={onClose} marginRight="12px">
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onDelete(id)}
+            bg="secondary.critical"
+            _hover={{ bg: 'secondary.criticalHover' }}
+          >
+            Delete
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 // Eslint Disable Temporarily for Pagination since API hookup not complete.
+import { useState } from 'react'; // React
 import { GetServerSideProps } from 'next'; // Get server side props
 import { getSession } from 'next-auth/client'; // Session management
 import Layout from '@components/internal/Layout'; // Layout component
@@ -18,64 +19,12 @@ import {
   IconButton,
   Button,
   Select,
+  useDisclosure,
 } from '@chakra-ui/react'; // Chakra UI
 import { AddIcon } from '@chakra-ui/icons'; // Chakra UI icons
 import Pagination from '@components/internal/Pagination'; // Pagination component
-
-// Table columns
-const COLUMNS = [
-  {
-    Header: 'Name',
-    accessor: 'name',
-    sortDescFirst: true,
-    minWidth: 240,
-  },
-  {
-    Header: 'Email',
-    accessor: 'email',
-    disableSortBy: true,
-    minWidth: 270,
-  },
-  {
-    Header: 'Role',
-    accessor: 'role',
-    Cell: ({ value }: { value: string }) => {
-      return (
-        <Select defaultValue={value} width={190}>
-          <option value="frontDesk">Front Desk</option>
-          <option value="accountant">Accountant</option>
-          <option value="admin">Admin</option>
-        </Select>
-      );
-    },
-    disableSortBy: true,
-    minWidth: 240,
-  },
-  {
-    Header: 'Actions',
-    Cell: () => {
-      return (
-        <Menu>
-          <MenuButton
-            as={IconButton}
-            aria-label="Options"
-            icon={<img src="/assets/three-dots.svg" />}
-            variant="outline"
-            border="none"
-          />
-          <MenuList>
-            <MenuItem>Edit User</MenuItem>
-            <MenuItem color="text.critical" textStyle="button-regular">
-              Delete User
-            </MenuItem>
-          </MenuList>
-        </Menu>
-      );
-    },
-    disableSortBy: true,
-    width: 120,
-  },
-];
+import ConfirmDeleteAdminModal from '@components/admin-management/ConfirmDeleteAdminModal'; // Confirm Delete Admin modal
+import { UserToDelete } from '@tools/pages/admin-management/types'; // Admin management types
 
 // Placeholder data
 const DATA = [
@@ -112,6 +61,84 @@ const DATA = [
 ];
 
 export default function AdminManagement() {
+  // Deletion modal state
+  const {
+    isOpen: isConfirmDeleteModalOpen,
+    onOpen: onOpenConfirmDeleteModal,
+    onClose: onCloseConfirmDeleteModal,
+  } = useDisclosure();
+
+  // State for admin to delete
+  const [userToDelete, setUserToDelete] = useState<UserToDelete>();
+
+  // Table columns
+  const COLUMNS = [
+    {
+      Header: 'Name',
+      accessor: 'name',
+      sortDescFirst: true,
+      minWidth: 240,
+    },
+    {
+      Header: 'Email',
+      accessor: 'email',
+      disableSortBy: true,
+      minWidth: 270,
+    },
+    {
+      Header: 'Role',
+      accessor: 'role',
+      Cell: ({ value }: { value: string }) => {
+        return (
+          <Select defaultValue={value} width={190}>
+            <option value="frontDesk">Front Desk</option>
+            <option value="accountant">Accountant</option>
+            <option value="admin">Admin</option>
+          </Select>
+        );
+      },
+      disableSortBy: true,
+      minWidth: 240,
+    },
+    {
+      Header: 'Actions',
+      Cell: ({
+        row: {
+          original: { id, name },
+        },
+      }: {
+        row: { original: { id: number; name: string } };
+      }) => {
+        return (
+          <Menu>
+            <MenuButton
+              as={IconButton}
+              aria-label="Options"
+              icon={<img src="/assets/three-dots.svg" />}
+              variant="outline"
+              border="none"
+            />
+            <MenuList>
+              <MenuItem>Edit User</MenuItem>
+              <MenuItem
+                color="text.critical"
+                textStyle="button-regular"
+                onClick={() => {
+                  setUserToDelete({ id, name });
+                  onOpenConfirmDeleteModal();
+                }}
+              >
+                Delete User
+              </MenuItem>
+            </MenuList>
+          </Menu>
+        );
+      },
+      disableSortBy: true,
+      width: 120,
+    },
+  ];
+
   return (
     <Layout>
       <GridItem colSpan={12}>
@@ -128,6 +155,15 @@ export default function AdminManagement() {
           </Flex>
         </Box>
       </GridItem>
+      {userToDelete && (
+        <ConfirmDeleteAdminModal
+          isOpen={isConfirmDeleteModalOpen}
+          onClose={onCloseConfirmDeleteModal}
+          user={userToDelete}
+          // TODO: Replace onDelete handler during API hookup
+          onDelete={onCloseConfirmDeleteModal}
+        />
+      )}
     </Layout>
   );
 }

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -60,6 +60,9 @@ const DATA = [
   },
 ];
 
+/**
+ * Admin management page
+ */
 export default function AdminManagement() {
   // Deletion modal state
   const {

--- a/tools/pages/admin-management/types.ts
+++ b/tools/pages/admin-management/types.ts
@@ -1,0 +1,7 @@
+/**
+ * User type in Confirm Delete Admin modal
+ */
+export type UserToDelete = {
+  readonly id: number;
+  readonly name: string;
+};

--- a/tools/theme/colors.ts
+++ b/tools/theme/colors.ts
@@ -16,6 +16,7 @@ const colors = {
     caution: '#FF8A00',
   },
   text: {
+    default: '#1A1A1A',
     secondary: '#323741',
     filler: '#A3AEBE',
     critical: '#D72C0D',


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Delete-Users-Modal-frontend-80f3ad345b8043ebb40869dd96b12bb5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Built confirm delete admin modal using Chakra UI `AlertDialog` component
* Implemented modal in Admin Management page such that clicking on "Delete User" in a user's menu opens the modal
* Clicking "Cancel" or in the modal overlay will close the modal
* Clicking "Delete" will simply close the modal for now. Need to implement delete functionality in future API hookup


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Needed to move column configuration to inside the `AdminManagement` component so that clicking the options menu could affect the component state
* Note that when opening the modal, the "Cancel" button is automatically focused. This is to make it harder for keyboard users to accidentally delete the admin

## Screenshots
Updated 2021-09-25:
![image](https://user-images.githubusercontent.com/30249230/134783189-e640d68f-a7f1-4dd6-bbf5-70d4005e8a38.png)

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
