### PR TITLE
[Fix] Show correct rcdUserId in requests and permit holders tables

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -53,11 +53,9 @@ const COLUMNS: Column<any>[] = [
       return (
         <div>
           <Text>{`${value.firstName} ${value.lastName}`}</Text>
-          {value.rcdUserId && (
-            <Text textStyle="caption" textColor="secondary">
-              ID: {value.rcdUserId}
-            </Text>
-          )}
+          <Text textStyle="caption" textColor="secondary">
+            ID: {value.rcdUserId ? '#' + value.rcdUserId : 'N/A'}
+          </Text>
         </div>
       );
     },
@@ -165,12 +163,12 @@ export default function Requests() {
     notifyOnNetworkStatusChange: true,
     onCompleted: data => {
       setRequestsData(
-        data.applications.result.map(record => ({
+        data.applications?.result.map(record => ({
           id: record.id,
           name: {
             firstName: record.firstName,
             lastName: record.lastName,
-            rcdUserId: record.applicantId || undefined,
+            rcdUserId: record.rcdUserId || undefined,
           },
           dateReceived: record.createdAt,
           permitType: record.permitType,

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -54,7 +54,7 @@ const COLUMNS: Column<any>[] = [
         <div>
           <Text>{`${value.firstName} ${value.lastName}`}</Text>
           <Text textStyle="caption" textColor="secondary">
-            ID: {value.rcdUserId ? '#' + value.rcdUserId : 'N/A'}
+            ID: {value.rcdUserId ? `#${value.rcdUserId}` : 'N/A'}
           </Text>
         </div>
       );

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -54,7 +54,7 @@ const COLUMNS: Column<any>[] = [
             {value.firstName} {value.middleName || ''} {value.lastName}
           </Text>
           <Text textStyle="caption" textColor="secondary">
-            ID: {value.rcdUserId ? '#' + value.rcdUserId : 'N/A'}
+            ID: {value.rcdUserId ? `#${value.rcdUserId}` : 'N/A'}
           </Text>
         </>
       );

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -54,7 +54,7 @@ const COLUMNS: Column<any>[] = [
             {value.firstName} {value.middleName || ''} {value.lastName}
           </Text>
           <Text textStyle="caption" textColor="secondary">
-            ID: {value.rcdUserId}
+            ID: {value.rcdUserId ? '#' + value.rcdUserId : 'N/A'}
           </Text>
         </>
       );
@@ -190,7 +190,7 @@ type PermitTableInputData = PermitHolder & {
     firstName: string;
     lastName: string;
     middleName: string | null | undefined;
-    rcdUserId: number;
+    rcdUserId?: number;
   };
   homeAddress: {
     address: string;
@@ -246,7 +246,7 @@ export default function PermitHolders() {
           firstName: record.firstName,
           lastName: record.lastName,
           middleName: record.middleName || undefined,
-          rcdUserId: record.id,
+          rcdUserId: record.rcdUserId || undefined,
         },
         homeAddress: {
           address: record.addressLine1,

--- a/tools/pages/admin/index.ts
+++ b/tools/pages/admin/index.ts
@@ -11,7 +11,7 @@ export const GET_APPLICATIONS_QUERY = gql`
         createdAt
         permitType
         isRenewal
-        applicantId
+        rcdUserId
         applicationProcessing {
           status
         }
@@ -30,7 +30,7 @@ export type GetApplicationsResponse = {
     result: ReadonlyArray<
       Pick<
         Application,
-        'firstName' | 'lastName' | 'id' | 'createdAt' | 'permitType' | 'isRenewal' | 'applicantId'
+        'firstName' | 'lastName' | 'id' | 'createdAt' | 'permitType' | 'isRenewal' | 'rcdUserId'
       > & {
         applicationProcessing: Pick<ApplicationProcessing, 'status'>;
       }

--- a/tools/pages/permit-holders/permit-holders-table.ts
+++ b/tools/pages/permit-holders/permit-holders-table.ts
@@ -19,7 +19,7 @@ export const GET_PERMIT_HOLDERS_QUERY = gql`
           rcdPermitId
         }
         status
-        id
+        rcdUserId
       }
       totalCount
     }
@@ -43,7 +43,7 @@ export type PermitHolder = Pick<
   | 'phone'
   | 'mostRecentPermit'
   | 'status'
-  | 'id'
+  | 'rcdUserId'
 >;
 
 export type GetPermitHoldersResponse = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[User ID displaying wrong field in tables](https://www.notion.so/uwblueprintexecs/User-ID-displaying-wrong-field-in-tables-3b070960332e4cecb40948169fc3d5f3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Return `rcdUserId` instead of `applicantId` in `GET_APPLICATIONS_QUERY` and `GET_PERMIT_HOLDERS_QUERY` and pass to table
* Show "N/A" in table for the ID if the `rcdUserId` does not exist.

<img width="567" alt="Screen Shot 2021-09-22 at 11 59 43 PM" src="https://user-images.githubusercontent.com/35577524/134453375-99968921-9a02-458a-8f98-e21caad7fa8a.png">

<img width="749" alt="Screen Shot 2021-09-22 at 11 59 32 PM" src="https://user-images.githubusercontent.com/35577524/134453385-7d968c47-1c4c-4788-b0ef-2c626ef7cb10.png">

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
