### PR TITLE
[Fix] Requests Table search by user ID not working

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -49,7 +49,7 @@ export const applicants: Resolver = async (_parent, { filter }, { prisma }) => {
 
     let expiryDateUpperBound,
       expiryDateLowerBound,
-      userIDSearch,
+      rcdUserIDSearch,
       nameFilters,
       firstSearch,
       middleSearch,
@@ -57,7 +57,7 @@ export const applicants: Resolver = async (_parent, { filter }, { prisma }) => {
 
     // Parse search input for id or name
     if (parseInt(search)) {
-      userIDSearch = parseInt(search);
+      rcdUserIDSearch = parseInt(search);
     } else if (search) {
       // Split search to first, middle and last name elements
       [firstSearch, middleSearch, lastSearch] = search?.split(' ');
@@ -134,7 +134,7 @@ export const applicants: Resolver = async (_parent, { filter }, { prisma }) => {
 
     // Update default filter since there were filter arguments
     where = {
-      rcdUserId: userIDSearch,
+      rcdUserId: rcdUserIDSearch,
       status: userStatus,
       permits: permitFilter,
       ...nameFilters,

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -113,9 +113,7 @@ export const applications: Resolver = async (_parent, { filter }, { prisma }) =>
     }
 
     where = {
-      applicant: {
-        id: userIDSearch,
-      },
+      rcdUserId: userIDSearch,
       applicationProcessing: {
         status: status,
       },

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -56,10 +56,10 @@ export const applications: Resolver = async (_parent, { filter }, { prisma }) =>
     } = filter;
 
     // Parse search string
-    let userIDSearch, firstSearch, middleSearch, lastSearch, nameFilters;
+    let rcdUserIDSearch, firstSearch, middleSearch, lastSearch, nameFilters;
 
     if (parseInt(search)) {
-      userIDSearch = parseInt(search);
+      rcdUserIDSearch = parseInt(search);
     } else if (search) {
       // Split search to first, middle and last name elements
       [firstSearch, middleSearch, lastSearch] = search?.split(' ');
@@ -113,7 +113,7 @@ export const applications: Resolver = async (_parent, { filter }, { prisma }) =>
     }
 
     where = {
-      rcdUserId: userIDSearch,
+      rcdUserId: rcdUserIDSearch,
       applicationProcessing: {
         status: status,
       },


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Requests Table search by user ID not working](https://www.notion.so/uwblueprintexecs/Requests-Table-search-by-user-ID-not-working-7e0fcd020c51498f987c9afc11864cb3)

![rcd1](https://user-images.githubusercontent.com/55164714/134605323-ae74d1ba-8f91-411b-9b92-788f9011024e.gif)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed the `applications` resolver to filter by the `rcdUserId` column instead of the `id` column of the `applicants` table
* Made variable names more clear to avoid confusion in the future

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* I might be missing some context but I'm not sure why the applications resolver was looking at the `applicants` table to begin with. Are there any implications of filtering by the `rcdUserId` field in the `applications` table instead?

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
