### PR TITLE
[Fix] Add applicant ID back to permit holders table GraphQL query

### DIFF
--- a/tools/pages/permit-holders/permit-holders-table.ts
+++ b/tools/pages/permit-holders/permit-holders-table.ts
@@ -5,6 +5,7 @@ export const GET_PERMIT_HOLDERS_QUERY = gql`
   query FilterPermitHoldersQuery($filter: ApplicantsFilter) {
     applicants(filter: $filter) {
       result {
+        id
         firstName
         middleName
         lastName
@@ -32,6 +33,7 @@ export type GetPermitHoldersRequest = {
 
 export type PermitHolder = Pick<
   Applicant,
+  | 'id'
   | 'firstName'
   | 'middleName'
   | 'lastName'


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-permit-holders-table-redirecting-to-undefined-page-6a87255c7a1b4ca483291054b44ebb95)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* In https://github.com/uwblueprint/richmond-centre-for-disability/pull/65, we removed the `id` field from the permit holders GraphQL query. Thus, every permit holder row did not have an `id` field so when redirecting to the individual permit holder pages, the permit holder ID was undefined so the page didn't fully load.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
