### PR TITLE
[Improvement] Add inactive reason to applicant schema

### DIFF
--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -18,6 +18,7 @@ export default `
     rcdUserId: Int
     acceptedTos: Date
     status: ApplicantStatus
+    inactiveReason: String
     activePermit: Permit
     applications: [Application!]
     guardianId: Int
@@ -74,6 +75,7 @@ export default `
     addressLine1: String
     addressLine2: String
     postalCode: String
+    inactiveReason: String
     rcdUserId: Int
   }
 

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -44,6 +44,7 @@ export type Applicant = {
   rcdUserId: Maybe<Scalars['Int']>;
   acceptedTos: Maybe<Scalars['Date']>;
   status: Maybe<ApplicantStatus>;
+  inactiveReason: Maybe<Scalars['String']>;
   activePermit: Maybe<Permit>;
   applications: Maybe<Array<Application>>;
   guardianId: Maybe<Scalars['Int']>;
@@ -711,6 +712,7 @@ export type UpdateApplicantInput = {
   addressLine1?: Maybe<Scalars['String']>;
   addressLine2?: Maybe<Scalars['String']>;
   postalCode?: Maybe<Scalars['String']>;
+  inactiveReason?: Maybe<Scalars['String']>;
   rcdUserId?: Maybe<Scalars['Int']>;
 };
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Applicant {
   postalCode           String             @map("postal_code") @db.Char(6)
   rcdUserId            Int?               @unique @map("rcd_user_id")
   status               ApplicantStatus?
+  inactiveReason       String?            @map("inactive_reason") @db.VarChar(255)
   acceptedTos          DateTime?          @map("accepted_tos") @db.Timestamptz(6)
   guardianId           Int?               @unique @map("guardian_id")
   medicalInformationId Int                @unique @map("medical_information_id")

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -136,6 +136,7 @@ CREATE TABLE applicants (
   postal_code               CHAR(6) NOT NULL,
   rcd_user_id               INTEGER UNIQUE,
   status                    ApplicantStatus,
+  inactive_reason           VARCHAR(255),
   accepted_tos              TIMESTAMPTZ,
   guardian_id               INTEGER UNIQUE,
   medical_information_id    INTEGER UNIQUE NOT NULL,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add inactive_reason to applicant schema](https://www.notion.so/uwblueprintexecs/Add-inactive_reason-to-applicant-schema-d30de2632d7344508132f231ed8b2d21)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `inactive_reason` field to applicant sql schema, and `Applicant` and `UpdateApplicantInput` graphql types


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
