### PR TITLE
[Fix] Fix completing application failing for users with guardians

### DIFF
--- a/lib/application-processing/errors.ts
+++ b/lib/application-processing/errors.ts
@@ -10,3 +10,14 @@ export class ApplicationNotFoundError extends ApolloError {
     Object.defineProperty(this, 'name', { value: 'ApplicationNotFoundError' });
   }
 }
+
+/**
+ * Missing guardian fields error
+ */
+export class MissingGuardianFieldsError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'MISSING_GUARDIAN_FIELDS');
+
+    Object.defineProperty(this, 'name', { value: 'MissingGuardianFieldsError' });
+  }
+}

--- a/lib/application-processing/types.ts
+++ b/lib/application-processing/types.ts
@@ -1,0 +1,22 @@
+import { Province } from '@lib/graphql/types'; // GraphQL types
+
+/**
+ * Guardian update fields for completing new application
+ */
+export type CompleteNewApplicationGuardianUpdate =
+  | {
+      create: {
+        firstName: string;
+        middleName: string | null;
+        lastName: string;
+        phone: string;
+        province: Province;
+        city: string;
+        addressLine1: string;
+        addressLine2: string | null;
+        postalCode: string;
+        relationship: string;
+        notes: string | null;
+      };
+    }
+  | undefined;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Completing-an-application-fails-af0dddbcc9aa433195ae1775744c5124)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Having a guardian is no longer required for applicants and applications, so when attempting to mark an application as completed, the nested guardian update would fail for applicants that don't have a guardian. Added conditional logic to handle cases wherein guardian fields are complete/incomplete and the case where an applicant does not have a guardian.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
