### PR TITLE
[Fix] Replace Alert component with toast

### DIFF
--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -149,14 +149,6 @@ export default function IdentityVerificationForm() {
             20th August 1950, you would enter 1950-08-20`}
               </FormHelperText>
             </FormControl>
-            {/* {data?.verifyIdentity.failureReason && (
-              <Alert status="error" marginBottom="20px">
-                <AlertIcon />
-                <AlertDescription>
-                  {getErrorMessage(data.verifyIdentity.failureReason)}
-                </AlertDescription>
-              </Alert>
-            )} */}
             <Flex width="100%" justifyContent="flex-end">
               <Link href="/">
                 <Button variant="outline" marginRight="12px">{`Go back to home page`}</Button>

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -13,14 +13,11 @@ import {
   FormHelperText,
   NumberInput,
   NumberInputField,
-  Alert,
-  AlertIcon,
   Popover,
   PopoverTrigger,
   PopoverContent,
   PopoverBody,
   PopoverFooter,
-  AlertDescription,
   Input,
   useToast,
 } from '@chakra-ui/react'; // Chakra UI
@@ -51,23 +48,28 @@ export default function IdentityVerificationForm() {
   const [dateOfBirth, setDateOfBirth] = useState(formatDate(new Date(), true));
 
   // Verify identity query
-  const [verifyIdentity, { data, loading }] = useMutation<
-    VerifyIdentityResponse,
-    VerifyIdentityRequest
-  >(VERIFY_IDENTITY_MUTATION, {
-    onCompleted: data => {
-      if (data.verifyIdentity.ok && data.verifyIdentity.applicantId) {
-        setApplicantId(data.verifyIdentity.applicantId);
-        router.push('/renew');
-      }
-    },
-    onError: error => {
-      toast({
-        status: 'error',
-        description: error.message,
-      });
-    },
-  });
+  const [verifyIdentity, { loading }] = useMutation<VerifyIdentityResponse, VerifyIdentityRequest>(
+    VERIFY_IDENTITY_MUTATION,
+    {
+      onCompleted: data => {
+        if (data.verifyIdentity.ok && data.verifyIdentity.applicantId) {
+          setApplicantId(data.verifyIdentity.applicantId);
+          router.push('/renew');
+        } else if (data.verifyIdentity.failureReason) {
+          toast({
+            status: 'error',
+            description: getErrorMessage(data.verifyIdentity.failureReason),
+          });
+        }
+      },
+      onError: error => {
+        toast({
+          status: 'error',
+          description: error.message,
+        });
+      },
+    }
+  );
 
   /**
    * Handle identity verification submit
@@ -147,14 +149,14 @@ export default function IdentityVerificationForm() {
             20th August 1950, you would enter 1950-08-20`}
               </FormHelperText>
             </FormControl>
-            {data?.verifyIdentity.failureReason && (
+            {/* {data?.verifyIdentity.failureReason && (
               <Alert status="error" marginBottom="20px">
                 <AlertIcon />
                 <AlertDescription>
                   {getErrorMessage(data.verifyIdentity.failureReason)}
                 </AlertDescription>
               </Alert>
-            )}
+            )} */}
             <Flex width="100%" justifyContent="flex-end">
               <Link href="/">
                 <Button variant="outline" marginRight="12px">{`Go back to home page`}</Button>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Change error message to toast on User Validation Page in application flow](https://www.notion.so/uwblueprintexecs/Change-error-message-to-toast-on-User-Validation-Page-in-application-flow-e0d01ef9bc9844539db1452b7ec5869b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Took out the Alert component and added logic to the onCompleted callback to show toast instead


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
