### PR TITLE
[Feature] Admin Management Table API Hookup

### DIFF
--- a/lib/employees/resolvers.ts
+++ b/lib/employees/resolvers.ts
@@ -149,7 +149,7 @@ export const updateEmployee: Resolver = async (_, args, { prisma }) => {
  * @returns status of operation (ok)
  */
 export const deleteEmployee: Resolver = async (_, args, { prisma }) => {
-  const id = parseInt(args.input);
+  const id = parseInt(args.id);
 
   const employee = await prisma.employee.findUnique({
     where: {

--- a/lib/employees/resolvers.ts
+++ b/lib/employees/resolvers.ts
@@ -149,7 +149,7 @@ export const updateEmployee: Resolver = async (_, args, { prisma }) => {
  * @returns status of operation (ok)
  */
 export const deleteEmployee: Resolver = async (_, args, { prisma }) => {
-  const id = parseInt(args.input.id);
+  const id = parseInt(args.input);
 
   const employee = await prisma.employee.findUnique({
     where: {
@@ -180,5 +180,5 @@ export const deleteEmployee: Resolver = async (_, args, { prisma }) => {
     }
   }
   if (!updatedEmployee) throw new ApolloError('Employee was unable to be deleted');
-  return { ok: true };
+  return { ok: true, employee: updatedEmployee };
 };

--- a/lib/employees/resolvers.ts
+++ b/lib/employees/resolvers.ts
@@ -149,7 +149,8 @@ export const updateEmployee: Resolver = async (_, args, { prisma }) => {
  * @returns status of operation (ok)
  */
 export const deleteEmployee: Resolver = async (_, args, { prisma }) => {
-  const id = parseInt(args.id);
+  const id = parseInt(args.input.id);
+
   const employee = await prisma.employee.findUnique({
     where: {
       id,

--- a/lib/employees/schema.ts
+++ b/lib/employees/schema.ts
@@ -36,6 +36,10 @@ export default `
     employee: Employee!
   }
 
+  input DeleteEmployeeInput {
+    id: ID!
+  }
+
   type DeleteEmployeeResult {
     ok: Boolean!
   }

--- a/lib/employees/schema.ts
+++ b/lib/employees/schema.ts
@@ -36,12 +36,9 @@ export default `
     employee: Employee!
   }
 
-  input DeleteEmployeeInput {
-    id: ID!
-  }
-
   type DeleteEmployeeResult {
     ok: Boolean!
+    employee: Employee!
   }
 
   input EmployeesFilter {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -16,7 +16,7 @@ export default `
     updateApplicant(input: UpdateApplicantInput!): UpdateApplicantResult!
     createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
     updateEmployee(input: UpdateEmployeeInput!): UpdateEmployeeResult!
-    deleteEmployee(input: ID!): DeleteEmployeeResult!
+    deleteEmployee(id: ID!): DeleteEmployeeResult!
     createPhysician(input: CreatePhysicianInput!): CreatePhysicianResult!
     upsertPhysician(input: UpsertPhysicianInput!): UpsertPhysicianResult!
     createApplication(input: CreateApplicationInput!): CreateApplicationResult!

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -16,7 +16,7 @@ export default `
     updateApplicant(input: UpdateApplicantInput!): UpdateApplicantResult!
     createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
     updateEmployee(input: UpdateEmployeeInput!): UpdateEmployeeResult!
-    deleteEmployee(input: DeleteEmployeeInput!): DeleteEmployeeResult!
+    deleteEmployee(input: ID!): DeleteEmployeeResult!
     createPhysician(input: CreatePhysicianInput!): CreatePhysicianResult!
     upsertPhysician(input: UpsertPhysicianInput!): UpsertPhysicianResult!
     createApplication(input: CreateApplicationInput!): CreateApplicationResult!

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -16,7 +16,7 @@ export default `
     updateApplicant(input: UpdateApplicantInput!): UpdateApplicantResult!
     createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
     updateEmployee(input: UpdateEmployeeInput!): UpdateEmployeeResult!
-    deleteEmployee(id: ID!): DeleteEmployeeResult!
+    deleteEmployee(input: DeleteEmployeeInput!): DeleteEmployeeResult!
     createPhysician(input: CreatePhysicianInput!): CreatePhysicianResult!
     upsertPhysician(input: UpsertPhysicianInput!): UpsertPhysicianResult!
     createApplication(input: CreateApplicationInput!): CreateApplicationResult!

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -500,7 +500,7 @@ export type MutationUpdateEmployeeArgs = {
 
 
 export type MutationDeleteEmployeeArgs = {
-  input: Scalars['ID'];
+  id: Scalars['ID'];
 };
 
 

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -386,13 +386,10 @@ export type CreateRenewalApplicationResult = {
 };
 
 
-export type DeleteEmployeeInput = {
-  id: Scalars['ID'];
-};
-
 export type DeleteEmployeeResult = {
   __typename?: 'DeleteEmployeeResult';
   ok: Scalars['Boolean'];
+  employee: Employee;
 };
 
 export type Employee = {
@@ -503,7 +500,7 @@ export type MutationUpdateEmployeeArgs = {
 
 
 export type MutationDeleteEmployeeArgs = {
-  input: DeleteEmployeeInput;
+  input: Scalars['ID'];
 };
 
 

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -386,6 +386,10 @@ export type CreateRenewalApplicationResult = {
 };
 
 
+export type DeleteEmployeeInput = {
+  id: Scalars['ID'];
+};
+
 export type DeleteEmployeeResult = {
   __typename?: 'DeleteEmployeeResult';
   ok: Scalars['Boolean'];
@@ -499,7 +503,7 @@ export type MutationUpdateEmployeeArgs = {
 
 
 export type MutationDeleteEmployeeArgs = {
-  id: Scalars['ID'];
+  input: DeleteEmployeeInput;
 };
 
 

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -42,6 +42,12 @@ import {
   UPDATE_EMPLOYEE_MUTATION,
 } from '@tools/pages/admin/admin-management/update-employee'; // Update Employee Mutation
 
+import {
+  DeleteEmployeeRequest,
+  DeleteEmployeeResponse,
+  DELETE_EMPLOYEE_MUTATION,
+} from '@tools/pages/admin/admin-management/delete-employee'; // Delete Employee Mutation
+
 // Max number of entries in a page
 const PAGE_SIZE = 20;
 
@@ -262,7 +268,42 @@ export default function AdminManagement() {
       );
       setRecordsCount(data.employees.totalCount);
     },
+    onError: error => {
+      toast({
+        status: 'error',
+        description: error.message,
+      });
+    },
   });
+
+  const [deleteEmployee] = useMutation<DeleteEmployeeResponse, DeleteEmployeeRequest>(
+    DELETE_EMPLOYEE_MUTATION,
+    {
+      onCompleted: data => {
+        if (data.deleteEmployee.ok) {
+          toast({
+            status: 'success',
+            description: `${userToDelete?.name} has been deleted`,
+          });
+        }
+      },
+    }
+  );
+
+  const handleDelete = async () => {
+    if (userToDelete) {
+      await deleteEmployee({
+        variables: {
+          input: {
+            id: userToDelete?.id,
+          },
+        },
+      });
+    }
+
+    onCloseConfirmDeleteModal();
+    refetch();
+  };
 
   return (
     <Layout>
@@ -303,7 +344,7 @@ export default function AdminManagement() {
           onClose={onCloseConfirmDeleteModal}
           user={userToDelete}
           // TODO: Replace onDelete handler during API hookup
-          onDelete={onCloseConfirmDeleteModal}
+          onDelete={handleDelete}
         />
       )}
       <AdminModal

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -276,6 +276,7 @@ export default function AdminManagement() {
     },
   });
 
+  // Delete Employee Hook
   const [deleteEmployee] = useMutation<DeleteEmployeeResponse, DeleteEmployeeRequest>(
     DELETE_EMPLOYEE_MUTATION,
     {
@@ -290,6 +291,7 @@ export default function AdminManagement() {
     }
   );
 
+  // Handle delete employee action
   const handleDelete = async () => {
     if (userToDelete) {
       await deleteEmployee({

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -296,9 +296,7 @@ export default function AdminManagement() {
     if (userToDelete) {
       await deleteEmployee({
         variables: {
-          input: {
-            id: userToDelete?.id,
-          },
+          input: userToDelete?.id,
         },
       });
     }
@@ -345,7 +343,6 @@ export default function AdminManagement() {
           isOpen={isConfirmDeleteModalOpen}
           onClose={onCloseConfirmDeleteModal}
           user={userToDelete}
-          // TODO: Replace onDelete handler during API hookup
           onDelete={handleDelete}
         />
       )}

--- a/pages/admin/admin-management.tsx
+++ b/pages/admin/admin-management.tsx
@@ -284,7 +284,7 @@ export default function AdminManagement() {
         if (data.deleteEmployee.ok) {
           toast({
             status: 'success',
-            description: `${userToDelete?.name} has been deleted`,
+            description: `${data.deleteEmployee.employee.firstName} ${data.deleteEmployee.employee.lastName} has been deleted`,
           });
         }
       },
@@ -296,7 +296,7 @@ export default function AdminManagement() {
     if (userToDelete) {
       await deleteEmployee({
         variables: {
-          input: userToDelete?.id,
+          id: userToDelete?.id,
         },
       });
     }

--- a/tools/pages/admin/admin-management/delete-employee.ts
+++ b/tools/pages/admin/admin-management/delete-employee.ts
@@ -1,13 +1,18 @@
+import { Employee } from '.prisma/client';
 import { gql } from '@apollo/client'; // gql tag
-import { MutationDeleteEmployeeArgs, DeleteEmployeeResult } from '@lib/graphql/types'; // GraphQL types
+import { MutationDeleteEmployeeArgs } from '@lib/graphql/types'; // GraphQL types
 
 /**
  * GQL query to delete employee
  */
 export const DELETE_EMPLOYEE_MUTATION = gql`
-  mutation DeleteEmployeeMutation($input: DeleteEmployeeInput!) {
+  mutation DeleteEmployeeMutation($input: ID!) {
     deleteEmployee(input: $input) {
       ok
+      employee {
+        firstName
+        lastName
+      }
     }
   }
 `;
@@ -21,5 +26,8 @@ export type DeleteEmployeeRequest = MutationDeleteEmployeeArgs;
  * Response type of delete employee
  */
 export type DeleteEmployeeResponse = {
-  deleteEmployee: DeleteEmployeeResult;
+  deleteEmployee: {
+    ok: boolean;
+    employee: Employee;
+  };
 };

--- a/tools/pages/admin/admin-management/delete-employee.ts
+++ b/tools/pages/admin/admin-management/delete-employee.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client'; // gql tag
+import { MutationDeleteEmployeeArgs, DeleteEmployeeResult } from '@lib/graphql/types';
+
+export const DELETE_EMPLOYEE_MUTATION = gql`
+  mutation DeleteEmployeeMutation($input: DeleteEmployeeInput!) {
+    deleteEmployee(input: $input) {
+      ok
+    }
+  }
+`;
+
+export type DeleteEmployeeRequest = MutationDeleteEmployeeArgs;
+
+export type DeleteEmployeeResponse = {
+  deleteEmployee: DeleteEmployeeResult;
+};

--- a/tools/pages/admin/admin-management/delete-employee.ts
+++ b/tools/pages/admin/admin-management/delete-employee.ts
@@ -1,4 +1,4 @@
-import { Employee } from '.prisma/client';
+import { Employee } from '@prisma/client';
 import { gql } from '@apollo/client'; // gql tag
 import { MutationDeleteEmployeeArgs } from '@lib/graphql/types'; // GraphQL types
 

--- a/tools/pages/admin/admin-management/delete-employee.ts
+++ b/tools/pages/admin/admin-management/delete-employee.ts
@@ -1,6 +1,9 @@
 import { gql } from '@apollo/client'; // gql tag
-import { MutationDeleteEmployeeArgs, DeleteEmployeeResult } from '@lib/graphql/types';
+import { MutationDeleteEmployeeArgs, DeleteEmployeeResult } from '@lib/graphql/types'; // GraphQL types
 
+/**
+ * GQL query to delete employee
+ */
 export const DELETE_EMPLOYEE_MUTATION = gql`
   mutation DeleteEmployeeMutation($input: DeleteEmployeeInput!) {
     deleteEmployee(input: $input) {
@@ -9,8 +12,14 @@ export const DELETE_EMPLOYEE_MUTATION = gql`
   }
 `;
 
+/**
+ * Input parameters for delete employee
+ */
 export type DeleteEmployeeRequest = MutationDeleteEmployeeArgs;
 
+/**
+ * Response type of delete employee
+ */
 export type DeleteEmployeeResponse = {
   deleteEmployee: DeleteEmployeeResult;
 };

--- a/tools/pages/admin/admin-management/delete-employee.ts
+++ b/tools/pages/admin/admin-management/delete-employee.ts
@@ -6,8 +6,8 @@ import { MutationDeleteEmployeeArgs } from '@lib/graphql/types'; // GraphQL type
  * GQL query to delete employee
  */
 export const DELETE_EMPLOYEE_MUTATION = gql`
-  mutation DeleteEmployeeMutation($input: ID!) {
-    deleteEmployee(input: $input) {
+  mutation DeleteEmployeeMutation($id: ID!) {
+    deleteEmployee(id: $id) {
       ok
       employee {
         firstName

--- a/tools/pages/admin/admin-management/types.ts
+++ b/tools/pages/admin/admin-management/types.ts
@@ -4,6 +4,7 @@ import { Role } from '@lib/types'; //GraphQL types
  * Employee data type for admin-management table
  */
 export type EmployeeData = {
+  id: number;
   name: {
     firstName: string;
     lastName: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Admin Management Table API Hookup - Delete admin](https://www.notion.so/uwblueprintexecs/Admin-Management-Table-API-Hookup-Delete-admin-05121d7aff88479691d2155c1c5dcc84)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created the gql delete admin mutation 
* hooked the api up to the delete admin modal
* added `notifyOnNetworkStatusChange` to the getEmployees useQuery hook to update the admin-management table upon deletion


<!-- Catch all sections that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Made a slight change to the deleteEmployee resolver to make sure the ID is recieved through args and it is parsed to be an integer
* Will add comments to added code later 
* Lines 142 and 143 in `admin-management.tsx` are not fixed because that would be part of the update api hookup ticket. Not sure if I should fix it in this PR, would like a second opinion pls!


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
