### PR TITLE
[Improvement] Refactor and Extract State from Payment Card Section

### DIFF
--- a/components/admin/requests/PaymentInformationCard.tsx
+++ b/components/admin/requests/PaymentInformationCard.tsx
@@ -1,20 +1,20 @@
 import { Box, Text, Divider, SimpleGrid, VStack, Button } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/PermitHolderInfoCard'; // Custom Card component
 import EditPaymentDetailsModal from '@components/admin/requests/modals/EditPaymentDetailsModal'; // Edit modal
-import { PaymentInformation } from '@tools/components/admin/requests/payment-information-card'; // Applicant type
+import { PaymentDetails } from '@tools/components/admin/requests/forms/types';
 
 type PaymentInformationProps = {
-  readonly paymentInformation: PaymentInformation;
+  readonly paymentInformation: PaymentDetails;
   readonly isUpdated?: boolean;
   readonly onSave: (applicationData: any) => void;
 };
 
 export default function PaymentInformationCard(props: PaymentInformationProps) {
   const { paymentInformation, isUpdated, onSave } = props;
+
   const {
-    processingFee,
-    donationAmount,
     paymentMethod,
+    donationAmount,
     shippingAddressLine1,
     shippingAddressLine2,
     shippingCity,
@@ -55,7 +55,8 @@ export default function PaymentInformationCard(props: PaymentInformationProps) {
           </Box>
           <Box>
             <Text as="p" textStyle="body-regular">
-              ${processingFee}
+              {/* Fixed cost */}
+              {'$26'}
             </Text>
           </Box>
           <Box>

--- a/components/admin/requests/forms/PaymentDetailsForm.tsx
+++ b/components/admin/requests/forms/PaymentDetailsForm.tsx
@@ -1,0 +1,384 @@
+import { PaymentDetails } from '@tools/components/admin/requests/forms/types';
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  Text,
+  Stack,
+  FormHelperText,
+  Radio,
+  RadioGroup,
+  Box,
+  InputGroup,
+  InputLeftElement,
+  Checkbox,
+  Select,
+  Grid,
+  GridItem,
+  Divider,
+} from '@chakra-ui/react'; // Chakra UI
+import { PaymentType, Province } from '@lib/graphql/types';
+
+type PaymentDetailsFormProps = {
+  readonly paymentInformation: PaymentDetails;
+  readonly onChange: (updatedData: PaymentDetails) => void;
+};
+
+/**
+ * Function Passed into PaymentDetailsProps for monitoring the changes done to fields in PaymentDetailsForm Component.
+ *
+ * @callback onChangeCallback
+ * @param {PaymentDetails} updatedData
+ */
+
+/**
+ * PaymentDetailsForm Component for allowing users to edit payment details.
+ *
+ * @param {PaymentDetails} paymentInformation Data Structure that holds all paymentInformation for a client request.
+ * @param {onChangeCallback} onChange Function that uses the updated values from form.
+ * @returns
+ */
+export default function PaymentDetailsForm({
+  paymentInformation,
+  onChange,
+}: PaymentDetailsFormProps) {
+  const {
+    paymentMethod,
+    donationAmount,
+    shippingAddressSameAsHomeAddress,
+    shippingFullName,
+    shippingAddressLine1,
+    shippingAddressLine2,
+    shippingCity,
+    shippingProvince,
+    shippingPostalCode,
+    billingAddressSameAsHomeAddress,
+    billingFullName,
+    billingAddressLine1,
+    billingAddressLine2,
+    billingCity,
+    billingProvince,
+    billingPostalCode,
+  } = paymentInformation;
+  return (
+    <>
+      <Box paddingBottom="32px">
+        <Grid templateColumns="repeat(2, 1fr)" rowGap={'24px'}>
+          <GridItem rowSpan={2} colSpan={1}>
+            <FormControl as="fieldset" isRequired>
+              <FormLabel as="legend">{'Payment method'}</FormLabel>
+              <RadioGroup
+                onChange={value =>
+                  onChange({
+                    ...paymentInformation,
+                    paymentMethod: value as PaymentType,
+                  })
+                }
+                value={paymentMethod}
+              >
+                <Stack>
+                  <Radio value={PaymentType.Mastercard}>{'Mastercard'}</Radio>
+                  <Radio value={PaymentType.Visa}>{'Visa'}</Radio>
+                  <Radio value={PaymentType.Debit}>{'Debit'}</Radio>
+                  <Radio value={PaymentType.Cash}>{'Cash'}</Radio>
+                  <Radio value={PaymentType.Cheque}>{'Cheque'}</Radio>
+                  <Radio value={PaymentType.Etransfer}>{'E-transfer'}</Radio>
+                </Stack>
+              </RadioGroup>
+            </FormControl>
+          </GridItem>
+
+          <GridItem>
+            <FormControl isRequired isDisabled>
+              <FormLabel>
+                {'Permit fee '}
+                <Box as="span" textStyle="body-regular">
+                  {'(fixed cost)'}
+                </Box>
+              </FormLabel>
+              <InputGroup>
+                <InputLeftElement pointerEvents="none" color="texticon.filler" fontSize="1.2em">
+                  {'$'}
+                </InputLeftElement>
+                <Input placeholder="26" />
+              </InputGroup>
+            </FormControl>
+          </GridItem>
+
+          <GridItem colSpan={1}>
+            <FormControl>
+              <FormLabel>
+                {'Donation '}
+                <Box as="span" textStyle="body-regular">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <InputGroup>
+                <InputLeftElement pointerEvents="none" color="texticon.filler" fontSize="1.2em">
+                  {'$'}
+                </InputLeftElement>
+                <Input
+                  value={donationAmount || 0}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      donationAmount: parseInt(event.target.value),
+                    })
+                  }
+                />
+              </InputGroup>
+            </FormControl>
+          </GridItem>
+        </Grid>
+      </Box>
+
+      <Divider borderColor="border.secondary" />
+
+      <Box paddingY="32px">
+        <Text as="h3" textStyle="heading" paddingBottom="24px">
+          {'Shipping Address'}
+        </Text>
+
+        <Checkbox
+          paddingBottom="24px"
+          isChecked={shippingAddressSameAsHomeAddress}
+          onChange={event =>
+            onChange({
+              ...paymentInformation,
+              shippingAddressSameAsHomeAddress: event.target.checked,
+            })
+          }
+        >
+          {'Same as home address'}
+        </Checkbox>
+
+        {/* Section is hidden if same as home address checkbox is checked */}
+        {!shippingAddressSameAsHomeAddress && (
+          <>
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{'Full name'}</FormLabel>
+              <Input
+                value={shippingFullName || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    shippingFullName: event.target.value,
+                  })
+                }
+              />
+            </FormControl>
+
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{'Address line 1'}</FormLabel>
+              <Input
+                value={shippingAddressLine1 || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    shippingAddressLine1: event.target.value,
+                  })
+                }
+              />
+              <FormHelperText color="text.seconday">
+                {'Street Address, P.O. Box, Company Name, c/o'}
+              </FormHelperText>
+            </FormControl>
+
+            <FormControl paddingBottom="24px">
+              <FormLabel>
+                {'Address line 2 '}
+                <Box as="span" textStyle="body-regular">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <Input
+                value={shippingAddressLine2 || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    shippingAddressLine2: event.target.value,
+                  })
+                }
+              />
+              <FormHelperText color="text.seconday">
+                {'Apartment, suite, unit, building, floor, etc'}
+              </FormHelperText>
+            </FormControl>
+
+            <Stack direction="row" spacing="20px">
+              <FormControl isRequired paddingBottom="24px">
+                <FormLabel>{'City'}</FormLabel>
+                <Input
+                  value={shippingCity || ''}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      shippingCity: event.target.value,
+                    })
+                  }
+                />
+              </FormControl>
+
+              <FormControl isRequired>
+                <FormLabel>{'Province / territory'}</FormLabel>
+                <Select
+                  placeholder="Select province / territory"
+                  value={shippingProvince || undefined}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      shippingProvince: event.target.value as Province,
+                    })
+                  }
+                >
+                  <option value={Province.On}>Ontario</option>
+                  <option value={Province.Bc}>British Columbia</option>
+                </Select>
+              </FormControl>
+            </Stack>
+
+            <Stack direction="row" spacing="20px">
+              <FormControl isRequired>
+                <FormLabel>{'Postal code'}</FormLabel>
+                <Input
+                  value={shippingPostalCode || ''}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      shippingPostalCode: event.target.value,
+                    })
+                  }
+                />
+                <FormHelperText color="text.seconday">{'Example: X0X 0X0'} </FormHelperText>
+              </FormControl>
+            </Stack>
+          </>
+        )}
+      </Box>
+
+      <Divider borderColor="border.secondary" />
+
+      <Box paddingTop="32px">
+        <Text as="h3" textStyle="heading" paddingBottom="24px">
+          {'Billing Address'}
+        </Text>
+
+        <Checkbox
+          paddingBottom="24px"
+          isChecked={billingAddressSameAsHomeAddress}
+          onChange={event =>
+            onChange({
+              ...paymentInformation,
+              billingAddressSameAsHomeAddress: event.target.checked,
+            })
+          }
+        >
+          {'Same as home address'}
+        </Checkbox>
+
+        {/* Section is hidden if same as home address checkbox is checked */}
+        {!billingAddressSameAsHomeAddress && (
+          <>
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{'Full name'}</FormLabel>
+              <Input
+                value={billingFullName || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    billingFullName: event.target.value,
+                  })
+                }
+              />
+            </FormControl>
+
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{'Address line 1'}</FormLabel>
+              <Input
+                value={billingAddressLine1 || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    billingAddressLine1: event.target.value,
+                  })
+                }
+              />
+              <FormHelperText color="text.seconday">
+                {'Street Address, P.O. Box, Company Name, c/o'}
+              </FormHelperText>
+            </FormControl>
+
+            <FormControl paddingBottom="24px">
+              <FormLabel>
+                {'Address line 2 '}
+                <Box as="span" textStyle="body-regular">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <Input
+                value={billingAddressLine2 || ''}
+                onChange={event =>
+                  onChange({
+                    ...paymentInformation,
+                    billingAddressLine2: event.target.value,
+                  })
+                }
+              />
+              <FormHelperText color="text.seconday">
+                {'Apartment, suite, unit, building, floor, etc'}
+              </FormHelperText>
+            </FormControl>
+
+            <Stack direction="row" spacing="20px" paddingBottom="24px">
+              <FormControl isRequired>
+                <FormLabel>{'City'}</FormLabel>
+                <Input
+                  value={billingCity || ''}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      billingCity: event.target.value,
+                    })
+                  }
+                />
+              </FormControl>
+
+              <FormControl>
+                <FormLabel>{'Province / territory'}</FormLabel>
+                <Select
+                  placeholder="Select province / territory"
+                  value={billingProvince || undefined}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      billingProvince: event.target.value as Province,
+                    })
+                  }
+                >
+                  <option value={Province.On}>Ontario</option>
+                  <option value={Province.Bc}>British Columbia</option>
+                </Select>
+              </FormControl>
+            </Stack>
+
+            <Stack direction="row" spacing="20px">
+              <FormControl isRequired>
+                <FormLabel>{'Postal code'}</FormLabel>
+                <Input
+                  value={billingPostalCode || ''}
+                  onChange={event =>
+                    onChange({
+                      ...paymentInformation,
+                      billingPostalCode: event.target.value,
+                    })
+                  }
+                />
+                <FormHelperText color="text.seconday">{'Example: X0X 0X0'} </FormHelperText>
+              </FormControl>
+            </Stack>
+          </>
+        )}
+      </Box>
+    </>
+  );
+}

--- a/components/admin/requests/forms/PaymentDetailsForm.tsx
+++ b/components/admin/requests/forms/PaymentDetailsForm.tsx
@@ -25,18 +25,10 @@ type PaymentDetailsFormProps = {
 };
 
 /**
- * Function Passed into PaymentDetailsProps for monitoring the changes done to fields in PaymentDetailsForm Component.
- *
- * @callback onChangeCallback
- * @param {PaymentDetails} updatedData
- */
-
-/**
  * PaymentDetailsForm Component for allowing users to edit payment details.
  *
  * @param {PaymentDetails} paymentInformation Data Structure that holds all paymentInformation for a client request.
  * @param {onChangeCallback} onChange Function that uses the updated values from form.
- * @returns
  */
 export default function PaymentDetailsForm({
   paymentInformation,

--- a/components/admin/requests/modals/EditPaymentDetailsModal.tsx
+++ b/components/admin/requests/modals/EditPaymentDetailsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, ReactNode, SyntheticEvent } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -6,85 +7,49 @@ import {
   ModalFooter,
   ModalBody,
   Button,
-  FormControl,
-  FormLabel,
-  Input,
   useDisclosure,
   Text,
-  Stack,
-  FormHelperText,
-  Radio,
-  RadioGroup,
   Box,
-  InputGroup,
-  InputLeftElement,
-  Checkbox,
-  Select,
-  Grid,
-  GridItem,
-  Divider,
 } from '@chakra-ui/react'; // Chakra UI
-import { useState, useEffect, SyntheticEvent, ReactNode } from 'react'; // React
-import { PaymentType, Province } from '@lib/graphql/types'; // Types
-import { PaymentInformation } from '@tools/components/admin/requests/payment-information-card'; // PaymentInformation type
+import { PaymentDetails } from '@tools/components/admin/requests/forms/types';
+import PaymentDetailsForm from '@components/admin/requests/forms/PaymentDetailsForm';
 
 type EditPaymentDetailsModalProps = {
   readonly children: ReactNode;
-  readonly paymentInformation: PaymentInformation;
+  readonly paymentInformation: PaymentDetails;
   readonly onSave: (applicationData: any) => void;
 };
 
 export default function EditPaymentDetailsModal({
   children,
-  paymentInformation,
+  paymentInformation: currentPaymentInformation,
   onSave,
 }: EditPaymentDetailsModalProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const [paymentMethod, setPaymentMethod] = useState<PaymentType>();
-  const [donationAmount, setDonationAmount] = useState<number | undefined>();
-
-  //   Shipping address information state
-  const [shippingAddressSameAsHomeAddress, setShippingAddressSameAsHomeAddress] = useState(false);
-  const [shippingFullName, setShippingFullName] = useState('');
-  const [shippingAddressLine1, setShippingAddressLine1] = useState('');
-  const [shippingAddressLine2, setShippingAddressLine2] = useState('');
-  const [shippingCity, setShippingCity] = useState('');
-  const [shippingProvince, setShippingProvince] = useState<Province | undefined>();
-  const [shippingPostalCode, setShippingPostalCode] = useState('');
-
-  //   TODO: Add error states for each field as follows (post-mvp)
-  // const [shippingFullNameInputError, setShippingFullNameInputError] = useState(''); // Error message displayed under input
-
-  //   Billing address information state
-  const [billingAddressSameAsHomeAddress, setBillingAddressSameAsHomeAddress] = useState(false);
-  const [billingFullName, setBillingFullName] = useState('');
-  const [billingAddressLine1, setBillingAddressLine1] = useState('');
-  const [billingAddressLine2, setBillingAddressLine2] = useState('');
-  const [billingCity, setBillingCity] = useState('');
-  const [billingProvince, setBillingProvince] = useState<Province | undefined>();
-  const [billingPostalCode, setBillingPostalCode] = useState('');
+  const [paymentInformation, setPaymentInformation] = useState<PaymentDetails>(
+    currentPaymentInformation || {
+      paymentMethod: undefined,
+      donationAmount: null,
+      shippingAddressSameAsHomeAddress: false,
+      shippingFullName: '',
+      shippingAddressLine1: '',
+      shippingAddressLine2: '',
+      shippingCity: '',
+      shippingProvince: undefined,
+      shippingPostalCode: '',
+      billingAddressSameAsHomeAddress: false,
+      billingFullName: '',
+      billingAddressLine1: '',
+      billingAddressLine2: '',
+      billingCity: '',
+      billingProvince: undefined,
+      billingPostalCode: '',
+    }
+  );
 
   useEffect(() => {
-    setPaymentMethod(paymentInformation.paymentMethod);
-    setDonationAmount(paymentInformation.donationAmount || 0);
-
-    setShippingAddressSameAsHomeAddress(paymentInformation.shippingAddressSameAsHomeAddress);
-    setShippingFullName(paymentInformation.shippingFullName || '');
-    setShippingAddressLine1(paymentInformation.shippingAddressLine1 || '');
-    setShippingAddressLine2(paymentInformation.shippingAddressLine2 || '');
-    setShippingCity(paymentInformation.shippingCity || '');
-    setShippingProvince(paymentInformation.shippingProvince || undefined);
-    setShippingPostalCode(paymentInformation.shippingPostalCode || '');
-
-    setBillingAddressSameAsHomeAddress(paymentInformation.billingAddressSameAsHomeAddress);
-    setBillingFullName(paymentInformation.billingFullName || '');
-    setBillingAddressLine1(paymentInformation.billingAddressLine1 || '');
-    setBillingAddressLine2(paymentInformation.billingAddressLine2 || '');
-    setBillingCity(paymentInformation.billingCity || '');
-    setBillingProvince(paymentInformation.billingProvince || undefined);
-    setBillingPostalCode(paymentInformation.billingPostalCode || '');
-  }, [paymentInformation]);
+    setPaymentInformation(currentPaymentInformation);
+  }, [currentPaymentInformation, isOpen]);
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
@@ -94,6 +59,24 @@ export default function EditPaymentDetailsModal({
     //     setShippingFullNameInputError("Please enter the recipient's full name.");
     //   }
     // }
+    const {
+      paymentMethod,
+      donationAmount,
+      shippingAddressSameAsHomeAddress,
+      shippingFullName,
+      shippingAddressLine1,
+      shippingAddressLine2,
+      shippingCity,
+      shippingProvince,
+      shippingPostalCode,
+      billingAddressSameAsHomeAddress,
+      billingFullName,
+      billingAddressLine1,
+      billingAddressLine2,
+      billingCity,
+      billingProvince,
+      billingPostalCode,
+    } = paymentInformation;
     onSave({
       ...(paymentMethod && { paymentMethod }),
       ...(donationAmount !== undefined && { donationAmount }),
@@ -139,251 +122,10 @@ export default function EditPaymentDetailsModal({
               </Text>
             </ModalHeader>
             <ModalBody paddingY="20px" paddingX="4px">
-              <Box paddingBottom="32px">
-                <Grid templateColumns="repeat(2, 1fr)" rowGap={'24px'}>
-                  <GridItem rowSpan={2} colSpan={1}>
-                    <FormControl as="fieldset" isRequired>
-                      <FormLabel as="legend">{'Payment method'}</FormLabel>
-                      <RadioGroup
-                        onChange={value => setPaymentMethod(value as PaymentType)}
-                        value={paymentMethod}
-                      >
-                        <Stack>
-                          <Radio value={PaymentType.Mastercard}>{'Mastercard'}</Radio>
-                          <Radio value={PaymentType.Visa}>{'Visa'}</Radio>
-                          <Radio value={PaymentType.Debit}>{'Debit'}</Radio>
-                          <Radio value={PaymentType.Cash}>{'Cash'}</Radio>
-                          <Radio value={PaymentType.Cheque}>{'Cheque'}</Radio>
-                          <Radio value={PaymentType.Etransfer}>{'E-transfer'}</Radio>
-                        </Stack>
-                      </RadioGroup>
-                    </FormControl>
-                  </GridItem>
-
-                  <GridItem>
-                    <FormControl isRequired isDisabled>
-                      <FormLabel>
-                        {'Permit fee '}
-                        <Box as="span" textStyle="body-regular">
-                          {'(fixed cost)'}
-                        </Box>
-                      </FormLabel>
-                      <InputGroup>
-                        <InputLeftElement
-                          pointerEvents="none"
-                          color="texticon.filler"
-                          fontSize="1.2em"
-                        >
-                          {'$'}
-                        </InputLeftElement>
-                        <Input placeholder="26" />
-                      </InputGroup>
-                    </FormControl>
-                  </GridItem>
-
-                  <GridItem colSpan={1}>
-                    <FormControl>
-                      <FormLabel>
-                        {'Donation '}
-                        <Box as="span" textStyle="body-regular">
-                          {'(optional)'}
-                        </Box>
-                      </FormLabel>
-                      <InputGroup>
-                        <InputLeftElement
-                          pointerEvents="none"
-                          color="texticon.filler"
-                          fontSize="1.2em"
-                        >
-                          {'$'}
-                        </InputLeftElement>
-                        <Input
-                          value={donationAmount}
-                          onChange={event => setDonationAmount(parseInt(event.target.value))}
-                        />
-                      </InputGroup>
-                    </FormControl>
-                  </GridItem>
-                </Grid>
-              </Box>
-
-              <Divider borderColor="border.secondary" />
-
-              <Box paddingY="32px">
-                <Text as="h3" textStyle="heading" paddingBottom="24px">
-                  {'Shipping Address'}
-                </Text>
-
-                <Checkbox
-                  paddingBottom="24px"
-                  isChecked={shippingAddressSameAsHomeAddress}
-                  onChange={event => setShippingAddressSameAsHomeAddress(event.target.checked)}
-                >
-                  {'Same as home address'}
-                </Checkbox>
-
-                {/* Section is hidden if same as home address checkbox is checked */}
-                {!shippingAddressSameAsHomeAddress && (
-                  <>
-                    <FormControl isRequired paddingBottom="24px">
-                      <FormLabel>{'Full name'}</FormLabel>
-                      <Input
-                        value={shippingFullName}
-                        onChange={event => setShippingFullName(event.target.value)}
-                      />
-                    </FormControl>
-
-                    <FormControl isRequired paddingBottom="24px">
-                      <FormLabel>{'Address line 1'}</FormLabel>
-                      <Input
-                        value={shippingAddressLine1}
-                        onChange={event => setShippingAddressLine1(event.target.value)}
-                      />
-                      <FormHelperText color="text.seconday">
-                        {'Street Address, P.O. Box, Company Name, c/o'}
-                      </FormHelperText>
-                    </FormControl>
-
-                    <FormControl paddingBottom="24px">
-                      <FormLabel>
-                        {'Address line 2 '}
-                        <Box as="span" textStyle="body-regular">
-                          {'(optional)'}
-                        </Box>
-                      </FormLabel>
-                      <Input
-                        value={shippingAddressLine2}
-                        onChange={event => setShippingAddressLine2(event.target.value)}
-                      />
-                      <FormHelperText color="text.seconday">
-                        {'Apartment, suite, unit, building, floor, etc'}
-                      </FormHelperText>
-                    </FormControl>
-
-                    <Stack direction="row" spacing="20px">
-                      <FormControl isRequired paddingBottom="24px">
-                        <FormLabel>{'City'}</FormLabel>
-                        <Input
-                          value={shippingCity}
-                          onChange={event => setShippingCity(event.target.value)}
-                        />
-                      </FormControl>
-
-                      <FormControl isRequired>
-                        <FormLabel>{'Province / territory'}</FormLabel>
-                        <Select
-                          placeholder="Select province / territory"
-                          value={shippingProvince}
-                          onChange={event => setShippingProvince(event.target.value as Province)}
-                        >
-                          <option value={Province.On}>Ontario</option>
-                          <option value={Province.Bc}>British Columbia</option>
-                        </Select>
-                      </FormControl>
-                    </Stack>
-
-                    <Stack direction="row" spacing="20px">
-                      <FormControl isRequired>
-                        <FormLabel>{'Postal code'}</FormLabel>
-                        <Input
-                          value={shippingPostalCode}
-                          onChange={event => setShippingPostalCode(event.target.value)}
-                        />
-                        <FormHelperText color="text.seconday">{'Example: X0X 0X0'} </FormHelperText>
-                      </FormControl>
-                    </Stack>
-                  </>
-                )}
-              </Box>
-
-              <Divider borderColor="border.secondary" />
-
-              <Box paddingTop="32px">
-                <Text as="h3" textStyle="heading" paddingBottom="24px">
-                  {'Billing Address'}
-                </Text>
-
-                <Checkbox
-                  paddingBottom="24px"
-                  isChecked={billingAddressSameAsHomeAddress}
-                  onChange={event => setBillingAddressSameAsHomeAddress(event.target.checked)}
-                >
-                  {'Same as home address'}
-                </Checkbox>
-
-                {/* Section is hidden if same as home address checkbox is checked */}
-                {!billingAddressSameAsHomeAddress && (
-                  <>
-                    <FormControl isRequired paddingBottom="24px">
-                      <FormLabel>{'Full name'}</FormLabel>
-                      <Input
-                        value={billingFullName}
-                        onChange={event => setBillingFullName(event.target.value)}
-                      />
-                    </FormControl>
-
-                    <FormControl isRequired paddingBottom="24px">
-                      <FormLabel>{'Address line 1'}</FormLabel>
-                      <Input
-                        value={billingAddressLine1}
-                        onChange={event => setBillingAddressLine1(event.target.value)}
-                      />
-                      <FormHelperText color="text.seconday">
-                        {'Street Address, P.O. Box, Company Name, c/o'}
-                      </FormHelperText>
-                    </FormControl>
-
-                    <FormControl paddingBottom="24px">
-                      <FormLabel>
-                        {'Address line 2 '}
-                        <Box as="span" textStyle="body-regular">
-                          {'(optional)'}
-                        </Box>
-                      </FormLabel>
-                      <Input
-                        value={billingAddressLine2}
-                        onChange={event => setBillingAddressLine2(event.target.value)}
-                      />
-                      <FormHelperText color="text.seconday">
-                        {'Apartment, suite, unit, building, floor, etc'}
-                      </FormHelperText>
-                    </FormControl>
-
-                    <Stack direction="row" spacing="20px" paddingBottom="24px">
-                      <FormControl isRequired>
-                        <FormLabel>{'City'}</FormLabel>
-                        <Input
-                          value={billingCity}
-                          onChange={event => setBillingCity(event.target.value)}
-                        />
-                      </FormControl>
-
-                      <FormControl>
-                        <FormLabel>{'Province / territory'}</FormLabel>
-                        <Select
-                          placeholder="Select province / territory"
-                          value={billingProvince}
-                          onChange={event => setBillingProvince(event.target.value as Province)}
-                        >
-                          <option value={Province.On}>Ontario</option>
-                          <option value={Province.Bc}>British Columbia</option>
-                        </Select>
-                      </FormControl>
-                    </Stack>
-
-                    <Stack direction="row" spacing="20px">
-                      <FormControl isRequired>
-                        <FormLabel>{'Postal code'}</FormLabel>
-                        <Input
-                          value={billingPostalCode}
-                          onChange={event => setBillingPostalCode(event.target.value)}
-                        />
-                        <FormHelperText color="text.seconday">{'Example: X0X 0X0'} </FormHelperText>
-                      </FormControl>
-                    </Stack>
-                  </>
-                )}
-              </Box>
+              <PaymentDetailsForm
+                paymentInformation={paymentInformation}
+                onChange={setPaymentInformation}
+              />
             </ModalBody>
             <ModalFooter paddingBottom="24px" paddingX="4px">
               <Button colorScheme="gray" variant="solid" onClick={onClose}>

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -134,7 +134,6 @@ export default function Request({ id }: Props) {
     billingProvince,
     billingPostalCode,
 
-    processingFee,
     donationAmount,
     paymentMethod,
 
@@ -165,8 +164,23 @@ export default function Request({ id }: Props) {
     mostRecentAppExpiryDate: new Date(expiryDate),
   };
 
-  // Payment data for Payment Information Card
-  const paymentInformationData = {
+  // Physician data for Doctor Information Card
+  const physicianData = {
+    name: physicianName,
+    mspNumber: physicianMspNumber,
+    addressLine1: physicianAddressLine1,
+    addressLine2: physicianAddressLine2,
+    city: physicianCity,
+    province: physicianProvince,
+    postalCode: physicianPostalCode,
+    phone: physicianPhone,
+    notes: physicianNotes,
+  };
+
+  // Payment data
+  const paymentInformation = {
+    paymentMethod,
+    donationAmount,
     shippingAddressSameAsHomeAddress,
     shippingFullName,
     shippingAddressLine1,
@@ -181,22 +195,6 @@ export default function Request({ id }: Props) {
     billingCity,
     billingProvince,
     billingPostalCode,
-    processingFee,
-    donationAmount,
-    paymentMethod,
-  };
-
-  // Physician data for Doctor Information Card
-  const physicianData = {
-    name: physicianName,
-    mspNumber: physicianMspNumber,
-    addressLine1: physicianAddressLine1,
-    addressLine2: physicianAddressLine2,
-    city: physicianCity,
-    province: physicianProvince,
-    postalCode: physicianPostalCode,
-    phone: physicianPhone,
-    notes: physicianNotes,
   };
 
   /**
@@ -284,7 +282,7 @@ export default function Request({ id }: Props) {
             <DoctorInformationCard physician={physicianData} onSave={handleUpdateApplication} />
           )}
           <PaymentInformationCard
-            paymentInformation={paymentInformationData}
+            paymentInformation={paymentInformation}
             onSave={handleUpdateApplication}
           />
         </Stack>

--- a/tools/components/admin/requests/forms/types.ts
+++ b/tools/components/admin/requests/forms/types.ts
@@ -1,4 +1,4 @@
-import { Application, Renewal } from '@lib/graphql/types'; // Renewal & Application type
+import { Application, Renewal } from '@lib/graphql/types'; // GraphQL Types
 
 // Additional Questions Object
 export type AdditionalQuestions = Pick<

--- a/tools/components/admin/requests/forms/types.ts
+++ b/tools/components/admin/requests/forms/types.ts
@@ -1,5 +1,4 @@
-import { Renewal } from '@lib/graphql/types'; // Renewal type
-import { Application } from '@lib/graphql/types';
+import { Application, Renewal } from '@lib/graphql/types'; // Renewal type
 
 // Additional Questions Object
 export type AdditionalQuestions = Pick<

--- a/tools/components/admin/requests/forms/types.ts
+++ b/tools/components/admin/requests/forms/types.ts
@@ -1,4 +1,4 @@
-import { Application, Renewal } from '@lib/graphql/types'; // Renewal type
+import { Application, Renewal } from '@lib/graphql/types'; // Renewal & Application type
 
 // Additional Questions Object
 export type AdditionalQuestions = Pick<

--- a/tools/components/admin/requests/forms/types.ts
+++ b/tools/components/admin/requests/forms/types.ts
@@ -1,6 +1,29 @@
 import { Renewal } from '@lib/graphql/types'; // Renewal type
+import { Application } from '@lib/graphql/types';
 
+// Additional Questions Object
 export type AdditionalQuestions = Pick<
   Renewal,
   'usesAccessibleConvertedVan' | 'requiresWiderParkingSpace'
+>;
+
+// Payment Details Object
+export type PaymentDetails = Pick<
+  Application,
+  | 'paymentMethod'
+  | 'donationAmount'
+  | 'shippingAddressSameAsHomeAddress'
+  | 'shippingFullName'
+  | 'shippingAddressLine1'
+  | 'shippingAddressLine2'
+  | 'shippingCity'
+  | 'shippingProvince'
+  | 'shippingPostalCode'
+  | 'billingAddressSameAsHomeAddress'
+  | 'billingFullName'
+  | 'billingAddressLine1'
+  | 'billingAddressLine2'
+  | 'billingCity'
+  | 'billingProvince'
+  | 'billingPostalCode'
 >;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[New Renewal Request Form Payment Card Section](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=884f93c751444b6ca9e954d35d0cd3b5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed Large State Field and Connected it to Single Object - `PaymentDetailsData`
* Wired State as Updated On Open with `useEffect` as well as on API changes (accounts for Saving)
* Created Custom `PaymentDetailsForm` Component for PaymentDetails to be accessed elsewhere.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Oustan Ding will probably explain the flow of this modal for other modals following up.


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
