### PR TITLE
[Bugfix] Fix Permit Holder Email Bug

### DIFF
--- a/components/admin/permit-holders/modals/EditUserInformationModal.tsx
+++ b/components/admin/permit-holders/modals/EditUserInformationModal.tsx
@@ -42,7 +42,7 @@ export default function EditUserInformationModal({
   const [gender, setGender] = useState<Gender | undefined>();
 
   // Contact information state
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState<string | null>('');
   const [phoneNumber, setPhoneNumber] = useState('');
 
   // Home address information state
@@ -60,7 +60,7 @@ export default function EditUserInformationModal({
     setLastName(applicant.lastName);
     setDateOfBirth(formatDate(applicant.dateOfBirth, true));
     setGender(applicant.gender);
-    setEmail(applicant.email || '');
+    setEmail(applicant.email);
     setPhoneNumber(applicant.phone);
     setAddressLine1(applicant.addressLine1);
     setAddressLine2(applicant.addressLine2 || '');
@@ -169,7 +169,12 @@ export default function EditUserInformationModal({
                         {'(optional)'}
                       </Box>
                     </FormLabel>
-                    <Input value={email} onChange={event => setEmail(event.target.value)} />
+                    <Input
+                      value={email || ''}
+                      onChange={event =>
+                        setEmail(event.target.value === '' ? null : event.target.value)
+                      }
+                    />
                   </FormControl>
 
                   <FormControl isRequired>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix Permit Holder Email Bug](https://www.notion.so/uwblueprintexecs/Fix-Permit-Holder-Email-Bug-2971daede6d84407801922089d289dec)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* More detailed bug description is in Notion
* The roots of the problem:
  * In our database schema, `email` is a unique field on the `applicants` table
  * When trying to update applicant information, the `email` field was being set to the empty string `''` if the email field was empty
    * This is the case when either the applicant already doesn't have an email, or if you try to remove the email field
  * Since other applicants already had `''` as their email, this resulted in a `UniqueConstraintFailed` database error

* Fix:
  * if the email field in the form is empty, set the `email` to `null`

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
