### PR TITLE
[Improvement] Extract Reason for Replacement Card

### DIFF
--- a/components/admin/requests/ReasonForReplacementCard.tsx
+++ b/components/admin/requests/ReasonForReplacementCard.tsx
@@ -1,10 +1,10 @@
 import { Box, Text, Divider, SimpleGrid, Button } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/PermitHolderInfoCard'; // Custom Card Component
 import EditReasonForReplacementModal from '@components/admin/requests/modals/EditReasonForReplacementModal'; // Edit modal
-import { ReplacementData } from '@tools/components/admin/requests/reason-for-replacement-card'; // ReplacementData type
+import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types'; // ReasonForReplacement Type
 
 type ReplacementProps = {
-  readonly replacement: ReplacementData;
+  readonly replacement: ReasonForReplacement;
   readonly isUpdated?: boolean;
 };
 
@@ -16,7 +16,7 @@ export default function ReasonForReplacementCard(props: ReplacementProps) {
       header={`Reason For Replacement`}
       updated={isUpdated}
       editModal={
-        <EditReasonForReplacementModal replacement={replacement}>
+        <EditReasonForReplacementModal reasonForReplacement={replacement}>
           <Button color="primary" variant="ghost" textDecoration="underline">
             <Text textStyle="body-bold">Edit</Text>
           </Button>

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -58,16 +58,22 @@ export default function ReasonForReplacementForm({
             <FormLabel>{`Date`}</FormLabel>
             <Input
               type="date"
-              value={formatDate(new Date(reasonForReplacement.lostTimestamp), true) || ''}
+              value={
+                reasonForReplacement.lostTimestamp
+                  ? formatDate(new Date(reasonForReplacement.lostTimestamp), true)
+                  : ''
+              }
               onChange={event => {
                 const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
                 updatedlostTimestamp.setFullYear(parseInt(event.target.value.substring(0, 4)));
-                updatedlostTimestamp.setMonth(parseInt(event.target.value.substring(5, 7)));
+                updatedlostTimestamp.setMonth(parseInt(event.target.value.substring(5, 7)) - 1);
                 updatedlostTimestamp.setDate(parseInt(event.target.value.substring(8, 10)));
 
                 onChange({
                   ...reasonForReplacement,
-                  lostTimestamp: updatedlostTimestamp,
+                  lostTimestamp: Date.parse(updatedlostTimestamp.toString())
+                    ? updatedlostTimestamp
+                    : reasonForReplacement.lostTimestamp,
                 });
               }}
             />
@@ -97,7 +103,9 @@ export default function ReasonForReplacementForm({
 
                 onChange({
                   ...reasonForReplacement,
-                  lostTimestamp: updatedlostTimestamp,
+                  lostTimestamp: Date.parse(updatedlostTimestamp.toString())
+                    ? updatedlostTimestamp
+                    : reasonForReplacement.lostTimestamp,
                 });
               }}
             />

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -10,6 +10,7 @@ import {
   Textarea,
 } from '@chakra-ui/react'; // Chakra UI
 import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
+import { formatDate } from '@lib/utils/format'; // Date formatter util
 import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types'; // Reason For Replacement Type
 
 type ReasonForReplacementProps = {
@@ -55,7 +56,21 @@ export default function ReasonForReplacementForm({
         <>
           <FormControl isRequired paddingBottom="24px">
             <FormLabel>{`Date`}</FormLabel>
-            <Input type="date" />
+            <Input
+              type="date"
+              value={formatDate(new Date(reasonForReplacement.lostTimestamp), true) || ''}
+              onChange={event => {
+                const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
+                updatedlostTimestamp.setFullYear(parseInt(event.target.value.substring(0, 4)));
+                updatedlostTimestamp.setMonth(parseInt(event.target.value.substring(5, 7)));
+                updatedlostTimestamp.setDate(parseInt(event.target.value.substring(8, 10)));
+
+                onChange({
+                  ...reasonForReplacement,
+                  lostTimestamp: updatedlostTimestamp,
+                });
+              }}
+            />
           </FormControl>
 
           <FormControl paddingBottom="24px">
@@ -67,13 +82,24 @@ export default function ReasonForReplacementForm({
             </FormLabel>
             <Input
               placeholder={'eg. 04:00 pm'}
-              value={reasonForReplacement.lostTimestamp || ''}
-              onChange={event =>
+              type="time"
+              value={
+                new Date(reasonForReplacement.lostTimestamp).toLocaleTimeString('en-US', {
+                  hour12: false,
+                  hour: '2-digit',
+                  minute: '2-digit',
+                }) || ''
+              }
+              onChange={event => {
+                const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
+                updatedlostTimestamp.setHours(parseInt(event.target.value.substring(0, 2)));
+                updatedlostTimestamp.setMinutes(parseInt(event.target.value.substring(3, 5)));
+
                 onChange({
                   ...reasonForReplacement,
-                  lostTimestamp: event.target.value,
-                })
-              }
+                  lostTimestamp: updatedlostTimestamp,
+                });
+              }}
             />
             <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
           </FormControl>

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -20,7 +20,7 @@ type ReasonForReplacementProps = {
 /**
  * ReasonForReplacementForm Component for allowing users to edit reason for replacement information.
  *
- * @param {ReasonForReplacement} ReasonForReplacementForm Data Structure that holds all reason for replacement information for a client request.
+ * @param {ReasonForReplacement} ReasonForReplacement Data Structure that holds all reason for replacement information for a client request.
  * @param onChange Function that uses the updated values from form.
  */
 export default function ReasonForReplacementForm({

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -114,7 +114,7 @@ export default function ReasonForReplacementForm({
           <FormControl isRequired paddingBottom="24px">
             <FormLabel>{'Police file number'}</FormLabel>
             <Input
-              value={reasonForReplacement.stolenPoliceFileNumber || 0}
+              value={reasonForReplacement.stolenPoliceFileNumber || undefined}
               onChange={event =>
                 onChange({
                   ...reasonForReplacement,

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -55,7 +55,7 @@ export default function ReasonForReplacementForm({
         <>
           <FormControl isRequired paddingBottom="24px">
             <FormLabel>{`Date`}</FormLabel>
-            <Input type="date" value={date} onChange={event => setDate(event.target.value)} />
+            <Input type="date" />
           </FormControl>
 
           <FormControl paddingBottom="24px">
@@ -67,11 +67,11 @@ export default function ReasonForReplacementForm({
             </FormLabel>
             <Input
               placeholder={'eg. 04:00 pm'}
-              value={reasonForReplacement.lostTimestamp}
-              onChange={value =>
+              value={reasonForReplacement.lostTimestamp || ''}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  lostTimestamp: value,
+                  lostTimestamp: event.target.value,
                 })
               }
             />

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -82,11 +82,11 @@ export default function ReasonForReplacementForm({
             <FormLabel>{'Location'}</FormLabel>
             <Input
               placeholder={'eg. Library'}
-              value={reasonForReplacement.lostLocation}
-              onChange={value =>
+              value={reasonForReplacement.lostLocation || ''}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  lostLocation: value,
+                  lostLocation: event.target.value,
                 })
               }
             />
@@ -96,11 +96,11 @@ export default function ReasonForReplacementForm({
             <FormLabel>{'Event description'}</FormLabel>
             <Textarea
               placeholder={'Explain what happened.'}
-              value={reasonForReplacement.description}
-              onChange={value =>
+              value={reasonForReplacement.description || ''}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  description: value,
+                  description: event.target.value,
                 })
               }
             />
@@ -114,11 +114,11 @@ export default function ReasonForReplacementForm({
           <FormControl isRequired paddingBottom="24px">
             <FormLabel>{'Police file number'}</FormLabel>
             <Input
-              value={reasonForReplacement.stolenPoliceFileNumber}
-              onChange={value =>
+              value={reasonForReplacement.stolenPoliceFileNumber || 0}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  stolenPoliceFileNumber: value,
+                  stolenPoliceFileNumber: parseInt(event.target.value),
                 })
               }
             />
@@ -132,11 +132,11 @@ export default function ReasonForReplacementForm({
               </Box>
             </FormLabel>
             <Input
-              value={reasonForReplacement.stolenJurisdiction}
-              onChange={value =>
+              value={reasonForReplacement.stolenJurisdiction || ''}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  stolenJurisdiction: value,
+                  stolenJurisdiction: event.target.value,
                 })
               }
             />
@@ -150,11 +150,11 @@ export default function ReasonForReplacementForm({
               </Box>
             </FormLabel>
             <Input
-              value={reasonForReplacement.stolenPoliceOfficerName}
-              onChange={value =>
+              value={reasonForReplacement.stolenPoliceOfficerName || ''}
+              onChange={event =>
                 onChange({
                   ...reasonForReplacement,
-                  stolenPoliceOfficerName: value,
+                  stolenPoliceOfficerName: event.target.value,
                 })
               }
             />
@@ -168,11 +168,11 @@ export default function ReasonForReplacementForm({
           <FormLabel>{'Event description'}</FormLabel>
           <Textarea
             placeholder={'Explain what happened.'}
-            value={reasonForReplacement.description}
-            onChange={value =>
+            value={reasonForReplacement.description || ''}
+            onChange={event =>
               onChange({
                 ...reasonForReplacement,
-                description: value,
+                description: event.target.value,
               })
             }
           />

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -1,0 +1,183 @@
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  FormHelperText,
+  Box,
+  RadioGroup,
+  Radio,
+  Textarea,
+} from '@chakra-ui/react'; // Chakra UI
+import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
+import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types'; // Reason For Replacement Type
+
+type ReasonForReplacementProps = {
+  readonly reasonForReplacement: ReasonForReplacement;
+  readonly onChange: (updatedData: ReasonForReplacement) => void;
+};
+
+/**
+ * ReasonForReplacementForm Component for allowing users to edit reason for replacement information.
+ *
+ * @param {ReasonForReplacement} ReasonForReplacementForm Data Structure that holds all reason for replacement information for a client request.
+ * @param onChange Function that uses the updated values from form.
+ */
+export default function ReasonForReplacementForm({
+  reasonForReplacement,
+  onChange,
+}: ReasonForReplacementProps) {
+  return (
+    <>
+      <FormControl as="fieldset" paddingBottom="24px">
+        <FormLabel as="legend" marginBottom="8px">
+          {'Reason'}
+        </FormLabel>
+        <RadioGroup
+          value={reasonForReplacement.reason}
+          onChange={value =>
+            onChange({
+              ...reasonForReplacement,
+              reason: value as ReasonForReplacementEnum,
+            })
+          }
+        >
+          <Stack>
+            <Radio value={ReasonForReplacementEnum.Lost}>{'Lost'}</Radio>
+            <Radio value={ReasonForReplacementEnum.Stolen}>{'Stolen'}</Radio>
+            <Radio value={ReasonForReplacementEnum.Other}>{'Other'}</Radio>
+          </Stack>
+        </RadioGroup>
+      </FormControl>
+
+      {/* Conditionally render this section if Lost is selected as replacement reason */}
+      {reasonForReplacement.reason === ReasonForReplacementEnum.Lost && (
+        <>
+          <FormControl isRequired paddingBottom="24px">
+            <FormLabel>{`Date`}</FormLabel>
+            <Input type="date" value={date} onChange={event => setDate(event.target.value)} />
+          </FormControl>
+
+          <FormControl paddingBottom="24px">
+            <FormLabel>
+              {'Timestamp '}
+              <Box as="span" textStyle="body-regular">
+                {'(optional)'}
+              </Box>
+            </FormLabel>
+            <Input
+              placeholder={'eg. 04:00 pm'}
+              value={reasonForReplacement.lostTimestamp}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  lostTimestamp: value,
+                })
+              }
+            />
+            <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
+          </FormControl>
+
+          <FormControl isRequired paddingBottom="24px">
+            <FormLabel>{'Location'}</FormLabel>
+            <Input
+              placeholder={'eg. Library'}
+              value={reasonForReplacement.lostLocation}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  lostLocation: value,
+                })
+              }
+            />
+          </FormControl>
+
+          <FormControl isRequired>
+            <FormLabel>{'Event description'}</FormLabel>
+            <Textarea
+              placeholder={'Explain what happened.'}
+              value={reasonForReplacement.description}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  description: value,
+                })
+              }
+            />
+          </FormControl>
+        </>
+      )}
+
+      {/* Conditionally renders this section if Stolen is selected as replacement reason */}
+      {reasonForReplacement.reason === ReasonForReplacementEnum.Stolen && (
+        <>
+          <FormControl isRequired paddingBottom="24px">
+            <FormLabel>{'Police file number'}</FormLabel>
+            <Input
+              value={reasonForReplacement.stolenPoliceFileNumber}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  stolenPoliceFileNumber: value,
+                })
+              }
+            />
+          </FormControl>
+
+          <FormControl paddingBottom="24px">
+            <FormLabel>
+              {'Jurisdiction '}
+              <Box as="span" textStyle="body-regular">
+                {'(optional)'}
+              </Box>
+            </FormLabel>
+            <Input
+              value={reasonForReplacement.stolenJurisdiction}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  stolenJurisdiction: value,
+                })
+              }
+            />
+          </FormControl>
+
+          <FormControl>
+            <FormLabel>
+              {'Police officer name '}
+              <Box as="span" textStyle="body-regular">
+                {'(optional)'}
+              </Box>
+            </FormLabel>
+            <Input
+              value={reasonForReplacement.stolenPoliceOfficerName}
+              onChange={value =>
+                onChange({
+                  ...reasonForReplacement,
+                  stolenPoliceOfficerName: value,
+                })
+              }
+            />
+          </FormControl>
+        </>
+      )}
+
+      {/* Conditionally renders this section if Other is selected as replacement reason */}
+      {reasonForReplacement.reason === ReasonForReplacementEnum.Other && (
+        <FormControl isRequired>
+          <FormLabel>{'Event description'}</FormLabel>
+          <Textarea
+            placeholder={'Explain what happened.'}
+            value={reasonForReplacement.description}
+            onChange={value =>
+              onChange({
+                ...reasonForReplacement,
+                description: value,
+              })
+            }
+          />
+        </FormControl>
+      )}
+    </>
+  );
+}

--- a/components/admin/requests/modals/EditReasonForReplacementModal.tsx
+++ b/components/admin/requests/modals/EditReasonForReplacementModal.tsx
@@ -6,56 +6,32 @@ import {
   ModalFooter,
   ModalBody,
   Button,
-  FormControl,
-  FormLabel,
-  Input,
   useDisclosure,
   Text,
-  Stack,
-  FormHelperText,
   Box,
-  RadioGroup,
-  Radio,
-  Textarea,
 } from '@chakra-ui/react'; // Chakra UI
 import { useState, useEffect, SyntheticEvent, ReactNode } from 'react'; // React
-import { ReplacementData } from '@tools/components/admin/requests/reason-for-replacement-card'; // ReplacementData type
-import { formatDate } from '@lib/utils/format'; // Date formatter util
+import ReasonForReplacementForm from '../forms/ReasonForReplacementForm';
+import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types';
 
 type EditReasonForReplacementModalProps = {
-  readonly replacement: ReplacementData;
+  readonly reasonForReplacement: ReasonForReplacement;
   readonly children: ReactNode;
 };
 
 export default function EditReasonForReplacementModal({
-  replacement,
+  reasonForReplacement: currentReasonForReplacement,
   children,
 }: EditReasonForReplacementModalProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  // TODO: need to replace values with ReasonForReplacement enum when that is available
-  const [reason, setReason] = useState('');
-
-  //   Lost Information state
-  const [date, setDate] = useState(formatDate(new Date(), true));
-  const [timestamp, setTimestamp] = useState('');
-  const [location, setLocation] = useState<string | undefined>('');
-  const [eventDescription, setEventDescription] = useState<string | undefined>('');
-
-  //   Stolen Information state
-  const [policeFileNumber, setPoliceFileNumber] = useState('');
-  const [jurisdiction, setJurisdiction] = useState('');
-  const [policeOfficerName, setPoliceOfficerName] = useState('');
-
-  //   Other information state
-  const [otherEventDescription, setOtherEventDescription] = useState('');
+  const [reasonForReplacement, setReasonForReplacement] = useState<ReasonForReplacement>(
+    currentReasonForReplacement
+  );
 
   useEffect(() => {
-    setReason(replacement.reason);
-    setTimestamp(replacement.lostTimestamp);
-    setLocation(replacement.lostLocation || undefined);
-    setEventDescription(replacement.description || undefined);
-  }, [replacement]);
+    setReasonForReplacement(currentReasonForReplacement);
+  }, [currentReasonForReplacement, isOpen]);
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
@@ -77,117 +53,10 @@ export default function EditReasonForReplacementModal({
               </Text>
             </ModalHeader>
             <ModalBody paddingY="16px" paddingX="4px">
-              <FormControl as="fieldset" paddingBottom="24px">
-                <FormLabel as="legend" marginBottom="8px">
-                  {'Reason'}
-                </FormLabel>
-                <RadioGroup onChange={setReason} value={reason}>
-                  <Stack>
-                    <Radio value="Lost">{'Lost'}</Radio>
-                    <Radio value="Stolen">{'Stolen'}</Radio>
-                    <Radio value="Other">{'Other'}</Radio>
-                    {/* TODO: need to replace values with ReasonForReplacement enum when that is available */}
-                  </Stack>
-                </RadioGroup>
-              </FormControl>
-
-              {/* Conditionally render this section if Lost is selected as replacement reason */}
-              {reason === 'Lost' && (
-                <>
-                  <FormControl isRequired paddingBottom="24px">
-                    <FormLabel>{`Date`}</FormLabel>
-                    <Input
-                      type="date"
-                      value={date}
-                      onChange={event => setDate(event.target.value)}
-                    />
-                  </FormControl>
-
-                  <FormControl paddingBottom="24px">
-                    <FormLabel>
-                      {'Timestamp '}
-                      <Box as="span" textStyle="body-regular">
-                        {'(optional)'}
-                      </Box>
-                    </FormLabel>
-                    <Input
-                      placeholder={'eg. 04:00 pm'}
-                      value={timestamp}
-                      onChange={event => setTimestamp(event.target.value)}
-                    />
-                    <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
-                  </FormControl>
-
-                  <FormControl isRequired paddingBottom="24px">
-                    <FormLabel>{'Location'}</FormLabel>
-                    <Input
-                      placeholder={'eg. Library'}
-                      value={location}
-                      onChange={event => setLocation(event.target.value)}
-                    />
-                  </FormControl>
-
-                  <FormControl isRequired>
-                    <FormLabel>{'Event description'}</FormLabel>
-                    <Textarea
-                      placeholder={'Explain what happened.'}
-                      value={eventDescription}
-                      onChange={event => setEventDescription(event.target.value)}
-                    />
-                  </FormControl>
-                </>
-              )}
-
-              {/* Conditionally renders this section if Stolen is selected as replacement reason */}
-              {reason === 'Stolen' && (
-                <>
-                  <FormControl isRequired paddingBottom="24px">
-                    <FormLabel>{'Police file number'}</FormLabel>
-                    <Input
-                      value={policeFileNumber}
-                      onChange={event => setPoliceFileNumber(event.target.value)}
-                    />
-                  </FormControl>
-
-                  <FormControl paddingBottom="24px">
-                    <FormLabel>
-                      {'Jurisdiction '}
-                      <Box as="span" textStyle="body-regular">
-                        {'(optional)'}
-                      </Box>
-                    </FormLabel>
-                    <Input
-                      value={jurisdiction}
-                      onChange={event => setJurisdiction(event.target.value)}
-                    />
-                  </FormControl>
-
-                  <FormControl>
-                    <FormLabel>
-                      {'Police officer name '}
-                      <Box as="span" textStyle="body-regular">
-                        {'(optional)'}
-                      </Box>
-                    </FormLabel>
-                    <Input
-                      value={policeOfficerName}
-                      onChange={event => setPoliceOfficerName(event.target.value)}
-                    />
-                  </FormControl>
-                </>
-              )}
-
-              {/* Conditionally renders this section if Other is selected as replacement reason */}
-              {reason === 'Other' && (
-                <FormControl isRequired>
-                  <FormLabel>{'Event description'}</FormLabel>
-                  <Textarea
-                    placeholder={'Explain what happened.'}
-                    value={otherEventDescription}
-                    onChange={event => setOtherEventDescription(event.target.value)}
-                  />
-                </FormControl>
-              )}
+              <ReasonForReplacementForm
+                reasonForReplacement={reasonForReplacement}
+                onChange={setReasonForReplacement}
+              />
             </ModalBody>
             <ModalFooter paddingBottom="24px" paddingTop="8px">
               <Button colorScheme="gray" variant="solid" onClick={onClose}>

--- a/components/admin/requests/modals/EditReasonForReplacementModal.tsx
+++ b/components/admin/requests/modals/EditReasonForReplacementModal.tsx
@@ -11,8 +11,8 @@ import {
   Box,
 } from '@chakra-ui/react'; // Chakra UI
 import { useState, useEffect, SyntheticEvent, ReactNode } from 'react'; // React
-import ReasonForReplacementForm from '../forms/ReasonForReplacementForm';
-import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types';
+import ReasonForReplacementForm from '@components/admin/requests/forms/ReasonForReplacementForm'; // ReasonForReplacement form fields
+import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types'; // ReasonForReplacement Data type
 
 type EditReasonForReplacementModalProps = {
   readonly reasonForReplacement: ReasonForReplacement;

--- a/tools/components/admin/requests/forms/types.ts
+++ b/tools/components/admin/requests/forms/types.ts
@@ -1,4 +1,4 @@
-import { Application, Renewal } from '@lib/graphql/types'; // GraphQL Types
+import { Application, Renewal, Replacement } from '@lib/graphql/types'; // GraphQL Types
 
 // Permit Holder Information Object
 export type PermitHolderInformation = Pick<
@@ -38,4 +38,16 @@ export type PaymentDetails = Pick<
   | 'billingCity'
   | 'billingProvince'
   | 'billingPostalCode'
+>;
+
+// Reason For Replacement Object
+export type ReasonForReplacement = Pick<
+  Replacement,
+  | 'reason'
+  | 'lostTimestamp'
+  | 'lostLocation'
+  | 'description'
+  | 'stolenPoliceFileNumber'
+  | 'stolenJurisdiction'
+  | 'stolenPoliceOfficerName'
 >;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[New Replacement Request - Extract Reason for Replacement Card](https://www.notion.so/uwblueprintexecs/New-Replacement-Request-Extract-Reason-for-Replacement-Card-56986c1d5b0245deae4996e9860b7e3e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Extracted the form fields from the `EditReasonForReplacementModal` component (which is essentially all the content inside the `ModalBody`) into the new `ReasonForReplacementForm`  component
* Created `ReasonForReplacement` in `tools/components/admin/requests/forms/types.ts` to hold form fields data

Implementation closely follows Emilio and Anish's extraction PRs

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* See comment

## Demo


![uwblueprint-reason](https://user-images.githubusercontent.com/51224641/140678442-dc5894c9-7190-42d5-b642-b17658db221a.gif)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
