### PR TITLE
[Feature] Build Accounting Report Page Frontend

### DIFF
--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -4,13 +4,82 @@ import { Text, GridItem } from '@chakra-ui/react'; // Chakra UI
 import Layout from '@components/admin/Layout'; // Layout component
 import { Role } from '@lib/types'; // Role enum
 import { authorize } from '@tools/authorization'; // Page authorization
+// import { useState } from 'react';
+import { ChevronDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
+import { Button, Box, Flex, Menu, MenuButton, MenuList } from '@chakra-ui/react'; // Chakra UI
+
+type MenuTextProps = {
+  readonly name: string;
+  readonly value?: string;
+};
+
+function MenuText({ name, value }: MenuTextProps) {
+  return (
+    <>
+      <Text as="span" textStyle="button-semibold">
+        {`${name}: `}
+      </Text>
+      <Text as="span" textStyle="button-regular">
+        {value || 'All'}
+      </Text>
+    </>
+  );
+}
 
 // Internal home page
 export default function Reports() {
+  // const [startDate, setStartDate] = useState<Date>();
+  // const [endDate, setEndDate] = useState<Date>();
+
   return (
     <Layout>
       <GridItem colSpan={12}>
         <Text textStyle="display-xlarge">Reports</Text>
+      </GridItem>
+      <GridItem colSpan={12}>
+        <Box
+          border="1px solid"
+          borderColor="border.secondary"
+          borderRadius="12px"
+          bg="background.white"
+        >
+          <Box padding="24px 24px 0 24px">
+            <Flex marginBottom="20px">
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  variant="outline"
+                  rightIcon={<ChevronDownIcon />}
+                  marginRight="12px"
+                  color="text.secondary"
+                  borderColor="border.secondary"
+                  textAlign="left"
+                  width="420px"
+                >
+                  <MenuText name={`Start date`} />
+                </MenuButton>
+                <MenuList>
+                  {/* <DateRangePicker dateRange={dateRange} onDateChange={addDayToDateRange} /> */}
+                </MenuList>
+              </Menu>
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  variant="outline"
+                  rightIcon={<ChevronDownIcon />}
+                  marginRight="12px"
+                  color="text.secondary"
+                  borderColor="border.secondary"
+                  textAlign="left"
+                  width="420px"
+                >
+                  <MenuText name={`End date`} />
+                </MenuButton>
+                <MenuList></MenuList>
+              </Menu>
+            </Flex>
+          </Box>
+        </Box>
       </GridItem>
     </Layout>
   );

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -1,10 +1,9 @@
 import { GetServerSideProps } from 'next'; // Get server side props
 import { getSession } from 'next-auth/client'; // Session management
-import { Text, GridItem } from '@chakra-ui/react'; // Chakra UI
+import { Text, GridItem, Box, Flex, Input, Button, Spinner } from '@chakra-ui/react'; // Chakra UI
 import Layout from '@components/admin/Layout'; // Layout component
 import { Role } from '@lib/types'; // Role enum
 import { authorize } from '@tools/authorization'; // Page authorization
-import { Box, Flex, Input, Button, Spinner } from '@chakra-ui/react'; // Chakra UI
 import { DownloadIcon, SearchIcon } from '@chakra-ui/icons'; // Chakra UI icons
 import { useState } from 'react'; // React
 
@@ -60,7 +59,7 @@ export default function Reports() {
                   </Text>
                   <Input
                     type="date"
-                    placeholder="MM//DD/YYYY"
+                    placeholder="MM/DD/YYYY"
                     width="184px"
                     value={endDate}
                     onChange={event => {

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -59,7 +59,6 @@ export default function Reports() {
                   </Text>
                   <Input
                     type="date"
-                    placeholder="MM/DD/YYYY"
                     width="184px"
                     value={endDate}
                     onChange={event => {

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -7,6 +7,8 @@ import { authorize } from '@tools/authorization'; // Page authorization
 // import { useState } from 'react';
 import { ChevronDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import { Button, Box, Flex, Menu, MenuButton, MenuList } from '@chakra-ui/react'; // Chakra UI
+// import useDateRangePicker from '@tools/hooks/useDateRangePicker';
+import { DownloadIcon } from '@chakra-ui/icons'; // Chakra UI icons
 
 type MenuTextProps = {
   readonly name: string;
@@ -28,22 +30,21 @@ function MenuText({ name, value }: MenuTextProps) {
 
 // Internal home page
 export default function Reports() {
-  // const [startDate, setStartDate] = useState<Date>();
-  // const [endDate, setEndDate] = useState<Date>();
+  // const { dateRange, addDayToDateRange, dateRangeString } = useDateRangePicker();
 
   return (
     <Layout>
       <GridItem colSpan={12}>
-        <Text textStyle="display-xlarge">Reports</Text>
-      </GridItem>
-      <GridItem colSpan={12}>
+        <Flex justifyContent="space-between" alignItems="center" marginBottom="32px">
+          <Text textStyle="display-xlarge">Accountant Reports</Text>
+        </Flex>
         <Box
           border="1px solid"
           borderColor="border.secondary"
           borderRadius="12px"
           bg="background.white"
         >
-          <Box padding="24px 24px 0 24px">
+          <Box padding="24px">
             <Flex marginBottom="20px">
               <Menu>
                 <MenuButton
@@ -56,11 +57,9 @@ export default function Reports() {
                   textAlign="left"
                   width="420px"
                 >
-                  <MenuText name={`Start date`} />
+                  <MenuText name={`Start date`} value={'YYYY-MM-DD'} />
                 </MenuButton>
-                <MenuList>
-                  {/* <DateRangePicker dateRange={dateRange} onDateChange={addDayToDateRange} /> */}
-                </MenuList>
+                <MenuList>{/* <DatePicker onDateChange={addDayToDateRange} /> */}</MenuList>
               </Menu>
               <Menu>
                 <MenuButton
@@ -73,11 +72,22 @@ export default function Reports() {
                   textAlign="left"
                   width="420px"
                 >
-                  <MenuText name={`End date`} />
+                  <MenuText name={`End date`} value={'YYYY-MM-DD'} />
                 </MenuButton>
                 <MenuList></MenuList>
               </Menu>
             </Flex>
+            <Box padding="100px">
+              <Text textStyle="display-large">Processing Date:</Text>
+              <Text textStyle="display-large">01/01/2021 - 02/02/2021</Text>
+              <Flex justify="center">
+                <Text padding="16px" margin="auto" w="23em">
+                  Accounting Report has been successfully generated. Please download the report as a
+                  .csv by clicking the button below:
+                </Text>
+              </Flex>
+              <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
+            </Box>
           </Box>
         </Box>
       </GridItem>

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -4,33 +4,23 @@ import { Text, GridItem } from '@chakra-ui/react'; // Chakra UI
 import Layout from '@components/admin/Layout'; // Layout component
 import { Role } from '@lib/types'; // Role enum
 import { authorize } from '@tools/authorization'; // Page authorization
-// import { useState } from 'react';
-import { ChevronDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
-import { Button, Box, Flex, Menu, MenuButton, MenuList } from '@chakra-ui/react'; // Chakra UI
-// import useDateRangePicker from '@tools/hooks/useDateRangePicker';
-import { DownloadIcon } from '@chakra-ui/icons'; // Chakra UI icons
-
-type MenuTextProps = {
-  readonly name: string;
-  readonly value?: string;
-};
-
-function MenuText({ name, value }: MenuTextProps) {
-  return (
-    <>
-      <Text as="span" textStyle="button-semibold">
-        {`${name}: `}
-      </Text>
-      <Text as="span" textStyle="button-regular">
-        {value || 'All'}
-      </Text>
-    </>
-  );
-}
+import { Box, Flex, Input, Button, Spinner } from '@chakra-ui/react'; // Chakra UI
+import { DownloadIcon, SearchIcon } from '@chakra-ui/icons'; // Chakra UI icons
+import { useState } from 'react'; // React
 
 // Internal home page
 export default function Reports() {
   // const { dateRange, addDayToDateRange, dateRangeString } = useDateRangePicker();
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  //TODO: Remove after API hookup
+  function removeLoading() {
+    setTimeout(function () {
+      setLoading(false);
+    }, 3000);
+  }
 
   return (
     <Layout>
@@ -44,50 +34,78 @@ export default function Reports() {
           borderRadius="12px"
           bg="background.white"
         >
-          <Box padding="24px">
+          <Box padding="24px" justifyContent="space-between">
             <Flex marginBottom="20px">
-              <Menu>
-                <MenuButton
-                  as={Button}
-                  variant="outline"
-                  rightIcon={<ChevronDownIcon />}
-                  marginRight="12px"
-                  color="text.secondary"
-                  borderColor="border.secondary"
-                  textAlign="left"
-                  width="420px"
-                >
-                  <MenuText name={`Start date`} value={'YYYY-MM-DD'} />
-                </MenuButton>
-                <MenuList>{/* <DatePicker onDateChange={addDayToDateRange} /> */}</MenuList>
-              </Menu>
-              <Menu>
-                <MenuButton
-                  as={Button}
-                  variant="outline"
-                  rightIcon={<ChevronDownIcon />}
-                  marginRight="12px"
-                  color="text.secondary"
-                  borderColor="border.secondary"
-                  textAlign="left"
-                  width="420px"
-                >
-                  <MenuText name={`End date`} value={'YYYY-MM-DD'} />
-                </MenuButton>
-                <MenuList></MenuList>
-              </Menu>
+              <Box marginRight="10px">
+                <Flex>
+                  <Text textStyle="button-semibold" padding="8px 8px 0 0">
+                    Start Date:{' '}
+                  </Text>
+                  <Input
+                    type="date"
+                    width="184px"
+                    value={startDate}
+                    onChange={event => setStartDate(event.target.value)}
+                  />
+                </Flex>
+              </Box>
+              <Text textStyle="button-semibold" padding="8px">
+                {' '}
+                -{' '}
+              </Text>
+              <Box marginLeft="10px">
+                <Flex>
+                  <Text textStyle="button-semibold" padding="8px 8px 0 0">
+                    End Date:{' '}
+                  </Text>
+                  <Input
+                    type="date"
+                    width="184px"
+                    value={endDate}
+                    onChange={event => {
+                      setEndDate(event.target.value);
+                      setLoading(true);
+                      removeLoading();
+                    }}
+                  />
+                </Flex>
+              </Box>
             </Flex>
-            <Box padding="100px">
-              <Text textStyle="display-large">Processing Date:</Text>
-              <Text textStyle="display-large">01/01/2021 - 02/02/2021</Text>
-              <Flex justify="center">
-                <Text padding="16px" margin="auto" w="23em">
-                  Accounting Report has been successfully generated. Please download the report as a
-                  .csv by clicking the button below:
+            {startDate && endDate && loading == false ? (
+              <Box padding="150px">
+                <Text textStyle="display-large">Processing Date:</Text>
+                <Text textStyle="display-large">
+                  {startDate} - {endDate}
                 </Text>
-              </Flex>
-              <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
-            </Box>
+                <Flex justify="center">
+                  <Text padding="16px" margin="auto" w="23em">
+                    Accounting Report has been successfully generated. Please download the report as
+                    a .csv by clicking the button below:
+                  </Text>
+                </Flex>
+                <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
+              </Box>
+            ) : startDate && endDate && loading == true ? (
+              <Box padding="150px">
+                <Spinner
+                  thickness="4px"
+                  speed="0.65s"
+                  emptyColor="gray.200"
+                  color="blue.500"
+                  size="xl"
+                  paddingBottom="16px"
+                />
+                <Text textStyle="display-large">Fetching Data...</Text>
+              </Box>
+            ) : (
+              <Box padding="150px">
+                <SearchIcon w={20} h={20} />
+                <Text padding="12px 0 12px" textStyle="display-large">
+                  No Payments Found
+                </Text>
+                <Text fontSize="18px">Please select date range</Text>
+              </Box>
+            )}
           </Box>
         </Box>
       </GridItem>

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -60,6 +60,7 @@ export default function Reports() {
                   </Text>
                   <Input
                     type="date"
+                    placeholder="MM//DD/YYYY"
                     width="184px"
                     value={endDate}
                     onChange={event => {
@@ -72,7 +73,7 @@ export default function Reports() {
               </Box>
             </Flex>
             {startDate && endDate && loading == false ? (
-              <Box padding="150px">
+              <Box padding="153px">
                 <Text textStyle="display-large">Processing Date:</Text>
                 <Text textStyle="display-large">
                   {startDate} - {endDate}
@@ -86,7 +87,7 @@ export default function Reports() {
                 <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
               </Box>
             ) : startDate && endDate && loading == true ? (
-              <Box padding="150px">
+              <Box padding="218px">
                 <Spinner
                   thickness="4px"
                   speed="0.65s"
@@ -98,12 +99,12 @@ export default function Reports() {
                 <Text textStyle="display-large">Fetching Data...</Text>
               </Box>
             ) : (
-              <Box padding="150px">
-                <SearchIcon w={20} h={20} />
+              <Box padding="180px">
+                <SearchIcon w={20} h={20} color="#8C9196" />
                 <Text padding="12px 0 12px" textStyle="display-large">
                   No Payments Found
                 </Text>
-                <Text fontSize="18px">Please select date range</Text>
+                <Text fontSize="18px">Please select a date range</Text>
               </Box>
             )}
           </Box>

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -72,32 +72,34 @@ export default function Reports() {
                 </Flex>
               </Box>
             </Flex>
-            {startDate && endDate && loading == false ? (
-              <Box padding="153px">
-                <Text textStyle="display-large">Processing Date:</Text>
-                <Text textStyle="display-large">
-                  {startDate} - {endDate}
-                </Text>
-                <Flex justify="center">
-                  <Text padding="16px" margin="auto" w="23em">
-                    Accounting Report has been successfully generated. Please download the report as
-                    a .csv by clicking the button below:
+            {startDate && endDate ? (
+              loading ? (
+                <Box padding="218px">
+                  <Spinner
+                    thickness="4px"
+                    speed="0.65s"
+                    emptyColor="gray.200"
+                    color="blue.500"
+                    size="xl"
+                    paddingBottom="16px"
+                  />
+                  <Text textStyle="display-large">Fetching Data...</Text>
+                </Box>
+              ) : (
+                <Box padding="153px">
+                  <Text textStyle="display-large">Processing Date:</Text>
+                  <Text textStyle="display-large">
+                    {startDate} - {endDate}
                   </Text>
-                </Flex>
-                <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
-              </Box>
-            ) : startDate && endDate && loading == true ? (
-              <Box padding="218px">
-                <Spinner
-                  thickness="4px"
-                  speed="0.65s"
-                  emptyColor="gray.200"
-                  color="blue.500"
-                  size="xl"
-                  paddingBottom="16px"
-                />
-                <Text textStyle="display-large">Fetching Data...</Text>
-              </Box>
+                  <Flex justify="center">
+                    <Text padding="16px" margin="auto" w="23em">
+                      Accounting Report has been successfully generated. Please download the report
+                      as a .csv by clicking the button below:
+                    </Text>
+                  </Flex>
+                  <Button leftIcon={<DownloadIcon />}>Export as .CSV</Button>
+                </Box>
+              )
             ) : (
               <Box padding="180px">
                 <SearchIcon w={20} h={20} color="#8C9196" />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build Accounting Report Page Frontend](https://www.notion.so/uwblueprintexecs/Build-Accounting-Report-Page-Frontend-5ab4715f071548e699280dae5e3807a8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Had to switch date pickers with HTML date pickers 
* Added a setTimeout function to show loading state for 3 seconds before displaying the result screen

<img width="1678" alt="Screen Shot 2021-10-29 at 12 31 15 AM" src="https://user-images.githubusercontent.com/55823764/139375985-cf7b4680-d897-4586-86ca-d621b768dea1.png">

<img width="1671" alt="Screen Shot 2021-10-29 at 12 32 01 AM" src="https://user-images.githubusercontent.com/55823764/139376041-045a0264-05f7-46ae-922c-966014ddb70a.png">

<img width="1670" alt="Screen Shot 2021-10-29 at 12 32 21 AM" src="https://user-images.githubusercontent.com/55823764/139376073-8c89098a-f603-4478-a7fe-debb6423763f.png">

## Demo
![date-picker-demo](https://user-images.githubusercontent.com/55823764/139376219-b8b82269-3438-49e8-b2c2-c33eb0fa962f.gif)

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Switching date pickers changed the design of the Report box as well as the formatting of the date when displayed ( dashed instead of slashes)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
