### PR TITLE
[Improvement] Add ability to search with part of name/substring

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -67,19 +67,19 @@ export const applicants: Resolver = async (_parent, { filter }, { prisma }) => {
       if (firstSearch && middleSearch && lastSearch) {
         nameFilters = {
           AND: [
-            { firstName: { equals: firstSearch, mode: 'insensitive' } },
-            { middleName: { equals: middleSearch, mode: 'insensitive' } },
-            { lastName: { equals: lastSearch, mode: 'insensitive' } },
+            { firstName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: middleSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: lastSearch, mode: 'insensitive' } },
           ],
         };
         // If there are only two search elements, second element can correspond to either the middle or last name
         // search by first AND (middle OR last)
       } else if (firstSearch && middleSearch) {
         nameFilters = {
-          firstName: { equals: firstSearch, mode: 'insensitive' },
+          firstName: { startsWith: firstSearch, mode: 'insensitive' },
           OR: [
-            { middleName: { equals: middleSearch, mode: 'insensitive' } },
-            { lastName: { equals: middleSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: middleSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: middleSearch, mode: 'insensitive' } },
           ],
         };
         // If there is only one search element, it can correspond to the first, middle or last name
@@ -87,9 +87,9 @@ export const applicants: Resolver = async (_parent, { filter }, { prisma }) => {
       } else {
         nameFilters = {
           OR: [
-            { firstName: { equals: firstSearch, mode: 'insensitive' } },
-            { middleName: { equals: firstSearch, mode: 'insensitive' } },
-            { lastName: { equals: firstSearch, mode: 'insensitive' } },
+            { firstName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: firstSearch, mode: 'insensitive' } },
           ],
         };
       }

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -69,19 +69,19 @@ export const applications: Resolver = async (_parent, { filter }, { prisma }) =>
       if (firstSearch && middleSearch && lastSearch) {
         nameFilters = {
           AND: [
-            { firstName: { equals: firstSearch, mode: 'insensitive' } },
-            { middleName: { equals: middleSearch, mode: 'insensitive' } },
-            { lastName: { equals: lastSearch, mode: 'insensitive' } },
+            { firstName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: middleSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: lastSearch, mode: 'insensitive' } },
           ],
         };
         // If there are only two search elements, second element can correspond to either the middle or last name
         // search by first AND (middle OR last)
       } else if (firstSearch && middleSearch) {
         nameFilters = {
-          firstName: { equals: firstSearch, mode: 'insensitive' },
+          firstName: { startsWith: firstSearch, mode: 'insensitive' },
           OR: [
-            { middleName: { equals: middleSearch, mode: 'insensitive' } },
-            { lastName: { equals: middleSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: middleSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: middleSearch, mode: 'insensitive' } },
           ],
         };
         // If there is only one search element, it can correspond to the first, middle or last name
@@ -89,9 +89,9 @@ export const applications: Resolver = async (_parent, { filter }, { prisma }) =>
       } else {
         nameFilters = {
           OR: [
-            { firstName: { equals: firstSearch, mode: 'insensitive' } },
-            { middleName: { equals: firstSearch, mode: 'insensitive' } },
-            { lastName: { equals: firstSearch, mode: 'insensitive' } },
+            { firstName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { middleName: { startsWith: firstSearch, mode: 'insensitive' } },
+            { lastName: { startsWith: firstSearch, mode: 'insensitive' } },
           ],
         };
       }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add ability to search with part of name/substring](https://www.notion.so/uwblueprintexecs/Add-ability-to-search-with-part-of-name-substring-9a5cd7aa010c412a8373e90c676b4a65)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Quick fix: change `equals` to `startsWith` in applicants and applications resolvers

### Before

![rcd4](https://user-images.githubusercontent.com/55164714/139159631-bbf2a6f4-4fff-4dc9-93d8-6f5d61c36d3f.gif)
***
### After

![rcd5](https://user-images.githubusercontent.com/55164714/139159638-57b6490c-8faf-4659-8d0c-044c811e2dc4.gif)
<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* This change is for first, middle, and last name so a search for `"App T"` will match `Applicant Three` but not `Applicant One`


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
