### PR TITLE
[Feature] Hookup permit holder typeahead component

### DIFF
--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -17,9 +17,11 @@ type Props<T extends TypeaheadModel> = Pick<
   | 'isLoading' // boolean to indicate if query is loading
   | 'onSearch' // function to execute query when text is entered in input field
   | 'renderMenuItemChildren' // function to format each result in the menu
+  | 'labelKey'
 > & {
   results: Array<T>; // array of results to display in the typeahead menu
   placeholder: string; // placeholder text
+  setSelected: (selected: T | undefined) => void; // record selected item
 };
 
 /**
@@ -28,7 +30,15 @@ type Props<T extends TypeaheadModel> = Pick<
  * @returns Typeahead component which can be used to search with any query
  */
 export default function Typeahead<T extends TypeaheadModel>(props: Required<Props<T>>) {
-  const { isLoading, onSearch, renderMenuItemChildren, results, placeholder } = props;
+  const {
+    isLoading,
+    onSearch,
+    renderMenuItemChildren,
+    labelKey,
+    results,
+    placeholder,
+    setSelected,
+  } = props;
   const filterBy = () => true;
 
   return (
@@ -39,6 +49,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
         isLoading={isLoading}
         minLength={3}
         onSearch={onSearch}
+        labelKey={labelKey}
         options={results}
         placeholder={placeholder}
         emptyLabel="No results found."
@@ -48,6 +59,9 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
             width: '466px',
             height: '44px',
           },
+        }}
+        onChange={selected => {
+          selected.length > 0 ? setSelected(selected[0]) : setSelected(undefined);
         }}
         renderMenuItemChildren={renderMenuItemChildren}
         renderMenu={(results, menuProps, props) => {

--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -9,7 +9,7 @@ import 'react-bootstrap-typeahead/css/Typeahead.css'; //Typeahead styling
 import Helmet from 'react-helmet'; // Helmet
 import 'bootstrap/dist/css/bootstrap.min.css'; //Bootstrap styling
 import { Center, Divider, VStack, Text } from '@chakra-ui/layout'; // Chakra UI Layout
-import { Spacer } from '@chakra-ui/react'; //Chakra UI React
+import { Spacer, Spinner } from '@chakra-ui/react'; //Chakra UI React
 
 // Typeahead props
 type Props<T extends TypeaheadModel> = Pick<
@@ -59,6 +59,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
                 {results.length === 0 ? (
                   isLoading ? (
                     <Center height="80px">
+                      <Spinner color="primary" mr="8px" />
                       <Text textStyle="body-regular" color="secondary">
                         Searching...
                       </Text>

--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -17,7 +17,7 @@ type Props<T extends TypeaheadModel> = Pick<
   | 'isLoading' // boolean to indicate if query is loading
   | 'onSearch' // function to execute query when text is entered in input field
   | 'renderMenuItemChildren' // function to format each result in the menu
-  | 'labelKey'
+  | 'labelKey' // string used for searching and rendering typeahead results
 > & {
   results: Array<T>; // array of results to display in the typeahead menu
   placeholder: string; // placeholder text

--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -21,7 +21,7 @@ type Props<T extends TypeaheadModel> = Pick<
 > & {
   results: Array<T>; // array of results to display in the typeahead menu
   placeholder: string; // placeholder text
-  setSelected: (selected: T | undefined) => void; // record selected item
+  onSelected: (selected: T | undefined) => void; // record selected item
 };
 
 /**
@@ -37,7 +37,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
     labelKey,
     results,
     placeholder,
-    setSelected,
+    onSelected,
   } = props;
   const filterBy = () => true;
 
@@ -46,7 +46,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
       <AsyncTypeahead
         filterBy={filterBy}
         id="async-typeahead"
-        isLoading={false}
+        isLoading={false} // always false to hide spinner in input field when loading
         minLength={3}
         onSearch={onSearch}
         labelKey={labelKey}
@@ -61,7 +61,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
           },
         }}
         onChange={selected => {
-          selected.length > 0 ? setSelected(selected[0]) : setSelected(undefined);
+          selected.length > 0 ? onSelected(selected[0]) : onSelected(undefined);
         }}
         renderMenuItemChildren={renderMenuItemChildren}
         renderMenu={(results, menuProps, props) => {

--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -46,7 +46,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
       <AsyncTypeahead
         filterBy={filterBy}
         id="async-typeahead"
-        isLoading={isLoading}
+        isLoading={false}
         minLength={3}
         onSearch={onSearch}
         labelKey={labelKey}

--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -21,7 +21,7 @@ type Props<T extends TypeaheadModel> = Pick<
 > & {
   results: Array<T>; // array of results to display in the typeahead menu
   placeholder: string; // placeholder text
-  onSelected: (selected: T | undefined) => void; // record selected item
+  onSelect: (selected: T | undefined) => void; // record selected item
 };
 
 /**
@@ -30,15 +30,8 @@ type Props<T extends TypeaheadModel> = Pick<
  * @returns Typeahead component which can be used to search with any query
  */
 export default function Typeahead<T extends TypeaheadModel>(props: Required<Props<T>>) {
-  const {
-    isLoading,
-    onSearch,
-    renderMenuItemChildren,
-    labelKey,
-    results,
-    placeholder,
-    onSelected,
-  } = props;
+  const { isLoading, onSearch, renderMenuItemChildren, labelKey, results, placeholder, onSelect } =
+    props;
   const filterBy = () => true;
 
   return (
@@ -61,7 +54,7 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
           },
         }}
         onChange={selected => {
-          selected.length > 0 ? onSelected(selected[0]) : onSelected(undefined);
+          selected.length > 0 ? onSelect(selected[0]) : onSelect(undefined);
         }}
         renderMenuItemChildren={renderMenuItemChildren}
         renderMenu={(results, menuProps, props) => {

--- a/components/admin/permit-holders/PermitHolderTypeahead.tsx
+++ b/components/admin/permit-holders/PermitHolderTypeahead.tsx
@@ -12,18 +12,18 @@ import { useState } from 'react'; // React
 
 // Permit Holder Typeahead props
 type Props = {
-  setSelected: (selected: PermitHolder | undefined) => void; // record selected permit holder
+  onSelected: (selected: PermitHolder | undefined) => void; // handle selected permit holder
 };
 
 /**
- * Typeahead component to search for permit holders via asyncronous queries
+ * Typeahead component to search for permit holders via asynchronous queries
  * @returns Permit holder typeahead component to search for permit holders
  */
 export default function PermitHolderTypeahead(props: Props) {
-  const { setSelected } = props;
+  const { onSelected } = props;
   const [isTypeaheadLoading, setIsTypeaheadLoading] = useState(false);
   const [permitHolderResults, setPermitHolderResults] = useState<PermitHolder[]>([]);
-  const [searchString, setSearchString] = useState<string>();
+  const [searchString, setSearchString] = useState('');
 
   // permit holders query
   useQuery<GetPermitHoldersResponse, GetPermitHoldersRequest>(GET_PERMIT_HOLDERS_QUERY, {
@@ -43,7 +43,7 @@ export default function PermitHolderTypeahead(props: Props) {
     },
   });
 
-  const searchPermitHolders = (query: string) => {
+  const handleSearch = (query: string) => {
     setIsTypeaheadLoading(true);
     setSearchString(query);
   };
@@ -51,22 +51,22 @@ export default function PermitHolderTypeahead(props: Props) {
   return (
     <Typeahead
       isLoading={isTypeaheadLoading}
-      onSearch={searchPermitHolders}
+      onSearch={handleSearch}
       renderMenuItemChildren={(option: PermitHolder) => {
         return (
-          <div>
+          <>
             <Text textStyle="body-regular" mt="8px" mb="4px" ml="4px">
               {option.firstName} {option.lastName}
             </Text>
             <Text textStyle="caption" textColor="text.secondary" mb="8px" ml="4px">
               Date of Birth: {formatDateYYYYMMDD(option.dateOfBirth)}
             </Text>
-          </div>
+          </>
         );
       }}
       labelKey={(option: PermitHolder) => `${option.firstName} ${option.lastName}`}
       results={permitHolderResults}
-      setSelected={setSelected}
+      onSelected={onSelected}
       placeholder="Search by user ID, first name or last name"
     />
   );

--- a/components/admin/permit-holders/PermitHolderTypeahead.tsx
+++ b/components/admin/permit-holders/PermitHolderTypeahead.tsx
@@ -1,26 +1,31 @@
-import { useQuery } from '@apollo/client';
-import { Text } from '@chakra-ui/layout';
-import Typeahead from '@components/Typeahead';
-import { formatDateYYYYMMDD } from '@lib/utils/format';
+import { useQuery } from '@apollo/client'; // Apollo
+import { Text } from '@chakra-ui/layout'; //Chakra UI
+import Typeahead from '@components/Typeahead'; // Typeahead component
+import { formatDateYYYYMMDD } from '@lib/utils/format'; // Date formatter util
 import {
   GetPermitHoldersRequest,
   GetPermitHoldersResponse,
   GET_PERMIT_HOLDERS_QUERY,
-} from '@tools/pages/admin/permit-holders/get-permit-holders';
-import { useState } from 'react';
+  PermitHolder,
+} from '@tools/pages/admin/permit-holders/get-permit-holders'; // Permit holders GQL query
+import { useState } from 'react'; // React
 
-type PermitHolderItem = {
-  label: string;
-  firstName: string;
-  lastName: string;
-  dateOfBirth: Date;
+// Permit Holder Typeahead props
+type Props = {
+  setSelected: (selected: PermitHolder | undefined) => void; // record selected permit holder
 };
 
-export default function PermitHolderTypeahead() {
+/**
+ * Typeahead component to search for permit holders via asyncronous queries
+ * @returns Permit holder typeahead component to search for permit holders
+ */
+export default function PermitHolderTypeahead(props: Props) {
+  const { setSelected } = props;
   const [isTypeaheadLoading, setIsTypeaheadLoading] = useState(false);
-  const [permitHolderResults, setPermitHolderResults] = useState<PermitHolderItem[]>([]);
+  const [permitHolderResults, setPermitHolderResults] = useState<PermitHolder[]>([]);
   const [searchString, setSearchString] = useState<string>();
 
+  // permit holders query
   useQuery<GetPermitHoldersResponse, GetPermitHoldersRequest>(GET_PERMIT_HOLDERS_QUERY, {
     variables: {
       filter: {
@@ -30,10 +35,7 @@ export default function PermitHolderTypeahead() {
     onCompleted: ({ applicants: { result } }) => {
       setPermitHolderResults(
         result.map(record => ({
-          label: record.firstName + ' ' + record.lastName,
-          firstName: record.firstName,
-          lastName: record.lastName,
-          dateOfBirth: record.dateOfBirth,
+          ...record,
         }))
       );
 
@@ -50,11 +52,11 @@ export default function PermitHolderTypeahead() {
     <Typeahead
       isLoading={isTypeaheadLoading}
       onSearch={searchPermitHolders}
-      renderMenuItemChildren={option => {
+      renderMenuItemChildren={(option: PermitHolder) => {
         return (
           <div>
             <Text textStyle="body-regular" mt="8px" mb="4px" ml="4px">
-              {option.label}
+              {option.firstName} {option.lastName}
             </Text>
             <Text textStyle="caption" textColor="text.secondary" mb="8px" ml="4px">
               Date of Birth: {formatDateYYYYMMDD(option.dateOfBirth)}
@@ -62,7 +64,9 @@ export default function PermitHolderTypeahead() {
           </div>
         );
       }}
+      labelKey={(option: PermitHolder) => `${option.firstName} ${option.lastName}`}
       results={permitHolderResults}
+      setSelected={setSelected}
       placeholder="Search by user ID, first name or last name"
     />
   );

--- a/components/admin/permit-holders/PermitHolderTypeahead.tsx
+++ b/components/admin/permit-holders/PermitHolderTypeahead.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react'; // React
 
 // Permit Holder Typeahead props
 type Props = {
-  onSelected: (selected: PermitHolder | undefined) => void; // handle selected permit holder
+  onSelect: (selected: PermitHolder | undefined) => void; // handle selected permit holder
 };
 
 /**
@@ -20,7 +20,7 @@ type Props = {
  * @returns Permit holder typeahead component to search for permit holders
  */
 export default function PermitHolderTypeahead(props: Props) {
-  const { onSelected } = props;
+  const { onSelect } = props;
   const [isTypeaheadLoading, setIsTypeaheadLoading] = useState(false);
   const [permitHolderResults, setPermitHolderResults] = useState<PermitHolder[]>([]);
   const [searchString, setSearchString] = useState('');
@@ -66,7 +66,7 @@ export default function PermitHolderTypeahead(props: Props) {
       }}
       labelKey={(option: PermitHolder) => `${option.firstName} ${option.lastName}`}
       results={permitHolderResults}
-      onSelected={onSelected}
+      onSelect={onSelect}
       placeholder="Search by user ID, first name or last name"
     />
   );

--- a/components/admin/permit-holders/PermitHolderTypeahead.tsx
+++ b/components/admin/permit-holders/PermitHolderTypeahead.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from '@apollo/client';
+import { Text } from '@chakra-ui/layout';
+import Typeahead from '@components/Typeahead';
+import { formatDateYYYYMMDD } from '@lib/utils/format';
+import {
+  GetPermitHoldersRequest,
+  GetPermitHoldersResponse,
+  GET_PERMIT_HOLDERS_QUERY,
+} from '@tools/pages/admin/permit-holders/get-permit-holders';
+import { useState } from 'react';
+
+type PermitHolderItem = {
+  label: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: Date;
+};
+
+export default function PermitHolderTypeahead() {
+  const [isTypeaheadLoading, setIsTypeaheadLoading] = useState(false);
+  const [permitHolderResults, setPermitHolderResults] = useState<PermitHolderItem[]>([]);
+  const [searchString, setSearchString] = useState<string>();
+
+  useQuery<GetPermitHoldersResponse, GetPermitHoldersRequest>(GET_PERMIT_HOLDERS_QUERY, {
+    variables: {
+      filter: {
+        search: searchString,
+      },
+    },
+    onCompleted: ({ applicants: { result } }) => {
+      setPermitHolderResults(
+        result.map(record => ({
+          label: record.firstName + ' ' + record.lastName,
+          firstName: record.firstName,
+          lastName: record.lastName,
+          dateOfBirth: record.dateOfBirth,
+        }))
+      );
+
+      setIsTypeaheadLoading(false);
+    },
+  });
+
+  const searchPermitHolders = (query: string) => {
+    setIsTypeaheadLoading(true);
+    setSearchString(query);
+  };
+
+  return (
+    <Typeahead
+      isLoading={isTypeaheadLoading}
+      onSearch={searchPermitHolders}
+      renderMenuItemChildren={option => {
+        return (
+          <div>
+            <Text textStyle="body-regular" mt="8px" mb="4px" ml="4px">
+              {option.label}
+            </Text>
+            <Text textStyle="caption" textColor="text.secondary" mb="8px" ml="4px">
+              Date of Birth: {formatDateYYYYMMDD(option.dateOfBirth)}
+            </Text>
+          </div>
+        );
+      }}
+      results={permitHolderResults}
+      placeholder="Search by user ID, first name or last name"
+    />
+  );
+}

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -38,6 +38,16 @@ export const formatDate = (date: Date, dateInput = false): string => {
 };
 
 /**
+ * Format date to be in YYYY-MM-DD format
+ * TODO: verify timezone bug
+ * @param {Date} date date to be formatted
+ * @returns {string} formatted date
+ */
+export const formatDateYYYYMMDD = (date: Date): string => {
+  return new Date(date).toISOString().split('T')[0];
+};
+
+/**
  * Format date to be in written in the following format: Sep 11 2021, 03:07 pm
  * @param {Date} date date to be formatted
  * @returns {string} formatted verbose date

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -39,7 +39,6 @@ export const formatDate = (date: Date, dateInput = false): string => {
 
 /**
  * Format date to be in YYYY-MM-DD format
- * TODO: verify timezone bug
  * @param {Date} date date to be formatted
  * @returns {string} formatted date
  */

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -39,6 +39,7 @@ import useDebounce from '@tools/hooks/useDebounce'; // Debounce hook
 import { Column } from 'react-table';
 import { formatDateVerbose } from '@lib/utils/format'; // Verbose date formatter util
 import PermitHolderTypeahead from '@components/admin/permit-holders/PermitHolderTypeahead';
+import { PermitHolder } from '@tools/pages/admin/permit-holders/get-permit-holders';
 
 // Map uppercase enum strings to lowercase
 const permitTypeString: Record<string, string> = {
@@ -192,6 +193,9 @@ export default function Requests() {
     setPageNumber(0);
   }, [statusFilter, permitTypeFilter, requestTypeFilter, debouncedSearchFilter, sortOrder]);
 
+  //TODO: remove
+  const [, setSelectedPermitHolder] = useState<PermitHolder>();
+
   return (
     <Layout>
       <GridItem colSpan={12}>
@@ -214,8 +218,9 @@ export default function Requests() {
             </MenuList>
           </Menu> */}
         </Flex>
+        {/* TODO: remove */}
         <Flex mb="30px">
-          <PermitHolderTypeahead />
+          <PermitHolderTypeahead setSelected={setSelectedPermitHolder} />
         </Flex>
         <Box border="1px solid" borderColor="border.secondary" borderRadius="12px" bgColor="white">
           <Tabs marginBottom="20px">

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -38,8 +38,6 @@ import { ApplicationStatus, PermitType, Role } from '@lib/graphql/types'; //Grap
 import useDebounce from '@tools/hooks/useDebounce'; // Debounce hook
 import { Column } from 'react-table';
 import { formatDateVerbose } from '@lib/utils/format'; // Verbose date formatter util
-import PermitHolderTypeahead from '@components/admin/permit-holders/PermitHolderTypeahead';
-import { PermitHolder } from '@tools/pages/admin/permit-holders/get-permit-holders';
 
 // Map uppercase enum strings to lowercase
 const permitTypeString: Record<string, string> = {
@@ -193,9 +191,6 @@ export default function Requests() {
     setPageNumber(0);
   }, [statusFilter, permitTypeFilter, requestTypeFilter, debouncedSearchFilter, sortOrder]);
 
-  //TODO: remove
-  const [, setSelectedPermitHolder] = useState<PermitHolder>();
-
   return (
     <Layout>
       <GridItem colSpan={12}>
@@ -217,10 +212,6 @@ export default function Requests() {
               <MenuItem>Renewal Request</MenuItem>
             </MenuList>
           </Menu> */}
-        </Flex>
-        {/* TODO: remove */}
-        <Flex mb="30px">
-          <PermitHolderTypeahead setSelected={setSelectedPermitHolder} />
         </Flex>
         <Box border="1px solid" borderColor="border.secondary" borderRadius="12px" bgColor="white">
           <Tabs marginBottom="20px">

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -38,6 +38,7 @@ import { ApplicationStatus, PermitType, Role } from '@lib/graphql/types'; //Grap
 import useDebounce from '@tools/hooks/useDebounce'; // Debounce hook
 import { Column } from 'react-table';
 import { formatDateVerbose } from '@lib/utils/format'; // Verbose date formatter util
+import PermitHolderTypeahead from '@components/admin/permit-holders/PermitHolderTypeahead';
 
 // Map uppercase enum strings to lowercase
 const permitTypeString: Record<string, string> = {
@@ -212,6 +213,9 @@ export default function Requests() {
               <MenuItem>Renewal Request</MenuItem>
             </MenuList>
           </Menu> */}
+        </Flex>
+        <Flex mb="30px">
+          <PermitHolderTypeahead />
         </Flex>
         <Box border="1px solid" borderColor="border.secondary" borderRadius="12px" bgColor="white">
           <Tabs marginBottom="20px">


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Typeahead component hookup](https://www.notion.so/uwblueprintexecs/Typeahead-component-hookup-4d8df6195c554ac1ad7dff7d8cfea260)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Uses `Typeahead` component, and uses existing permit holders GQL query to search for permit holders
* A `setSelected` prop is required which allows the component to return the selected permit holder
* Two new props were added to the `Typeahead` component
* Added spinner to loading state (this loading state is pretty rare, the attached screen recording was taken by deliberately stalling the query)

https://user-images.githubusercontent.com/35577524/141050502-49cbc813-85a5-48a0-8192-3923db91e05f.mov

https://user-images.githubusercontent.com/35577524/141051638-907a7f22-ca97-4ab8-a0d5-84b4fd84d6e7.mov


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Currently testing and demonstrating use of the component in the admin `index.tsx`. This will be removed before merging.
* The spinner in right side of the input field when loading is no longer there, the videos are outdated


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
