### PR TITLE
[Feature] Build Replacement Request Frontend

### DIFF
--- a/components/admin/requests/forms/PaymentDetailsForm.tsx
+++ b/components/admin/requests/forms/PaymentDetailsForm.tsx
@@ -101,7 +101,7 @@ export default function PaymentDetailsForm({
             <FormControl>
               <FormLabel>
                 {'Donation '}
-                <Box as="span" textStyle="body-regular">
+                <Box as="span" textStyle="body-regular" fontSize="sm">
                   {'(optional)'}
                 </Box>
               </FormLabel>
@@ -179,7 +179,7 @@ export default function PaymentDetailsForm({
             <FormControl paddingBottom="24px">
               <FormLabel>
                 {'Address line 2 '}
-                <Box as="span" textStyle="body-regular">
+                <Box as="span" textStyle="body-regular" fontSize="sm">
                   {'(optional)'}
                 </Box>
               </FormLabel>
@@ -212,7 +212,7 @@ export default function PaymentDetailsForm({
               </FormControl>
 
               <FormControl isRequired>
-                <FormLabel>{'Province / territory'}</FormLabel>
+                <FormLabel>{'Province / Territory'}</FormLabel>
                 <Select
                   placeholder="Select province / territory"
                   value={shippingProvince || undefined}
@@ -303,7 +303,7 @@ export default function PaymentDetailsForm({
             <FormControl paddingBottom="24px">
               <FormLabel>
                 {'Address line 2 '}
-                <Box as="span" textStyle="body-regular">
+                <Box as="span" textStyle="body-regular" fontSize="sm">
                   {'(optional)'}
                 </Box>
               </FormLabel>
@@ -336,7 +336,7 @@ export default function PaymentDetailsForm({
               </FormControl>
 
               <FormControl>
-                <FormLabel>{'Province / territory'}</FormLabel>
+                <FormLabel>{'Province / Territory'}</FormLabel>
                 <Select
                   placeholder="Select province / territory"
                   value={billingProvince || undefined}

--- a/components/admin/requests/forms/PermitHolderInformationForm.tsx
+++ b/components/admin/requests/forms/PermitHolderInformationForm.tsx
@@ -89,7 +89,7 @@ export default function PermitHolderInformationForm({
           <FormControl>
             <FormLabel>
               {'Email address '}
-              <Box as="span" textStyle="body-regular">
+              <Box as="span" textStyle="body-regular" fontSize="sm">
                 {'(optional)'}
               </Box>
             </FormLabel>
@@ -137,7 +137,7 @@ export default function PermitHolderInformationForm({
         <FormControl paddingBottom="24px">
           <FormLabel>
             {'Address line 2 '}
-            <Box as="span" textStyle="caption">
+            <Box as="span" textStyle="caption" fontSize="sm">
               {'(optional)'}
             </Box>
           </FormLabel>

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -83,7 +83,7 @@ export default function ReasonForReplacementForm({
 
             <FormControl paddingBottom="24px">
               <FormLabel>
-                {'Time stamp '}
+                {'Timestamp '}
                 <Box as="span" textStyle="body-regular" fontSize="sm">
                   {'(optional)'}
                 </Box>
@@ -110,7 +110,7 @@ export default function ReasonForReplacementForm({
                   });
                 }}
               />
-              <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
+              <FormHelperText color="text.seconday">{'Example: HH:MM AM/PM'}</FormHelperText>
             </FormControl>
           </SimpleGrid>
 

--- a/components/admin/requests/forms/ReasonForReplacementForm.tsx
+++ b/components/admin/requests/forms/ReasonForReplacementForm.tsx
@@ -8,6 +8,7 @@ import {
   RadioGroup,
   Radio,
   Textarea,
+  SimpleGrid,
 } from '@chakra-ui/react'; // Chakra UI
 import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
 import { formatDate } from '@lib/utils/format'; // Date formatter util
@@ -30,7 +31,7 @@ export default function ReasonForReplacementForm({
 }: ReasonForReplacementProps) {
   return (
     <>
-      <FormControl as="fieldset" paddingBottom="24px">
+      <FormControl isRequired as="fieldset" paddingBottom="24px">
         <FormLabel as="legend" marginBottom="8px">
           {'Reason'}
         </FormLabel>
@@ -54,68 +55,68 @@ export default function ReasonForReplacementForm({
       {/* Conditionally render this section if Lost is selected as replacement reason */}
       {reasonForReplacement.reason === ReasonForReplacementEnum.Lost && (
         <>
-          <FormControl isRequired paddingBottom="24px">
-            <FormLabel>{`Date`}</FormLabel>
-            <Input
-              type="date"
-              value={
-                reasonForReplacement.lostTimestamp
-                  ? formatDate(new Date(reasonForReplacement.lostTimestamp), true)
-                  : ''
-              }
-              onChange={event => {
-                const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
-                updatedlostTimestamp.setFullYear(parseInt(event.target.value.substring(0, 4)));
-                updatedlostTimestamp.setMonth(parseInt(event.target.value.substring(5, 7)) - 1);
-                updatedlostTimestamp.setDate(parseInt(event.target.value.substring(8, 10)));
+          <SimpleGrid columns={[1, 1, 1, 2]} spacing="32px">
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{`Date`}</FormLabel>
+              <Input
+                type="date"
+                value={
+                  reasonForReplacement.lostTimestamp
+                    ? formatDate(new Date(reasonForReplacement.lostTimestamp), true)
+                    : ''
+                }
+                onChange={event => {
+                  const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
+                  updatedlostTimestamp.setFullYear(parseInt(event.target.value.substring(0, 4)));
+                  updatedlostTimestamp.setMonth(parseInt(event.target.value.substring(5, 7)) - 1);
+                  updatedlostTimestamp.setDate(parseInt(event.target.value.substring(8, 10)));
 
-                onChange({
-                  ...reasonForReplacement,
-                  lostTimestamp: Date.parse(updatedlostTimestamp.toString())
-                    ? updatedlostTimestamp
-                    : reasonForReplacement.lostTimestamp,
-                });
-              }}
-            />
-          </FormControl>
+                  onChange({
+                    ...reasonForReplacement,
+                    lostTimestamp: Date.parse(updatedlostTimestamp.toString())
+                      ? updatedlostTimestamp
+                      : reasonForReplacement.lostTimestamp,
+                  });
+                }}
+              />
+            </FormControl>
 
-          <FormControl paddingBottom="24px">
-            <FormLabel>
-              {'Timestamp '}
-              <Box as="span" textStyle="body-regular">
-                {'(optional)'}
-              </Box>
-            </FormLabel>
-            <Input
-              placeholder={'eg. 04:00 pm'}
-              type="time"
-              value={
-                new Date(reasonForReplacement.lostTimestamp).toLocaleTimeString('en-US', {
-                  hour12: false,
-                  hour: '2-digit',
-                  minute: '2-digit',
-                }) || ''
-              }
-              onChange={event => {
-                const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
-                updatedlostTimestamp.setHours(parseInt(event.target.value.substring(0, 2)));
-                updatedlostTimestamp.setMinutes(parseInt(event.target.value.substring(3, 5)));
+            <FormControl paddingBottom="24px">
+              <FormLabel>
+                {'Time stamp '}
+                <Box as="span" textStyle="body-regular" fontSize="sm">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <Input
+                type="time"
+                value={
+                  new Date(reasonForReplacement.lostTimestamp).toLocaleTimeString('en-US', {
+                    hour12: false,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  }) || ''
+                }
+                onChange={event => {
+                  const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
+                  updatedlostTimestamp.setHours(parseInt(event.target.value.substring(0, 2)));
+                  updatedlostTimestamp.setMinutes(parseInt(event.target.value.substring(3, 5)));
 
-                onChange({
-                  ...reasonForReplacement,
-                  lostTimestamp: Date.parse(updatedlostTimestamp.toString())
-                    ? updatedlostTimestamp
-                    : reasonForReplacement.lostTimestamp,
-                });
-              }}
-            />
-            <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
-          </FormControl>
+                  onChange({
+                    ...reasonForReplacement,
+                    lostTimestamp: Date.parse(updatedlostTimestamp.toString())
+                      ? updatedlostTimestamp
+                      : reasonForReplacement.lostTimestamp,
+                  });
+                }}
+              />
+              <FormHelperText color="text.seconday">{'hh:mm am/pm'}</FormHelperText>
+            </FormControl>
+          </SimpleGrid>
 
           <FormControl isRequired paddingBottom="24px">
             <FormLabel>{'Location'}</FormLabel>
             <Input
-              placeholder={'eg. Library'}
               value={reasonForReplacement.lostLocation || ''}
               onChange={event =>
                 onChange({
@@ -129,7 +130,6 @@ export default function ReasonForReplacementForm({
           <FormControl isRequired>
             <FormLabel>{'Event description'}</FormLabel>
             <Textarea
-              placeholder={'Explain what happened.'}
               value={reasonForReplacement.description || ''}
               onChange={event =>
                 onChange({
@@ -145,54 +145,56 @@ export default function ReasonForReplacementForm({
       {/* Conditionally renders this section if Stolen is selected as replacement reason */}
       {reasonForReplacement.reason === ReasonForReplacementEnum.Stolen && (
         <>
-          <FormControl isRequired paddingBottom="24px">
-            <FormLabel>{'Police file number'}</FormLabel>
-            <Input
-              value={reasonForReplacement.stolenPoliceFileNumber || undefined}
-              onChange={event =>
-                onChange({
-                  ...reasonForReplacement,
-                  stolenPoliceFileNumber: parseInt(event.target.value),
-                })
-              }
-            />
-          </FormControl>
+          <SimpleGrid columns={[1, 1, 1, 1, 3]} spacing="26px">
+            <FormControl isRequired paddingBottom="24px">
+              <FormLabel>{'Police file number'}</FormLabel>
+              <Input
+                value={reasonForReplacement.stolenPoliceFileNumber || undefined}
+                onChange={event =>
+                  onChange({
+                    ...reasonForReplacement,
+                    stolenPoliceFileNumber: parseInt(event.target.value),
+                  })
+                }
+              />
+            </FormControl>
 
-          <FormControl paddingBottom="24px">
-            <FormLabel>
-              {'Jurisdiction '}
-              <Box as="span" textStyle="body-regular">
-                {'(optional)'}
-              </Box>
-            </FormLabel>
-            <Input
-              value={reasonForReplacement.stolenJurisdiction || ''}
-              onChange={event =>
-                onChange({
-                  ...reasonForReplacement,
-                  stolenJurisdiction: event.target.value,
-                })
-              }
-            />
-          </FormControl>
+            <FormControl paddingBottom="24px">
+              <FormLabel>
+                {'Jurisdiction '}
+                <Box as="span" textStyle="body-regular" fontSize="sm">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <Input
+                value={reasonForReplacement.stolenJurisdiction || ''}
+                onChange={event =>
+                  onChange({
+                    ...reasonForReplacement,
+                    stolenJurisdiction: event.target.value,
+                  })
+                }
+              />
+            </FormControl>
 
-          <FormControl>
-            <FormLabel>
-              {'Police officer name '}
-              <Box as="span" textStyle="body-regular">
-                {'(optional)'}
-              </Box>
-            </FormLabel>
-            <Input
-              value={reasonForReplacement.stolenPoliceOfficerName || ''}
-              onChange={event =>
-                onChange({
-                  ...reasonForReplacement,
-                  stolenPoliceOfficerName: event.target.value,
-                })
-              }
-            />
-          </FormControl>
+            <FormControl>
+              <FormLabel>
+                {'Police officer name '}
+                <Box as="span" textStyle="body-regular" fontSize="sm">
+                  {'(optional)'}
+                </Box>
+              </FormLabel>
+              <Input
+                value={reasonForReplacement.stolenPoliceOfficerName || ''}
+                onChange={event =>
+                  onChange({
+                    ...reasonForReplacement,
+                    stolenPoliceOfficerName: event.target.value,
+                  })
+                }
+              />
+            </FormControl>
+          </SimpleGrid>
         </>
       )}
 
@@ -201,7 +203,6 @@ export default function ReasonForReplacementForm({
         <FormControl isRequired>
           <FormLabel>{'Event description'}</FormLabel>
           <Textarea
-            placeholder={'Explain what happened.'}
             value={reasonForReplacement.description || ''}
             onChange={event =>
               onChange({

--- a/pages/requests/create-replacement.tsx
+++ b/pages/requests/create-replacement.tsx
@@ -63,7 +63,7 @@ export default function CreateReplacement() {
             {`New Replacement Request (User ID:`}
             <Box as="span" color="primary">
               {' '}
-              <Link href={`/admin/request/${permitHolderID}`} passHref>
+              <Link href={`/admin/request/${permitHolderID}`}>
                 <a>{permitHolderID}</a>
               </Link>
             </Box>
@@ -162,7 +162,7 @@ export default function CreateReplacement() {
                 User ID:
                 <Box as="span" color="primary">
                   {' '}
-                  <Link href={`/admin/request/${permitHolderID}`} passHref>
+                  <Link href={`/admin/request/${permitHolderID}`}>
                     <a>{permitHolderID}</a>
                   </Link>
                 </Box>

--- a/pages/requests/create-replacement.tsx
+++ b/pages/requests/create-replacement.tsx
@@ -2,16 +2,19 @@ import Layout from '@components/admin/Layout'; // Layout component
 import { Text, Box, Flex, Stack, Button, GridItem, Input } from '@chakra-ui/react'; // Chakra UI
 import { useState } from 'react'; // React
 import PermitHolderInformationForm from '@components/admin/requests/forms/PermitHolderInformationForm'; //Permit holder information form
-import { PermitHolderInformation } from '@tools/components/admin/requests/forms/types'; //Permit holder information type
+import {
+  PaymentDetails,
+  PermitHolderInformation,
+} from '@tools/components/admin/requests/forms/types'; //Permit holder information type
 import PaymentDetailsForm from '@components/admin/requests/forms/PaymentDetailsForm'; //Payment details form
-import { PaymentDetails } from '@tools/components/admin/requests/forms/types'; //Payment details type
 import { PaymentType, Province } from '@lib/graphql/types'; //GraphQL types
 import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types';
 import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
 import ReasonForReplacementForm from '@components/admin/requests/forms/ReasonForReplacementForm';
+import Link from 'next/link'; // Link component
 
 export default function CreateReplacement() {
-  const [permitHolderID] = useState('303240');
+  const [permitHolderID] = useState(303240);
   const [permitHolderInformation, setPermitHolderInformation] = useState<PermitHolderInformation>({
     firstName: '',
     lastName: '',
@@ -36,14 +39,14 @@ export default function CreateReplacement() {
   const [paymentDetails, setPaymentDetails] = useState<PaymentDetails>({
     paymentMethod: PaymentType.Mastercard,
     donationAmount: 25,
-    shippingAddressSameAsHomeAddress: true,
+    shippingAddressSameAsHomeAddress: false,
     shippingFullName: '',
     shippingAddressLine1: '',
     shippingAddressLine2: '',
     shippingCity: '',
     shippingProvince: Province.Bc,
     shippingPostalCode: '',
-    billingAddressSameAsHomeAddress: true,
+    billingAddressSameAsHomeAddress: false,
     billingFullName: '',
     billingAddressLine1: '',
     billingAddressLine2: '',
@@ -53,15 +56,19 @@ export default function CreateReplacement() {
   });
 
   return (
-    <Layout footer={false}>
+    <Layout>
       <GridItem display="flex" flexDirection="column" colSpan={12} paddingX="108px">
         <Flex>
           <Text textStyle="display-large">
             {`New Replacement Request (User ID:`}
-            <Box as="span" color="primary">
-              {' '}
-              {permitHolderID}
-            </Box>
+            <Link href={`/admin/request/${permitHolderID}`} passHref>
+              <Box as="span" color="primary">
+                {' '}
+                <Link href={`/admin/request/${permitHolderID}`} passHref>
+                  <a>{permitHolderID}</a>
+                </Link>
+              </Box>
+            </Link>
             )
           </Text>
         </Flex>
@@ -157,21 +164,25 @@ export default function CreateReplacement() {
                 User ID:
                 <Box as="span" color="primary">
                   {' '}
-                  {permitHolderID}
+                  <Link href={`/admin/request/${permitHolderID}`} passHref>
+                    <a>{permitHolderID}</a>
+                  </Link>
                 </Box>
               </Text>
             </Box>
             <Box>
-              <Button
-                bg="background.gray"
-                _hover={{ bg: 'background.grayHover' }}
-                color="black"
-                marginRight="20px"
-                height="48px"
-                width="149px"
-              >
-                <Text textStyle="button-semibold">Cancel</Text>
-              </Button>
+              <Link href={`/admin`}>
+                <Button
+                  bg="background.gray"
+                  _hover={{ bg: 'background.grayHover' }}
+                  color="black"
+                  marginRight="20px"
+                  height="48px"
+                  width="149px"
+                >
+                  <Text textStyle="button-semibold">Cancel</Text>
+                </Button>
+              </Link>
               <Button bg="primary" height="48px" width="180px">
                 <Text textStyle="button-semibold">Create Request</Text>
               </Button>

--- a/pages/requests/create-replacement.tsx
+++ b/pages/requests/create-replacement.tsx
@@ -1,0 +1,184 @@
+import Layout from '@components/admin/Layout'; // Layout component
+import { Text, Box, Flex, Stack, Button, GridItem, Input } from '@chakra-ui/react'; // Chakra UI
+import { useState } from 'react'; // React
+import PermitHolderInformationForm from '@components/admin/requests/forms/PermitHolderInformationForm'; //Permit holder information form
+import { PermitHolderInformation } from '@tools/components/admin/requests/forms/types'; //Permit holder information type
+import PaymentDetailsForm from '@components/admin/requests/forms/PaymentDetailsForm'; //Payment details form
+import { PaymentDetails } from '@tools/components/admin/requests/forms/types'; //Payment details type
+import { PaymentType, Province } from '@lib/graphql/types'; //GraphQL types
+import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types';
+import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
+import ReasonForReplacementForm from '@components/admin/requests/forms/ReasonForReplacementForm';
+
+export default function CreateReplacement() {
+  const [permitHolderID] = useState('303240');
+  const [permitHolderInformation, setPermitHolderInformation] = useState<PermitHolderInformation>({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    addressLine1: '',
+    addressLine2: '',
+    city: '',
+    postalCode: '',
+  });
+
+  const [reasonDetails, setReason] = useState<ReasonForReplacement>({
+    reason: ReasonForReplacementEnum.Other,
+    lostTimestamp: null,
+    lostLocation: null,
+    description: null,
+    stolenJurisdiction: null,
+    stolenPoliceFileNumber: null,
+    stolenPoliceOfficerName: null,
+  });
+
+  const [paymentDetails, setPaymentDetails] = useState<PaymentDetails>({
+    paymentMethod: PaymentType.Mastercard,
+    donationAmount: 25,
+    shippingAddressSameAsHomeAddress: true,
+    shippingFullName: '',
+    shippingAddressLine1: '',
+    shippingAddressLine2: '',
+    shippingCity: '',
+    shippingProvince: Province.Bc,
+    shippingPostalCode: '',
+    billingAddressSameAsHomeAddress: true,
+    billingFullName: '',
+    billingAddressLine1: '',
+    billingAddressLine2: '',
+    billingCity: '',
+    billingProvince: Province.Bc,
+    billingPostalCode: '',
+  });
+
+  return (
+    <Layout footer={false}>
+      <GridItem display="flex" flexDirection="column" colSpan={12} paddingX="108px">
+        <Flex>
+          <Text textStyle="display-large">
+            {`New Replacement Request (User ID:`}
+            <Box as="span" color="primary">
+              {' '}
+              {permitHolderID}
+            </Box>
+            )
+          </Text>
+        </Flex>
+        {/* Typeahead component */}
+        <GridItem paddingTop="32px">
+          <Box
+            border="1px solid"
+            borderColor="border.secondary"
+            borderRadius="12px"
+            bgColor="white"
+            paddingTop="32px"
+            paddingBottom="40px"
+            paddingX="40px"
+            align="left"
+          >
+            <Text textStyle="display-small-semibold" paddingBottom="20px">
+              {`Search Permit Holder`}
+            </Text>
+            <Input width="466px" />
+          </Box>
+        </GridItem>
+        {/* Permit Holder Information Form */}
+        <GridItem paddingTop="32px">
+          <Box
+            border="1px solid"
+            borderColor="border.secondary"
+            borderRadius="12px"
+            bgColor="white"
+            paddingTop="32px"
+            paddingBottom="40px"
+            paddingX="40px"
+            align="left"
+          >
+            <Text textStyle="display-small-semibold" paddingBottom="20px">
+              {`Permit Holder's Information`}
+            </Text>
+            <PermitHolderInformationForm
+              permitHolderInformation={permitHolderInformation}
+              onChange={setPermitHolderInformation}
+            />
+          </Box>
+        </GridItem>
+        {/* Reason For Replacement Form */}
+        <GridItem paddingTop="32px">
+          <Box
+            border="1px solid"
+            borderColor="border.secondary"
+            borderRadius="12px"
+            bgColor="white"
+            paddingTop="32px"
+            paddingBottom="40px"
+            paddingX="40px"
+            align="left"
+          >
+            <Text textStyle="display-small-semibold" paddingBottom="20px">
+              {`Reason For Replacement Form`}
+            </Text>
+            <ReasonForReplacementForm reasonForReplacement={reasonDetails} onChange={setReason} />
+          </Box>
+        </GridItem>
+        {/* Payment Details Form */}
+        <GridItem paddingTop="32px" paddingBottom="68px">
+          <Box
+            border="1px solid"
+            borderColor="border.secondary"
+            borderRadius="12px"
+            bgColor="white"
+            paddingTop="32px"
+            paddingBottom="40px"
+            paddingX="40px"
+            align="left"
+          >
+            <Text textStyle="display-small-semibold" paddingBottom="20px">
+              {`Payment, Shipping, and Billing Information`}
+            </Text>
+            <PaymentDetailsForm paymentInformation={paymentDetails} onChange={setPaymentDetails} />
+          </Box>
+        </GridItem>
+        {/* Footer */}
+        <Box
+          position="fixed"
+          left="0"
+          bottom="0"
+          right="0"
+          paddingY="20px"
+          paddingX="188px"
+          bgColor="white"
+          boxShadow="dark-lg"
+        >
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Box>
+              <Text textStyle="body-bold">
+                User ID:
+                <Box as="span" color="primary">
+                  {' '}
+                  {permitHolderID}
+                </Box>
+              </Text>
+            </Box>
+            <Box>
+              <Button
+                bg="background.gray"
+                _hover={{ bg: 'background.grayHover' }}
+                color="black"
+                marginRight="20px"
+                height="48px"
+                width="149px"
+              >
+                <Text textStyle="button-semibold">Cancel</Text>
+              </Button>
+              <Button bg="primary" height="48px" width="180px">
+                <Text textStyle="button-semibold">Create Request</Text>
+              </Button>
+            </Box>
+          </Stack>
+        </Box>
+      </GridItem>
+    </Layout>
+  );
+}

--- a/pages/requests/create-replacement.tsx
+++ b/pages/requests/create-replacement.tsx
@@ -124,7 +124,7 @@ export default function CreateReplacement() {
             align="left"
           >
             <Text textStyle="display-small-semibold" paddingBottom="20px">
-              {`Reason For Replacement Form`}
+              {`Reason For Replacement`}
             </Text>
             <ReasonForReplacementForm reasonForReplacement={reasonDetails} onChange={setReason} />
           </Box>

--- a/pages/requests/create-replacement.tsx
+++ b/pages/requests/create-replacement.tsx
@@ -61,14 +61,12 @@ export default function CreateReplacement() {
         <Flex>
           <Text textStyle="display-large">
             {`New Replacement Request (User ID:`}
-            <Link href={`/admin/request/${permitHolderID}`} passHref>
-              <Box as="span" color="primary">
-                {' '}
-                <Link href={`/admin/request/${permitHolderID}`} passHref>
-                  <a>{permitHolderID}</a>
-                </Link>
-              </Box>
-            </Link>
+            <Box as="span" color="primary">
+              {' '}
+              <Link href={`/admin/request/${permitHolderID}`} passHref>
+                <a>{permitHolderID}</a>
+              </Link>
+            </Box>
             )
           </Text>
         </Flex>
@@ -124,7 +122,7 @@ export default function CreateReplacement() {
             align="left"
           >
             <Text textStyle="display-small-semibold" paddingBottom="20px">
-              {`Reason For Replacement`}
+              {`Reason for Replacement`}
             </Text>
             <ReasonForReplacementForm reasonForReplacement={reasonDetails} onChange={setReason} />
           </Box>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[New Replacement Request Page Forms and Cards Frontend](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=cf49d350118844e999cdfb7c2031650e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created new `create-replacement` page under `pages/requests/create-replacement.tsx`
* Added temporary text input field to act as the Typeahead component
* Added `PermitHolderInformationForm`, `ReasonForReplacementForm`, and `PaymentDetailsForm` components with state variables and state setters
* Built footer component, sticks to bottom of page when scrolling


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* No integrated Typeahead component yet
* No functionality with buttons, user ID links, etc.

## [Video for Design](https://drive.google.com/file/d/1mni-lmen3cnOrmrspEI_nBXb8vFipdFl/view?usp=sharing)

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket

### P.S. Took a lot of inspiration (maybe the whole thing) from @jennifertsai's fine work.
