### PR TITLE
[Hotfix] Move create replacement page to under /admin and add authorization check

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -19,9 +19,10 @@ import {
   InputLeftElement,
   Wrap,
   Tooltip,
+  HStack,
   useDisclosure,
 } from '@chakra-ui/react'; // Chakra UI
-import { ChevronDownIcon, SearchIcon } from '@chakra-ui/icons'; // Chakra UI Icons
+import { ChevronDownIcon, SearchIcon, AddIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import Layout from '@components/admin/Layout'; // Layout component
 import { authorize } from '@tools/authorization'; // Page authorization
 import Table from '@components/Table'; // Table component
@@ -205,25 +206,30 @@ export default function Requests() {
       <GridItem colSpan={12}>
         <Flex justifyContent="space-between" alignItems="center" marginBottom="32px">
           <Text textStyle="display-xlarge">Requests</Text>
-          <Button variant="outline" onClick={onOpenGenerateReportModal}>
-            Generate a Report
-          </Button>
-          {/* TODO: 'Create a new request' function is out of scope for this term's MVP
-          <Menu>
-            <MenuButton
-              as={Button}
-              leftIcon={<AddIcon width="14px" height="14px" />}
-              height="48px"
-              pl="24px"
-              pr="24px"
-            >
-              Create a request
-            </MenuButton>
-            <MenuList>
-              <MenuItem>Replacement Request</MenuItem>
-              <MenuItem>Renewal Request</MenuItem>
-            </MenuList>
-          </Menu> */}
+          <HStack spacing="12px">
+            <Button height="48px" variant="outline" onClick={onOpenGenerateReportModal}>
+              Generate a Report
+            </Button>
+            <Menu>
+              <MenuButton
+                as={Button}
+                leftIcon={<AddIcon width="14px" height="14px" />}
+                height="48px"
+                pl="24px"
+                pr="24px"
+              >
+                Create a request
+              </MenuButton>
+              <MenuList>
+                <MenuItem onClick={() => router.push('/admin/request/create-replacement')}>
+                  Replacement Request
+                </MenuItem>
+                <MenuItem onClick={() => router.push('/admin/request/create-renewal')}>
+                  Renewal Request
+                </MenuItem>
+              </MenuList>
+            </Menu>
+          </HStack>
         </Flex>
         <Box border="1px solid" borderColor="border.secondary" borderRadius="12px" bgColor="white">
           <Tabs marginBottom="20px">

--- a/pages/admin/request/create-replacement.tsx
+++ b/pages/admin/request/create-replacement.tsx
@@ -1,17 +1,20 @@
-import Layout from '@components/admin/Layout'; // Layout component
-import { Text, Box, Flex, Stack, Button, GridItem, Input } from '@chakra-ui/react'; // Chakra UI
 import { useState } from 'react'; // React
+import { GetServerSideProps } from 'next';
+import Link from 'next/link'; // Link component
+import { getSession } from 'next-auth/client'; // Session management
+import { authorize } from '@tools/authorization'; // Page authorization
+import { Text, Box, Flex, Stack, Button, GridItem, Input } from '@chakra-ui/react'; // Chakra UI
+import Layout from '@components/admin/Layout'; // Layout component
 import PermitHolderInformationForm from '@components/admin/requests/forms/PermitHolderInformationForm'; //Permit holder information form
 import {
   PaymentDetails,
   PermitHolderInformation,
 } from '@tools/components/admin/requests/forms/types'; //Permit holder information type
 import PaymentDetailsForm from '@components/admin/requests/forms/PaymentDetailsForm'; //Payment details form
-import { PaymentType, Province } from '@lib/graphql/types'; //GraphQL types
+import { PaymentType, Province, Role } from '@lib/graphql/types'; //GraphQL types
 import { ReasonForReplacement } from '@tools/components/admin/requests/forms/types';
 import { ReasonForReplacement as ReasonForReplacementEnum } from '@lib/graphql/types'; // Reason For Replacement Enum
 import ReasonForReplacementForm from '@components/admin/requests/forms/ReasonForReplacementForm';
-import Link from 'next/link'; // Link component
 
 export default function CreateReplacement() {
   const [permitHolderID] = useState(303240);
@@ -191,3 +194,22 @@ export default function CreateReplacement() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const session = await getSession(context);
+
+  // Only secretaries and admins can access APP requests
+  if (authorize(session, [Role.Secretary])) {
+    return {
+      props: {},
+    };
+  }
+
+  // Redirect to login if roles requirement not satisfied
+  return {
+    redirect: {
+      destination: '/admin/login',
+      permanent: false,
+    },
+  };
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A (hotfix)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Replacement page was under wrong route. Moved from `/requests/create-replacement` to `/admin/request/create-replacement`
* Add authorization check to create replacement page using `getServerSideProps`
* Link to create replacement and create renewal requests pages from requests table


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
