### PR TITLE
[Fix] Format CSV date fields

### DIFF
--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -13,7 +13,7 @@ import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant er
 import { DBErrorCode, getUniqueConstraintFailedFields } from '@lib/db/errors'; // Database errors
 import { SortOrder } from '@tools/types'; // Sorting type
 import { ApplicationsReportColumn, PaymentType } from '@lib/graphql/types'; // GraphQL types
-import { formatPhoneNumber, formatPostalCode } from '@lib/utils/format'; // Formatting utils
+import { formatDate, formatPhoneNumber, formatPostalCode } from '@lib/utils/format'; // Formatting utils
 import { createObjectCsvWriter } from 'csv-writer';
 
 /**
@@ -649,10 +649,12 @@ export const generateApplicantsReport: Resolver = async (_, args, { prisma }) =>
     },
   });
 
-  // Adds totalAmount, applicantName and rcdPermitId properties to allow for csv writing
+  // Formats the date fields and adds totalAmount, applicantName and rcdPermitId properties to allow for csv writing
   const csvApplications = applications.map(application => {
     return {
       ...application,
+      dateOfBirth: formatDate(application.dateOfBirth),
+      // TODO: Confirm desired format applicationDate: formatDate(application.createdAt),
       applicantName:
         application.firstName +
         (application.middleName

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -654,7 +654,14 @@ export const generateApplicantsReport: Resolver = async (_, args, { prisma }) =>
     return {
       ...application,
       dateOfBirth: formatDate(application.dateOfBirth),
-      // TODO: Confirm desired format applicationDate: formatDate(application.createdAt),
+      applicationDate: application.createdAt.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: 'numeric',
+        timeZone: 'America/Vancouver',
+      }),
       applicantName:
         application.firstName +
         (application.middleName
@@ -680,7 +687,7 @@ export const generateApplicantsReport: Resolver = async (_, args, { prisma }) =>
     csvHeaders.push({ id: 'rcdPermitId', title: 'APP Number' });
   }
   if (columnsSet.has(ApplicationsReportColumn.ApplicationDate)) {
-    csvHeaders.push({ id: 'createdAt', title: 'Application Date' });
+    csvHeaders.push({ id: 'applicationDate', title: 'Application Date' });
   }
   if (columnsSet.has(ApplicationsReportColumn.PaymentMethod)) {
     csvHeaders.push({ id: 'paymentMethod', title: 'Payment Method' });


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Format CSV date fields](https://www.notion.so/uwblueprintexecs/Format-CSV-date-fields-1af6ff95d16f43f9a01e68e5ef9fd29c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Wrapped date of birth field with `formatDate` util function.
* Changed application date to use PST timezone (should test/confirm this at some point becuase I'm not confident if the conversion is right, @OustanDing mentioned to do separately later on)

CSV with old format:
Applicant DoB,Application Date
Sat Oct 09 2021 20:00:00 GMT-0400 (Eastern Daylight Time),Sat Oct 09 2021 23:20:02 GMT-0400 (Eastern Daylight Time)

CSV with new format:
Applicant DoB,Application Date
10/10/2021,"Oct 09, 2021, 08:20 PM"

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
