### PR TITLE
[Feature] Build CSV generation API for permit holders

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -406,9 +406,9 @@ export const generatePermitHoldersReport: Resolver = async (_, args, { prisma })
 
   const applicants = await prisma.applicant.findMany({
     where: {
-      applications: {
+      permits: {
         some: {
-          createdAt: {
+          expiryDate: {
             gte: startDate,
             lte: endDate,
           },

--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -118,4 +118,15 @@ export default `
     IDENTITY_VERIFICATION_FAILED
     APP_DOES_NOT_EXPIRE_WITHIN_30_DAYS
   }
+
+  input GeneratePermitHoldersReportInput {
+    startDate: Date!
+    endDate: Date!
+    columns: [PermitHoldersReportColumn!]!
+  }
+
+  # TODO: Return link to AWS S3 file
+  type GeneratePermitHoldersReportResult {
+    ok: Boolean!
+  }
 `;

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -775,19 +775,22 @@ export const generatePermitHoldersReport: Resolver = async (_, args, { prisma })
           ? ` ${application.middleName} ${application.lastName}`
           : ` ${application.lastName}`),
       rcdPermitId: application.permit?.rcdPermitId,
-      homeAddress: `${application.addressLine1}, ${
-        application.addressLine2 ? `${application.addressLine2},` : ''
-      } ${application.city}, ${application.province}, ${application.postalCode}`,
+      homeAddress: `${application.addressLine1}, 
+      ${application.addressLine2 ? `${application.addressLine2},` : ''} ${application.city}, ${
+        application.province
+      }, ${application.postalCode}`,
       userStatus: application.permit?.active ? 'Active' : 'Inactive',
       guardianPOAName:
         application.guardianFirstName +
         (application.guardianMiddleName
           ? ` ${application.guardianMiddleName} ${application.guardianLastName}`
           : ` ${application.guardianLastName}`),
-      guardianPOAAdress: `${application.guardianAddressLine1}, ${
-        application.guardianAddressLine2 ? `${application.guardianAddressLine2},` : ''
-      } ${application.guardianCity}, ${application.guardianProvince}, ${
-        application.guardianPostalCode
+      guardianPOAAdress: `${
+        application.guardianAddressLine1 ? `${application.guardianAddressLine1},` : ''
+      } ${application.guardianAddressLine2 ? `${application.guardianAddressLine2},` : ''} ${
+        application.guardianCity ? `${application.guardianCity},` : ''
+      } ${application.guardianProvince ? `${application.guardianProvince},` : ''} ${
+        application.guardianPostalCode ?? ''
       }`,
     };
   });

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -12,7 +12,11 @@ import {
 import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant errors
 import { DBErrorCode, getUniqueConstraintFailedFields } from '@lib/db/errors'; // Database errors
 import { SortOrder } from '@tools/types'; // Sorting type
-import { ApplicationsReportColumn, PaymentType } from '@lib/graphql/types'; // GraphQL types
+import {
+  ApplicationsReportColumn,
+  PaymentType,
+  PermitHoldersReportColumn,
+} from '@lib/graphql/types'; // GraphQL types
 import { formatDate, formatPhoneNumber, formatPostalCode } from '@lib/utils/format'; // Formatting utils
 import { createObjectCsvWriter } from 'csv-writer';
 
@@ -704,6 +708,131 @@ export const generateApplicationsReport: Resolver = async (_, args, { prisma }) 
 
   const csvWriter = createObjectCsvWriter({
     path: 'temp/file.csv',
+    header: csvHeaders,
+  });
+
+  await csvWriter.writeRecords(csvApplications);
+
+  return {
+    ok: true,
+  };
+};
+
+export const generatePermitHoldersReport: Resolver = async (_, args, { prisma }) => {
+  const {
+    input: { startDate, endDate, columns },
+  } = args;
+
+  const columnsSet = new Set(columns);
+
+  const applications = await prisma.application.findMany({
+    where: {
+      createdAt: {
+        gte: startDate,
+        lte: endDate,
+      },
+    },
+    select: {
+      rcdUserId: columnsSet.has(PermitHoldersReportColumn.UserId),
+      firstName: columnsSet.has(PermitHoldersReportColumn.ApplicantName),
+      middleName: columnsSet.has(PermitHoldersReportColumn.ApplicantName),
+      lastName: columnsSet.has(PermitHoldersReportColumn.ApplicantName),
+      dateOfBirth: columnsSet.has(PermitHoldersReportColumn.ApplicantDateOfBirth),
+      addressLine1: columnsSet.has(PermitHoldersReportColumn.HomeAddress),
+      addressLine2: columnsSet.has(PermitHoldersReportColumn.HomeAddress),
+      city: columnsSet.has(PermitHoldersReportColumn.HomeAddress),
+      province: columnsSet.has(PermitHoldersReportColumn.HomeAddress),
+      postalCode: columnsSet.has(PermitHoldersReportColumn.HomeAddress),
+      email: columnsSet.has(PermitHoldersReportColumn.Email),
+      phone: columnsSet.has(PermitHoldersReportColumn.PhoneNumber),
+      guardianFirstName: columnsSet.has(PermitHoldersReportColumn.GuardianPoaName),
+      guardianMiddleName: columnsSet.has(PermitHoldersReportColumn.GuardianPoaName),
+      guardianLastName: columnsSet.has(PermitHoldersReportColumn.GuardianPoaName),
+      guardianRelationship: columnsSet.has(PermitHoldersReportColumn.GuardianPoaRelation),
+      guardianAddressLine1: columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress),
+      guardianAddressLine2: columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress),
+      guardianPostalCode: columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress),
+      guardianCity: columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress),
+      guardianProvince: columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress),
+      permit: {
+        select: {
+          rcdPermitId: true,
+          active: columnsSet.has(PermitHoldersReportColumn.UserStatus),
+        },
+      },
+      permitType: columnsSet.has(PermitHoldersReportColumn.RecentAppType),
+    },
+  });
+
+  // Formats the date fields and adds totalAmount, applicantName and rcdPermitId properties to allow for csv writing
+  const csvApplications = applications.map(application => {
+    return {
+      ...application,
+      dateOfBirth: formatDate(application.dateOfBirth),
+      applicantName:
+        application.firstName +
+        (application.middleName
+          ? ` ${application.middleName} ${application.lastName}`
+          : ` ${application.lastName}`),
+      rcdPermitId: application.permit?.rcdPermitId,
+      homeAddress: `${application.addressLine1}, ${
+        application.addressLine2 ? `${application.addressLine2},` : ''
+      } ${application.city}, ${application.province}, ${application.postalCode}`,
+      userStatus: application.permit?.active ? 'Active' : 'Inactive',
+      guardianPOAName:
+        application.guardianFirstName +
+        (application.guardianMiddleName
+          ? ` ${application.guardianMiddleName} ${application.guardianLastName}`
+          : ` ${application.guardianLastName}`),
+      guardianPOAAdress: `${application.guardianAddressLine1}, ${
+        application.guardianAddressLine2 ? `${application.guardianAddressLine2},` : ''
+      } ${application.guardianCity}, ${application.guardianProvince}, ${
+        application.guardianPostalCode
+      }`,
+    };
+  });
+
+  const csvHeaders = [];
+
+  if (columnsSet.has(PermitHoldersReportColumn.UserId)) {
+    csvHeaders.push({ id: 'rcdUserId', title: 'User ID' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.ApplicantName)) {
+    csvHeaders.push({ id: 'applicantName', title: 'Applicant Name' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.ApplicantDateOfBirth)) {
+    csvHeaders.push({ id: 'dateOfBirth', title: 'Applicant DoB' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.HomeAddress)) {
+    csvHeaders.push({ id: 'homeAddress', title: 'Home Address' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.Email)) {
+    csvHeaders.push({ id: 'email', title: 'Email' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.PhoneNumber)) {
+    csvHeaders.push({ id: 'phone', title: 'Phone Number' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.GuardianPoaName)) {
+    csvHeaders.push({ id: 'guardianPoaName', title: 'Guardian/POA Name' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.GuardianPoaRelation)) {
+    csvHeaders.push({ id: 'guardianRelationship', title: 'Guardian/POA Relation' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.GuardianPoaAddress)) {
+    csvHeaders.push({ id: 'guardianPOAAdress', title: 'Guardian/POA Address' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.RecentAppNumber)) {
+    csvHeaders.push({ id: 'rcdPermitId', title: 'Recent APP Number' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.RecentAppType)) {
+    csvHeaders.push({ id: 'permitType', title: 'Recent APP Type' });
+  }
+  if (columnsSet.has(PermitHoldersReportColumn.UserStatus)) {
+    csvHeaders.push({ id: 'userStatus', title: 'User Status' });
+  }
+
+  const csvWriter = createObjectCsvWriter({
+    path: 'temp/file-permit-holders.csv',
     header: csvHeaders,
   });
 

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -613,6 +613,11 @@ export const createReplacementApplication: Resolver = async (_, args, { prisma }
   };
 };
 
+/**
+ * Generates csv with applications' info, given a start date, end date, and values from
+ * ApplicationsReportColumn that the user would like to have on the generated csv
+ * @returns Whether a csv could be generated (ok), and in the future an AWS S3 file link
+ */
 export const generateApplicationsReport: Resolver = async (_, args, { prisma }) => {
   const {
     input: { startDate, endDate, columns },
@@ -662,11 +667,9 @@ export const generateApplicationsReport: Resolver = async (_, args, { prisma }) 
         minute: 'numeric',
         timeZone: 'America/Vancouver',
       }),
-      applicantName:
-        application.firstName +
-        (application.middleName
-          ? ` ${application.middleName} ${application.lastName}`
-          : ` ${application.lastName}`),
+      applicantName: `${application.firstName}${
+        application.middleName ? ` ${application.middleName}` : ''
+      } ${application.lastName}`,
       totalAmount: (application.processingFee || 0) + (application?.donationAmount || 0),
       rcdPermitId: application.permit?.rcdPermitId,
     };

--- a/lib/applications/schema.ts
+++ b/lib/applications/schema.ts
@@ -362,4 +362,15 @@ export default `
   type GenerateApplicationsReportResult {
     ok: Boolean!
   }
+
+  input GeneratePermitHoldersReportInput {
+    startDate: Date!
+    endDate: Date!
+    columns: [PermitHoldersReportColumn!]!
+  }
+
+  # TODO: Return link to AWS S3 file
+  type GeneratePermitHoldersReportResult {
+    ok: Boolean!
+  }
 `;

--- a/lib/applications/schema.ts
+++ b/lib/applications/schema.ts
@@ -362,15 +362,4 @@ export default `
   type GenerateApplicationsReportResult {
     ok: Boolean!
   }
-
-  input GeneratePermitHoldersReportInput {
-    startDate: Date!
-    endDate: Date!
-    columns: [PermitHoldersReportColumn!]!
-  }
-
-  # TODO: Return link to AWS S3 file
-  type GeneratePermitHoldersReportResult {
-    ok: Boolean!
-  }
 `;

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -22,6 +22,7 @@ import {
   createRenewalApplication,
   createReplacementApplication,
   generateApplicationsReport,
+  generatePermitHoldersReport,
 } from '@lib/applications/resolvers'; // Application resolvers
 import { permits, createPermit } from '@lib/permits/resolvers'; // Permit resolvers
 import {
@@ -73,6 +74,7 @@ const resolvers = {
     applicant: authorize(applicant, [Role.Secretary]),
     employee: authorize(employee, [Role.Admin]),
     generateApplicationsReport: authorize(generateApplicationsReport, [Role.Secretary]),
+    generatePermitHoldersReport: authorize(generatePermitHoldersReport, [Role.Secretary]),
   },
   Mutation: {
     createApplicant: authorize(createApplicant, [Role.Secretary]),

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -12,6 +12,7 @@ import {
   createApplicant,
   updateApplicant,
   verifyIdentity,
+  generatePermitHoldersReport,
 } from '@lib/applicants/resolvers'; // Applicant resolvers
 import { physicians, createPhysician, upsertPhysician } from '@lib/physicians/resolvers'; // Physician resolvers
 import {
@@ -22,7 +23,6 @@ import {
   createRenewalApplication,
   createReplacementApplication,
   generateApplicationsReport,
-  generatePermitHoldersReport,
 } from '@lib/applications/resolvers'; // Application resolvers
 import { permits, createPermit } from '@lib/permits/resolvers'; // Permit resolvers
 import {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -10,6 +10,7 @@ export default `
     application(id: ID!): Application
     permits: [Permit!]
     generateApplicationsReport(input: GenerateApplicationsReportInput!): GenerateApplicationsReportResult
+    generatePermitHoldersReport(input: GeneratePermitHoldersReportInput!): GeneratePermitHoldersReportResult
   }
 
   type Mutation {
@@ -131,5 +132,20 @@ export default `
     FEE_AMOUNT
     DONATION_AMOUNT
     TOTAL_AMOUNT
+  }
+
+  enum PermitHoldersReportColumn {
+    USER_ID
+    APPLICANT_NAME
+    APPLICANT_DATE_OF_BIRTH
+    HOME_ADDRESS
+    EMAIL
+    PHONE_NUMBER
+    GUARDIAN_POA_NAME
+    GUARDIAN_POA_RELATION
+    GUARDIAN_POA_ADDRESS
+    RECENT_APP_NUMBER
+    RECENT_APP_TYPE
+    USER_STATUS
   }
 `;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -438,9 +438,9 @@ export type CreateReplacementApplicationInput = {
   postalCode: Scalars['String'];
   /** Replacement Information */
   reason: ReasonForReplacement;
-  lostTimestamp: Scalars['Date'];
-  lostLocation: Scalars['String'];
-  description: Scalars['String'];
+  lostTimestamp?: Maybe<Scalars['Date']>;
+  lostLocation?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
   /** Payment Information */
   paymentMethod: PaymentType;
   donationAmount?: Maybe<Scalars['Float']>;
@@ -504,6 +504,18 @@ export type GenerateApplicationsReportInput = {
 /** TODO: Return link to AWS S3 file */
 export type GenerateApplicationsReportResult = {
   __typename?: 'GenerateApplicationsReportResult';
+  ok: Scalars['Boolean'];
+};
+
+export type GeneratePermitHoldersReportInput = {
+  startDate: Scalars['Date'];
+  endDate: Scalars['Date'];
+  columns: Array<PermitHoldersReportColumn>;
+};
+
+/** TODO: Return link to AWS S3 file */
+export type GeneratePermitHoldersReportResult = {
+  __typename?: 'GeneratePermitHoldersReportResult';
   ok: Scalars['Boolean'];
 };
 
@@ -680,6 +692,21 @@ export type Permit = {
   applicantId: Scalars['Int'];
 };
 
+export enum PermitHoldersReportColumn {
+  UserId = 'USER_ID',
+  ApplicantName = 'APPLICANT_NAME',
+  ApplicantDateOfBirth = 'APPLICANT_DATE_OF_BIRTH',
+  HomeAddress = 'HOME_ADDRESS',
+  Email = 'EMAIL',
+  PhoneNumber = 'PHONE_NUMBER',
+  GuardianPoaName = 'GUARDIAN_POA_NAME',
+  GuardianPoaRelation = 'GUARDIAN_POA_RELATION',
+  GuardianPoaAddress = 'GUARDIAN_POA_ADDRESS',
+  RecentAppNumber = 'RECENT_APP_NUMBER',
+  RecentAppType = 'RECENT_APP_TYPE',
+  UserStatus = 'USER_STATUS'
+}
+
 export enum PermitStatus {
   Valid = 'VALID',
   Expired = 'EXPIRED',
@@ -738,6 +765,7 @@ export type Query = {
   application: Maybe<Application>;
   permits: Maybe<Array<Permit>>;
   generateApplicationsReport: Maybe<GenerateApplicationsReportResult>;
+  generatePermitHoldersReport: Maybe<GeneratePermitHoldersReportResult>;
 };
 
 
@@ -773,6 +801,11 @@ export type QueryApplicationArgs = {
 
 export type QueryGenerateApplicationsReportArgs = {
   input: GenerateApplicationsReportInput;
+};
+
+
+export type QueryGeneratePermitHoldersReportArgs = {
+  input: GeneratePermitHoldersReportInput;
 };
 
 export type QueryApplicantsResult = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Reports - Build CSV generation API for permit holders](https://www.notion.so/uwblueprintexecs/Reports-Build-CSV-generation-API-for-permit-holders-96e83e2175714b4a87e69c7301d1d0af)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description

- Created a GraphQL query endpoint `generatePermitHoldersReport` that takes in an input object `input` with the following fields (all required):
    - `startDate` 
  - `endDate` 
  - `columns` - array of `PermitHoldersReportColumn` enum values
 - Created `PermitHoldersReportColumn` enum in `lib/graphql/schema.ts`  with appropriate enum values
- Used Prisma to query the `applicants` table and filter the records by `createdAt` timestamp of applicants' applications
- Used `csv-writer` to subsequently generate a CSV file

The generated file is saved in the file system for now.

### Demo:
GraphQL Query Results:
![image](https://user-images.githubusercontent.com/51224641/146297054-eee2dca8-9917-4ef3-995c-6a27932a3ae6.png)

Generated CSV (UPDATED):
[file-permit-holders.csv](https://github.com/uwblueprint/richmond-centre-for-disability/files/7765398/file-permit-holders.csv)


Screenshot of generated csv (UPDATED):
![image](https://user-images.githubusercontent.com/51224641/147158804-7cd8db15-c081-4f4f-9216-056b044c9f5a.png)

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Could you take a look at the csv and lmk if you want anything to be formatted differently
* Left some comments with questions


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
