### PR TITLE
[Bug fix] Replace phone number field with string input field

### DIFF
--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -132,9 +132,12 @@ export default function IdentityVerificationForm() {
             </FormControl>
             <FormControl isRequired textAlign="left" marginBottom="48px">
               <FormLabel>{`Last 4 digits of your phone number`}</FormLabel>
-              <NumberInput width="184px" value={phoneNumberSuffix} onChange={setPhoneNumberSuffix}>
-                <NumberInputField />
-              </NumberInput>
+              <Input
+                type="string"
+                width="184px"
+                value={phoneNumberSuffix}
+                onChange={event => setPhoneNumberSuffix(event.target.value)}
+              />
             </FormControl>
             <FormControl isRequired textAlign="left" marginBottom="20px">
               <FormLabel>{`Date of Birth`}</FormLabel>

--- a/pages/verify-identity.tsx
+++ b/pages/verify-identity.tsx
@@ -133,7 +133,6 @@ export default function IdentityVerificationForm() {
             <FormControl isRequired textAlign="left" marginBottom="48px">
               <FormLabel>{`Last 4 digits of your phone number`}</FormLabel>
               <Input
-                type="string"
                 width="184px"
                 value={phoneNumberSuffix}
                 onChange={event => setPhoneNumberSuffix(event.target.value)}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Replace last 4 digits of phone number field with string field](https://www.notion.so/uwblueprintexecs/Replace-last-4-digits-of-phone-number-field-with-string-field-98ff7ee584864d8fbe7abe1aad1a8afd)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed input type of last 4 digits of phone number field from a `NumberInput` to an `Input`


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
