### PR TITLE
[Fix] Make doctor phone number field in applicant renewal form required

### DIFF
--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -406,7 +406,7 @@ export default function Renew() {
                     />
                     <FormHelperText>{`e.g. X0X 0X0`}</FormHelperText>
                   </FormControl>
-                  <FormControl marginBottom="24px">
+                  <FormControl isRequired marginBottom="24px">
                     <FormLabel>{`Phone Number`}</FormLabel>
                     <Input
                       type="tel"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Mark-doctor-phone-number-field-as-required-f4814e5ecfbd4f95b42748807f145981)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set `isRequired` on `FormControl` element for doctor phone number in applicant-facing renewal form
![image](https://user-images.githubusercontent.com/30249230/148465622-2c80024c-f68a-478a-9a0d-ad0746aa4a3a.png)



## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
