### PR TITLE
[Hotfix] Remove deprecated fields from GraphQL queries

### DIFF
--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -260,12 +260,9 @@ export type CreateGuardianInput = {
   notes?: Maybe<Scalars['String']>;
 };
 
-/** Fields to specify when creating a medical information record for an applicant */
 export type CreateMedicalInformationInput = {
   disability: Scalars['String'];
-  affectsMobility: Scalars['Boolean'];
-  mobilityAidRequired: Scalars['Boolean'];
-  cannotWalk100m: Scalars['Boolean'];
+  patientEligibility: Eligibility;
   notes?: Maybe<Scalars['String']>;
   certificationDate?: Maybe<Scalars['Date']>;
   aid?: Maybe<Array<Aid>>;
@@ -1008,9 +1005,7 @@ export type UpdateGuardianResult = {
 export type UpdateMedicalInformationInput = {
   applicantId: Scalars['Int'];
   disability?: Maybe<Scalars['String']>;
-  affectsMobility?: Maybe<Scalars['Boolean']>;
-  mobilityAidRequired?: Maybe<Scalars['Boolean']>;
-  cannotWalk100m?: Maybe<Scalars['Boolean']>;
+  patientEligibility?: Maybe<Eligibility>;
   notes?: Maybe<Scalars['String']>;
   certificationDate?: Maybe<Scalars['Date']>;
   aid?: Maybe<Array<Aid>>;

--- a/lib/medical-information/schema.ts
+++ b/lib/medical-information/schema.ts
@@ -1,4 +1,6 @@
-export default `
+import { gql } from '@apollo/client';
+
+export default gql`
   type MedicalInformation {
     id: ID!
     disability: String!
@@ -16,9 +18,7 @@ export default `
   # Fields to specify when creating a medical information record for an applicant
   input CreateMedicalInformationInput {
     disability: String!
-    affectsMobility: Boolean!
-    mobilityAidRequired: Boolean!
-    cannotWalk100m: Boolean!
+    patientEligibility: Eligibility!
     notes: String
     certificationDate: Date
     aid: [Aid!]
@@ -28,9 +28,7 @@ export default `
   input UpdateMedicalInformationInput {
     applicantId: Int!
     disability: String
-    affectsMobility: Boolean
-    mobilityAidRequired: Boolean
-    cannotWalk100m: Boolean
+    patientEligibility: Eligibility
     notes: String
     certificationDate: Date
     aid: [Aid!]

--- a/tools/pages/admin/permit-holders/get-permit-holder.ts
+++ b/tools/pages/admin/permit-holders/get-permit-holder.ts
@@ -91,9 +91,7 @@ export const GET_PERMIT_HOLDER = gql`
       applications {
         id
         disability
-        affectsMobility
-        mobilityAidRequired
-        cannotWalk100m
+        patientEligibility
         aid
         createdAt
         notes

--- a/tools/pages/admin/requests/queries.ts
+++ b/tools/pages/admin/requests/queries.ts
@@ -26,9 +26,7 @@ export const GET_APPLICATION_QUERY = gql`
       notes
 
       disability
-      affectsMobility
-      mobilityAidRequired
-      cannotWalk100m
+      patientEligibility
 
       physicianName
       physicianMspNumber


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Boolean fields for `cannot_walk_100m`, `affects_mobility` and `mobility_aid_required` were replaced by a single `patient_eligibility` field in #122 
* Not all instances of these fields were removed - some remained in GraphQL queries and schemas
* Fix these instances to use the new `patientEligibility` field instead


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* This bug was causing 40x errors as the API schema was execting the boolean fields for inputs


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
