### PR TITLE
[Hotfix] Remove deprecated fields from GraphQL queries

### DIFF
--- a/tools/admin/requests/graphql/get-application.ts
+++ b/tools/admin/requests/graphql/get-application.ts
@@ -28,9 +28,7 @@ export const GET_APPLICATION_QUERY = gql`
       notes
 
       disability
-      affectsMobility
-      mobilityAidRequired
-      cannotWalk100m
+      patientEligibility
 
       physicianName
       physicianMspNumber


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* This was addressed in #130 but a rebase error left one instance of the deprecated field in a GraphQL query

## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
