### PR TITLE
[Fix] Fix applicants endpoint filter

### DIFF
--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -224,7 +224,16 @@ const PermitHolders: NextPage = () => {
         disableSortBy: true,
         width: 140,
         maxWidth: 140,
-        Cell: ({ value: { expiryDate, rcdPermitId } }) => {
+        Cell: ({ value }) => {
+          if (value === null) {
+            return (
+              <Text as="span" mr="9px">
+                N/A
+              </Text>
+            );
+          }
+
+          const { expiryDate, rcdPermitId } = value;
           const permitStatus = getPermitExpiryStatus(new Date(expiryDate));
           return (
             <Flex>

--- a/tools/admin/permit-holders/permit-holders-table.ts
+++ b/tools/admin/permit-holders/permit-holders-table.ts
@@ -37,7 +37,7 @@ export type PermitHolderRow = Pick<
     city: string;
     postalCode: string;
   };
-  mostRecentPermit: Pick<Permit, 'expiryDate' | 'rcdPermitId'>;
+  mostRecentPermit: Pick<Permit, 'expiryDate' | 'rcdPermitId'> | null;
 };
 
 /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-applicants-API-filter-5f59658a83a14a6f9bc907f29de6d205)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `applicants` endpoint was returning no applicants when an empty filter was specified since when an empty filter was specified, only applicants with at least one permit were selected
* Conditionally built filter based on which filters were specified (expiry date, permit status)
* Also fixes a small bug in the permit holders table - if the most recent permit is `null`, "N/A" will now be rendered in the table cell instead of the entire page breaking


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* There is still a small bug that deals with timezones and date filtering, which we will further investigate during the date auditing process


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
