### PR TITLE
[Fix] Revert applicants endpoint and add permits seeding

### DIFF
--- a/components/admin/permit-holders/app-history/Card.tsx
+++ b/components/admin/permit-holders/app-history/Card.tsx
@@ -37,7 +37,7 @@ const COLUMNS: Column<AppHistoryRow>[] = [
     maxWidth: 195,
     Cell: ({ value }) => (
       <Box pr="10px">
-        <PermitStatusBadge variant={getPermitExpiryStatus(new Date(value))} />
+        <PermitStatusBadge variant={value} />
       </Box>
     ),
   },

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -24,6 +24,7 @@ import { SortOrder } from '@tools/types'; // Sorting Type
 
 /**
  * Query and filter RCD applicants from the internal facing app.
+ * Will only return applicants that have had at least one permit.
  * All fields are optional.
  *
  * Filters:

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -224,16 +224,7 @@ const PermitHolders: NextPage = () => {
         disableSortBy: true,
         width: 140,
         maxWidth: 140,
-        Cell: ({ value }) => {
-          if (value === null) {
-            return (
-              <Text as="span" mr="9px">
-                N/A
-              </Text>
-            );
-          }
-
-          const { expiryDate, rcdPermitId } = value;
+        Cell: ({ value: { expiryDate, rcdPermitId } }) => {
           const permitStatus = getPermitExpiryStatus(new Date(expiryDate));
           return (
             <Flex>

--- a/prisma/dev-seed-utils/permits.ts
+++ b/prisma/dev-seed-utils/permits.ts
@@ -5,13 +5,13 @@ import prisma from '../index'; // Prisma client
 import { UpsertPermit } from '../types'; // Seeding types
 
 // Seed data
-const permits = [
+const permits: Array<UpsertPermit> = [
   {
     rcdPermitId: 1,
     applicantId: 2,
     applicationId: 2,
     type: PermitType.PERMANENT,
-    expiryDate: new Date(2018, 1, 1).toISOString(),
+    expiryDate: new Date(2018, 1, 1),
     active: false,
   },
   {
@@ -19,7 +19,7 @@ const permits = [
     applicantId: 3,
     applicationId: 3,
     type: PermitType.PERMANENT,
-    expiryDate: new Date(2025, 1, 1).toISOString(),
+    expiryDate: new Date(2025, 1, 1),
     active: true,
   },
 ];

--- a/prisma/dev-seed-utils/permits.ts
+++ b/prisma/dev-seed-utils/permits.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+// Relative paths required, path aliases throw error with seed command
+import { PermitType } from '@prisma/client';
+import prisma from '../index'; // Prisma client
+import { UpsertPermit } from '../types'; // Seeding types
+
+// Seed data
+const permits = [
+  {
+    rcdPermitId: 1,
+    applicantId: 2,
+    applicationId: 2,
+    type: PermitType.PERMANENT,
+    expiryDate: new Date(2018, 1, 1).toISOString(),
+    active: false,
+  },
+  {
+    rcdPermitId: 2,
+    applicantId: 3,
+    applicationId: 3,
+    type: PermitType.PERMANENT,
+    expiryDate: new Date(2025, 1, 1).toISOString(),
+    active: true,
+  },
+];
+
+/**
+ * Upsert permits
+ * @param data Custom permit data to be upserted
+ */
+export default async function permitUpsert(data?: UpsertPermit[]): Promise<void> {
+  for (const permit of data || permits) {
+    const { rcdPermitId, expiryDate = new Date().toISOString(), ...rest } = permit;
+    const permitUpsert = await prisma.permit.upsert({
+      where: { rcdPermitId },
+      update: rest,
+      create: { rcdPermitId, expiryDate, ...rest },
+    });
+    console.log({ permitUpsert });
+  }
+}

--- a/prisma/dev-seed-utils/permits.ts
+++ b/prisma/dev-seed-utils/permits.ts
@@ -11,7 +11,7 @@ const permits: Array<UpsertPermit> = [
     applicantId: 2,
     applicationId: 2,
     type: PermitType.PERMANENT,
-    expiryDate: new Date(2018, 1, 1),
+    expiryDate: new Date('2018-01-01'),
     active: false,
   },
   {
@@ -19,7 +19,7 @@ const permits: Array<UpsertPermit> = [
     applicantId: 3,
     applicationId: 3,
     type: PermitType.PERMANENT,
-    expiryDate: new Date(2025, 1, 1),
+    expiryDate: new Date('2025-01-01'),
     active: true,
   },
 ];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@
 import prisma from '../prisma/index'; // Prisma client
 import devApplicantUpsert from './dev-seed-utils/applicants'; // Dev applicants upsert
 import devApplicationUpsert from './dev-seed-utils/applications'; // Dev applications upsert
+import devPermitUpsert from './dev-seed-utils/permits'; // Dev employees upsert
 import devEmployeeUpsert from './dev-seed-utils/employees'; // Dev employees upsert
 import prodEmployeeUpsert from './prod-seed-utils/employees'; // Prod employees upsert
 
@@ -36,6 +37,9 @@ const devSeed = async () => {
 
   // Upsert applications
   await devApplicationUpsert();
+
+  // Upsert permits
+  await devPermitUpsert();
 };
 
 // Execute seeding

--- a/prisma/types.ts
+++ b/prisma/types.ts
@@ -4,6 +4,7 @@ import {
   Guardian,
   MedicalInformation,
   NewApplication,
+  Permit,
   Physician,
   RenewalApplication,
   ReplacementApplication,
@@ -174,3 +175,9 @@ export type UpsertApplication = Pick<
         >;
       }
   );
+
+// Type of Permit to upsert in DB
+export type UpsertPermit = Pick<
+  Permit,
+  'rcdPermitId' | 'applicantId' | 'applicationId' | 'type' | 'expiryDate' | 'active'
+>;

--- a/tools/admin/permit-holders/permit-holders-table.ts
+++ b/tools/admin/permit-holders/permit-holders-table.ts
@@ -37,7 +37,7 @@ export type PermitHolderRow = Pick<
     city: string;
     postalCode: string;
   };
-  mostRecentPermit: Pick<Permit, 'expiryDate' | 'rcdPermitId'> | null;
+  mostRecentPermit: Pick<Permit, 'expiryDate' | 'rcdPermitId'>;
 };
 
 /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* revert changes to applicants resolver which returned all applicants even if they have never had a permit. By reverting this change, we won't show applicants who have never had a permit in the permit holders table and in other use cases for viewing permit holders.
* Add seeding for permits so there are permit holders for testing
* Minor bug fix in App History Card which made the permit status badge always `ACTIVE`


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
