### PR TITLE
[Fix] Account for existing permit holder when creating and completing new APP applications

### DIFF
--- a/lib/application-processing/resolvers.ts
+++ b/lib/application-processing/resolvers.ts
@@ -264,43 +264,46 @@ export const completeApplication: Resolver<
           expiryDate,
           // Create a new applicant record
           applicant: {
-            create: {
-              firstName,
-              middleName,
-              lastName,
-              dateOfBirth,
-              gender,
-              otherGender,
-              phone,
-              email,
-              receiveEmailUpdates,
-              addressLine1,
-              addressLine2,
-              city,
-              province,
-              country,
-              postalCode,
-              // Connect application to newly created applicant
-              applications: {
-                connect: {
-                  id,
-                },
-              },
-              medicalInformation: {
-                create: {
-                  disability,
-                  disabilityCertificationDate,
-                  patientCondition,
-                  mobilityAids,
-                  otherPatientCondition,
-                  physician: {
-                    connect: { mspNumber: physicianMspNumber },
+            connectOrCreate: {
+              where: { id: applicantId || undefined },
+              create: {
+                firstName,
+                middleName,
+                lastName,
+                dateOfBirth,
+                gender,
+                otherGender,
+                phone,
+                email,
+                receiveEmailUpdates,
+                addressLine1,
+                addressLine2,
+                city,
+                province,
+                country,
+                postalCode,
+                // Connect application to newly created applicant
+                applications: {
+                  connect: {
+                    id,
                   },
                 },
+                medicalInformation: {
+                  create: {
+                    disability,
+                    disabilityCertificationDate,
+                    patientCondition,
+                    mobilityAids,
+                    otherPatientCondition,
+                    physician: {
+                      connect: { mspNumber: physicianMspNumber },
+                    },
+                  },
+                },
+                ...(guardian && {
+                  guardian: { create: guardian },
+                }),
               },
-              ...(guardian && {
-                guardian: { create: guardian },
-              }),
             },
           },
           // Connect permit to existing application

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -242,6 +242,7 @@ export const createNewApplication: Resolver<
     requiresWiderParkingSpaceReason,
     otherRequiresWiderParkingSpaceReason,
     donationAmount,
+    applicantId,
     ...data
   } = input;
 
@@ -256,6 +257,12 @@ export const createNewApplication: Resolver<
         type: 'NEW',
         processingFee: process.env.PROCESSING_FEE,
         donationAmount: donationAmount || 0,
+        // Connect to applicant if applicant exists in DB
+        ...(applicantId && {
+          applicant: {
+            connect: { id: applicantId },
+          },
+        }),
         ...data,
         newApplication: {
           create: {

--- a/lib/applications/schema.ts
+++ b/lib/applications/schema.ts
@@ -398,6 +398,8 @@ export default gql`
     billingProvince: Province
     billingCountry: String
     billingPostalCode: String
+
+    applicantId: Int
   }
 
   type CreateNewApplicationResult {

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -300,6 +300,7 @@ export type CreateNewApplicationInput = {
   billingProvince: Maybe<Province>;
   billingCountry: Maybe<Scalars['String']>;
   billingPostalCode: Maybe<Scalars['String']>;
+  applicantId: Maybe<Scalars['Int']>;
 };
 
 export type CreateNewApplicationResult = {

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -194,7 +194,7 @@ CREATE TABLE applicants (
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-  FOREIGN KEY(guardian_id) REFERENCES guardians(id),
+  FOREIGN KEY(guardian_id) REFERENCES guardians(id) ON DELETE SET NULL,
   FOREIGN KEY(medical_information_id) REFERENCES medical_information(id)
 );
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-Create-New-APP-API-eacde7c820684c1ca3c7009738180b5e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add `applicantId` as an optional parameter to `createNewApplication`, which connects the new application to the applicant if specified
* In `completeApplication`, for new applications, the resolver no longer creates a new applicant when the new application already has an applicant
  * If the applicant already exists, we update the applicant data (+medical information) and upsert guardian info if provided; if guardian info is not provided, we delete the guardian record
  * If the applicant does not exist, we create the permit and utilize Prisma transactions to create the applicant and connect the applicant to the application and permit


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
