### PR TITLE
[Improvement] Update payment method types

### DIFF
--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -138,7 +138,6 @@ export default gql`
     CASH
     CHEQUE
     DEBIT
-    MONEY_ORDER
     SHOPIFY
   }
 

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -781,7 +781,6 @@ export type PaymentType =
   | 'CASH'
   | 'CHEQUE'
   | 'DEBIT'
-  | 'MONEY_ORDER'
   | 'SHOPIFY';
 
 export type Permit = {

--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -262,7 +262,7 @@ export const generateAccountantReport: Resolver<
   } = args;
 
   const paymentTypeToString: Record<PaymentType, string> = {
-    MASTERCARD: 'MasterCard (Office)',
+    MASTERCARD: 'Mastercard (Office)',
     VISA: 'Visa (Office)',
     CASH: 'Cash',
     DEBIT: 'Interac - Debit (Office)',

--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -7,11 +7,13 @@ import {
   GenerateApplicationsReportResult,
   QueryGenerateAccountantReportArgs,
   GenerateAccountantReportResult,
+  PaymentType,
 } from '@lib/graphql/types';
 import { SortOrder } from '@tools/types';
-import { formatAddress, formatDate, formatFullName, formatPaymentType } from '@lib/utils/format'; // Formatting utils
+import { formatAddress, formatDate, formatFullName } from '@lib/utils/format'; // Formatting utils
 import { APPLICATIONS_COLUMNS, PERMIT_HOLDERS_COLUMNS } from '@tools/admin/reports';
 import { Prisma } from '@prisma/client';
+
 /**
  * Generates csv with permit holders' info, given a start date, end date, and values from
  * PermitHoldersReportColumn that the user would like to have on the generated csv
@@ -259,6 +261,16 @@ export const generateAccountantReport: Resolver<
     input: { startDate, endDate },
   } = args;
 
+  const paymentTypeToString: Record<PaymentType, string> = {
+    MASTERCARD: 'MasterCard (Office)',
+    VISA: 'Visa (Office)',
+    CASH: 'Cash',
+    DEBIT: 'Interac - Debit (Office)',
+    SHOPIFY: 'Shopify',
+    ETRANSFER: 'E-Transfer',
+    CHEQUE: 'Cheque',
+  };
+
   const paymentMethodGroups = await prisma.application.groupBy({
     by: ['paymentMethod'],
     where: {
@@ -289,7 +301,7 @@ export const generateAccountantReport: Resolver<
   const csvAccountantReportRows = [];
   for (const paymentMethodGroup of paymentMethodGroups) {
     csvAccountantReportRows.push({
-      rowName: formatPaymentType(paymentMethodGroup.paymentMethod),
+      rowName: paymentTypeToString[paymentMethodGroup.paymentMethod],
       countIssued: paymentMethodGroup._count.paymentMethod,
       processingFee: paymentMethodGroup._sum.processingFee || 0,
       donationAmount: paymentMethodGroup._sum.donationAmount || 0,

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -116,9 +116,8 @@ export const formatPaymentType = (paymentMethod: PaymentType): string => {
     MASTERCARD: 'MasterCard (Office)',
     VISA: 'Visa (Office)',
     CASH: 'Cash',
-    DEBIT: 'Debit',
+    DEBIT: 'Interac - Debit (Office)',
     SHOPIFY: 'Shopify',
-    MONEY_ORDER: 'Money Order',
     ETRANSFER: 'E-Transfer',
     CHEQUE: 'Cheque',
   };

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -1,4 +1,4 @@
-import { PaymentType, Province } from '@lib/graphql/types';
+import { Province } from '@lib/graphql/types';
 
 /**
  * Format North American phone number by removing all non-numeric characters.
@@ -104,22 +104,4 @@ ${province ? `${city} ${province}` : city}
 ${country || ''}
 ${postalCode}
   `;
-};
-
-/**
- * Format database payment types to respective CSV column name
- * @param {PaymentType} paymentMethod payment method to be formatted
- * @returns {string} formatted payment method
- */
-export const formatPaymentType = (paymentMethod: PaymentType): string => {
-  const paymentTypeToString: Record<PaymentType, string> = {
-    MASTERCARD: 'MasterCard (Office)',
-    VISA: 'Visa (Office)',
-    CASH: 'Cash',
-    DEBIT: 'Interac - Debit (Office)',
-    SHOPIFY: 'Shopify',
-    ETRANSFER: 'E-Transfer',
-    CHEQUE: 'Cheque',
-  };
-  return paymentTypeToString[paymentMethod];
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -321,7 +321,7 @@ enum ApplicantStatus {
   ACTIVE
   INACTIVE
 
-   @@map("applicantstatus")
+  @@map("applicantstatus")
 }
 
 enum Gender {
@@ -329,7 +329,7 @@ enum Gender {
   FEMALE
   OTHER
 
-   @@map("gender")
+  @@map("gender")
 }
 
 enum PaymentType {
@@ -341,14 +341,14 @@ enum PaymentType {
   DEBIT
   SHOPIFY
 
-   @@map("paymenttype")
+  @@map("paymenttype")
 }
 
 enum PhysicianStatus {
   ACTIVE
   INACTIVE
 
-   @@map("physicianstatus")
+  @@map("physicianstatus")
 }
 
 enum Province {
@@ -366,7 +366,7 @@ enum Province {
   NT
   YT
 
-   @@map("province")
+  @@map("province")
 }
 
 enum Role {
@@ -374,7 +374,7 @@ enum Role {
   ACCOUNTING
   SECRETARY
 
-   @@map("role")
+  @@map("role")
 }
 
 enum ApplicationStatus {
@@ -383,7 +383,7 @@ enum ApplicationStatus {
   REJECTED
   COMPLETED
 
-   @@map("applicationstatus")
+  @@map("applicationstatus")
 }
 
 enum ReasonForReplacement {
@@ -391,21 +391,21 @@ enum ReasonForReplacement {
   STOLEN
   OTHER
 
-   @@map("reasonforreplacement")
+  @@map("reasonforreplacement")
 }
 
 enum PermitType {
   PERMANENT
   TEMPORARY
 
-   @@map("permittype")
+  @@map("permittype")
 }
 
 enum AccessibleConvertedVanLoadingMethod {
   SIDE_LOADING
   END_LOADING
 
-   @@map("accessibleconvertedvanloadingmethod")
+  @@map("accessibleconvertedvanloadingmethod")
 }
 
 enum ApplicationType {
@@ -413,7 +413,7 @@ enum ApplicationType {
   RENEWAL
   REPLACEMENT
 
-   @@map("applicationtype")
+  @@map("applicationtype")
 }
 
 enum MobilityAid {
@@ -423,7 +423,7 @@ enum MobilityAid {
   SCOOTER
   WALKER
 
-   @@map("mobilityaid")
+  @@map("mobilityaid")
 }
 
 enum PatientCondition {
@@ -432,7 +432,7 @@ enum PatientCondition {
   CANNOT_WALK_100M
   OTHER
 
-   @@map("patientcondition")
+  @@map("patientcondition")
 }
 
 enum RequiresWiderParkingSpaceReason {
@@ -440,12 +440,12 @@ enum RequiresWiderParkingSpaceReason {
   MEDICAL_REASONS
   OTHER
 
-   @@map("requireswiderparkingspacereason")
+  @@map("requireswiderparkingspacereason")
 }
 
 enum ShopifyPaymentStatus {
   PENDING
   RECEIVED
 
-   @@map("shopifypaymentstatus")
+  @@map("shopifypaymentstatus")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -321,7 +321,7 @@ enum ApplicantStatus {
   ACTIVE
   INACTIVE
 
-  @@map("applicantstatus")
+   @@map("applicantstatus")
 }
 
 enum Gender {
@@ -329,7 +329,7 @@ enum Gender {
   FEMALE
   OTHER
 
-  @@map("gender")
+   @@map("gender")
 }
 
 enum PaymentType {
@@ -339,17 +339,16 @@ enum PaymentType {
   CASH
   CHEQUE
   DEBIT
-  MONEY_ORDER
   SHOPIFY
 
-  @@map("paymenttype")
+   @@map("paymenttype")
 }
 
 enum PhysicianStatus {
   ACTIVE
   INACTIVE
 
-  @@map("physicianstatus")
+   @@map("physicianstatus")
 }
 
 enum Province {
@@ -367,7 +366,7 @@ enum Province {
   NT
   YT
 
-  @@map("province")
+   @@map("province")
 }
 
 enum Role {
@@ -375,7 +374,7 @@ enum Role {
   ACCOUNTING
   SECRETARY
 
-  @@map("role")
+   @@map("role")
 }
 
 enum ApplicationStatus {
@@ -384,7 +383,7 @@ enum ApplicationStatus {
   REJECTED
   COMPLETED
 
-  @@map("applicationstatus")
+   @@map("applicationstatus")
 }
 
 enum ReasonForReplacement {
@@ -392,21 +391,21 @@ enum ReasonForReplacement {
   STOLEN
   OTHER
 
-  @@map("reasonforreplacement")
+   @@map("reasonforreplacement")
 }
 
 enum PermitType {
   PERMANENT
   TEMPORARY
 
-  @@map("permittype")
+   @@map("permittype")
 }
 
 enum AccessibleConvertedVanLoadingMethod {
   SIDE_LOADING
   END_LOADING
 
-  @@map("accessibleconvertedvanloadingmethod")
+   @@map("accessibleconvertedvanloadingmethod")
 }
 
 enum ApplicationType {
@@ -414,7 +413,7 @@ enum ApplicationType {
   RENEWAL
   REPLACEMENT
 
-  @@map("applicationtype")
+   @@map("applicationtype")
 }
 
 enum MobilityAid {
@@ -424,7 +423,7 @@ enum MobilityAid {
   SCOOTER
   WALKER
 
-  @@map("mobilityaid")
+   @@map("mobilityaid")
 }
 
 enum PatientCondition {
@@ -433,7 +432,7 @@ enum PatientCondition {
   CANNOT_WALK_100M
   OTHER
 
-  @@map("patientcondition")
+   @@map("patientcondition")
 }
 
 enum RequiresWiderParkingSpaceReason {
@@ -441,12 +440,12 @@ enum RequiresWiderParkingSpaceReason {
   MEDICAL_REASONS
   OTHER
 
-  @@map("requireswiderparkingspacereason")
+   @@map("requireswiderparkingspacereason")
 }
 
 enum ShopifyPaymentStatus {
   PENDING
   RECEIVED
 
-  @@map("shopifypaymentstatus")
+   @@map("shopifypaymentstatus")
 }

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -26,7 +26,6 @@ CREATE TYPE PaymentType as ENUM(
   'CASH',
   'CHEQUE',
   'DEBIT',
-  'MONEY_ORDER',
   'SHOPIFY'
 );
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update platform payment methods](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=ba333538f3c34c56ba2df2555f51347c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove MONEY_ORDER payment method
* Change display of debit to `Interac - Debit (Office)` in table
* Verify that no conflicts with seeding data

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Currently `populate-db-[timestamp].js` has a switch function that operates on the Money_Order data. Not sure if this is to be removed. 


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
