### PR TITLE
[Fix] Fix accountant report aggregation bug

### DIFF
--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -277,6 +277,12 @@ export const generateAccountantReport: Resolver<
   });
 
   const totalAggregate = await prisma.application.aggregate({
+    where: {
+      createdAt: {
+        gte: startDate,
+        lte: endDate,
+      },
+    },
     _sum: {
       processingFee: true,
       donationAmount: true,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix accountant report aggregation](https://www.notion.so/uwblueprintexecs/Fix-accountant-report-aggregation-6749e1a1ec87412abee6be8cd23eff3b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The Prisma Aggregation Information was not previously being filtered by date. A small code fix was all that was needed to fix the bug (I believe 🤞). Now Fixed Images Below.

One Application Removed via Date Selector:
![image](https://user-images.githubusercontent.com/30203792/154604647-20ed2279-8c37-473b-b9a0-955abfdd856e.png)
No Applications Removed via Date Selector:
![image](https://user-images.githubusercontent.com/30203792/154604681-4bcbaff2-829b-4386-b815-a6f9c90e0bd1.png)

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
