### PR TITLE
[Fix] Fix payment confirmation email not sending in staging

### DIFF
--- a/pages/api/payment-received.ts
+++ b/pages/api/payment-received.ts
@@ -1,5 +1,6 @@
 import { NextApiHandler } from 'next'; // Next
 import { Prisma, ShopifyPaymentStatus } from '@prisma/client'; // Prisma client
+import prisma from '@prisma/index'; // Prisma client
 import crypto from 'crypto'; // Verifying Shopify Request
 import getRawBody from 'raw-body';
 import sendConfirmationEmail from '@lib/reports/utils';


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix payment confirmation email not sending in staging](https://www.notion.so/uwblueprintexecs/Fix-payment-confirmation-email-not-sending-in-staging-e3849b0ba9ee4f5c8ee3cab8de60bf09)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* prisma is not defined in the payment received handler and needed to be imported
![image](https://user-images.githubusercontent.com/51224641/157578681-5d676112-13c9-40a5-a03b-fc5ef569648b.png)

* [NOT VISIBLE IN THIS PR] `CONFIRMATION_EMAIL_FROM` env variable was also missing from the staging and was added to resolve the issue

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
