### PR TITLE
[Fix] Added Address Title to Doctor's Information Card

### DIFF
--- a/components/admin/requests/doctor-information/Card.tsx
+++ b/components/admin/requests/doctor-information/Card.tsx
@@ -120,6 +120,9 @@ const Card: FC<Props> = props => {
         </VStack>
         <Divider />
         <VStack spacing="12px" align="left">
+          <Text as="h4" textStyle="body-bold">
+            Address
+          </Text>
           <Address address={{ addressLine1, addressLine2, city, province, country, postalCode }} />
         </VStack>
       </VStack>


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Hotfix that adds address title to personal information card.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Fixes first design suggestion in #156 by @carelynntsai 


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
