### PR TITLE
[Feature] Build Undo Confirmation Modal For Processing Tasks

### DIFF
--- a/components/admin/requests/processing/ReviewInformationStep.tsx
+++ b/components/admin/requests/processing/ReviewInformationStep.tsx
@@ -11,6 +11,7 @@ import PersonalInformationCard from '@components/admin/requests/permit-holder-in
 import ReasonForReplacementCard from '@components/admin/requests/reason-for-replacement/Card';
 import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card';
 import GuardianInformationCard from '@components/admin/requests/guardian-information/Card';
+import UndoReviewRequestModal from '@components/admin/requests/processing/UndoReviewRequestModal';
 
 import {
   Modal,
@@ -96,11 +97,13 @@ export default function ReviewInformationStep({
   return (
     <>
       {isCompleted ? (
-        <Button color={'black'} variant="ghost" textDecoration="underline black" onClick={onUndo}>
-          <Text textStyle="caption" color="black">
-            Undo Review
-          </Text>
-        </Button>
+        <UndoReviewRequestModal onUndoConfirmed={onUndo}>
+          <Button color={'black'} variant="ghost" textDecoration="underline black">
+            <Text textStyle="caption" color="black">
+              Undo Review
+            </Text>
+          </Button>
+        </UndoReviewRequestModal>
       ) : (
         <Button
           marginLeft="auto"

--- a/components/admin/requests/processing/UndoReviewRequestModal.tsx
+++ b/components/admin/requests/processing/UndoReviewRequestModal.tsx
@@ -1,0 +1,68 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  Text,
+  Box,
+  useDisclosure,
+} from '@chakra-ui/react'; // Chakra UI
+import { ReactNode } from 'react'; // React JSX Type
+
+type UndoReviewRequestProps = {
+  readonly onUndoConfirmed: () => void;
+  readonly children: ReactNode;
+};
+/**
+ * Modal for Back To Search Button Going Back to Requests
+ * @param children ReactNode children elements in component
+ */
+export default function UndoReviewRequestModal({
+  children,
+  onUndoConfirmed,
+}: UndoReviewRequestProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Box onClick={onOpen}>{children}</Box>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Undo Review Request</ModalHeader>
+          <ModalBody>
+            <Text textStyle="body-regular" paddingBottom="39px">
+              If you undo this step, editing will be re-enabled on the request. However, you will
+              need to redo all subsequent processing tasks.
+            </Text>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              bg="background.gray"
+              _hover={{ bg: 'background.grayHover' }}
+              color="black"
+              marginRight={3}
+              onClick={onClose}
+            >
+              <Text textStyle="button-semibold">Close</Text>
+            </Button>
+            <Button
+              bg="secondary.critical"
+              _hover={{ bg: 'secondary.criticalHover' }}
+              onClick={() => {
+                onClose();
+                onUndoConfirmed();
+              }}
+            >
+              <Text textStyle="button-semibold">Undo Review</Text>
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Undo Review Confirmation Request modal](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=ac3417562c394db095887e4f504b3420)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `UndoReviewRequestModal` to components & hooked up with button:
<img width="498" alt="modal" src="https://user-images.githubusercontent.com/30203792/160264921-74a74c12-88ca-4a5a-9ec0-d3836f4798ba.png">

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
