### PR TITLE
[Fix] Fix request and permit holder tables not updating after edit

### DIFF
--- a/components/admin/permit-holders/permit-holder-information/EditModal.tsx
+++ b/components/admin/permit-holders/permit-holder-information/EditModal.tsx
@@ -198,18 +198,6 @@ export default function EditUserInformationModal({
                       {'Example: 000-000-0000'}
                     </FormHelperText>
                   </FormControl>
-
-                  <FormControl isRequired>
-                    <FormLabel>{'Phone number'}</FormLabel>
-                    <Input
-                      value={phoneNumber}
-                      onChange={event => setPhoneNumber(event.target.value)}
-                      type="tel"
-                    />
-                    <FormHelperText color="text.secondary">
-                      {'Example: 000-000-0000'}
-                    </FormHelperText>
-                  </FormControl>
                 </Stack>
               </Box>
 

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -153,52 +153,55 @@ const Requests: NextPage = () => {
   const [recordsCount, setRecordsCount] = useState(0);
 
   // Make query to applications resolver
-  useQuery<GetApplicationsResponse, GetApplicationsRequest>(GET_APPLICATIONS_QUERY, {
-    variables: {
-      filter: {
-        order: sortOrder,
-        permitType: permitTypeFilter || null,
-        requestType: requestTypeFilter || null,
-        status: statusFilter || null,
-        search: debouncedSearchFilter,
-        offset: pageNumber * PAGE_SIZE,
-        limit: PAGE_SIZE,
+  const { refetch } = useQuery<GetApplicationsResponse, GetApplicationsRequest>(
+    GET_APPLICATIONS_QUERY,
+    {
+      variables: {
+        filter: {
+          order: sortOrder,
+          permitType: permitTypeFilter || null,
+          requestType: requestTypeFilter || null,
+          status: statusFilter || null,
+          search: debouncedSearchFilter,
+          offset: pageNumber * PAGE_SIZE,
+          limit: PAGE_SIZE,
+        },
       },
-    },
-    notifyOnNetworkStatusChange: true,
-    onCompleted: ({ applications: { result, totalCount } }) => {
-      setRequestsData(
-        result.map(
-          ({
-            id,
-            firstName,
-            middleName,
-            lastName,
-            createdAt,
-            applicant,
-            processing: { status },
-            ...application
-          }) => ({
-            id,
-            name: {
-              id: applicant?.id || null,
+      onCompleted: ({ applications: { result, totalCount } }) => {
+        setRequestsData(
+          result.map(
+            ({
+              id,
               firstName,
               middleName,
               lastName,
-            },
-            dateReceived: createdAt,
-            status,
-            ...application,
-          })
-        )
-      );
-      setRecordsCount(totalCount);
-    },
-  });
+              createdAt,
+              applicant,
+              processing: { status },
+              ...application
+            }) => ({
+              id,
+              name: {
+                id: applicant?.id || null,
+                firstName,
+                middleName,
+                lastName,
+              },
+              dateReceived: createdAt,
+              status,
+              ...application,
+            })
+          )
+        );
+        setRecordsCount(totalCount);
+      },
+    }
+  );
 
   // Set page number to 0 after every filter or sort change
   useEffect(() => {
     setPageNumber(0);
+    refetch();
   }, [statusFilter, permitTypeFilter, requestTypeFilter, debouncedSearchFilter, sortOrder]);
 
   return (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-tables-not-updating-when-navigating-back-02f8c3aa3af04d4c8ee994a5b8655ce4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Force refetch of requests/permit holders when navigating to table pages to include updates to individual records
* Implemented temporary fix for permit holders table to skip the cache (unideal, added alert comment)
* Fixed minor bug where there are 2 phone number fields in the edit permit holder information modal of the permit holder page


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* N/A


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
