### PR TITLE
[Bugfix] Disallow Inactive Employee Login

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -87,12 +87,19 @@ export default NextAuth({
         const validatedUser = await loginSchema.validate(user);
 
         // Check if user email exists in DB (throw error if not found)
-        await prisma.employee.findUnique({
+        const employee = await prisma.employee.findUnique({
           where: {
             email: validatedUser.email,
           },
+          select: {
+            active: true,
+          },
           rejectOnNotFound: true,
         });
+
+        if (!employee.active) {
+          throw new VerifySignInError('This employee is not active');
+        }
 
         return true;
       } catch (err) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Disallow inactive employee login](https://www.notion.so/uwblueprintexecs/Disallow-inactive-employee-login-5adf3b5980fe46e88972063dca9946f0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Active field is not a findUnique input so I used to select to grab the active field from the matched record and checked if the employee was active
* Because this operation is in a try catch block, the stored result `employee` is not accessible to the catch block so the conditional check if employee is active as well as the throw error statement is in the try block


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
