### PR TITLE
[Improvement] Set Permit Holder as Inactive Modal API Hookup

### DIFF
--- a/components/admin/permit-holders/table/ConfirmSetInactiveModal.tsx
+++ b/components/admin/permit-holders/table/ConfirmSetInactiveModal.tsx
@@ -11,11 +11,20 @@ import {
   FormControl,
   FormLabel,
   Textarea,
+  useToast,
 } from '@chakra-ui/react'; // Chakra UI
+import { useMutation } from '@apollo/client';
+import {
+  SetApplicantAsInactiveRequest,
+  SetApplicantAsInactiveResponse,
+  SET_APPLICANT_AS_INACTIVE,
+} from '@tools/admin/permit-holders/permit-holders-table';
 
 //Props
 type SetPermitHolderToInactiveModalProps = {
   readonly isOpen: boolean;
+  readonly permitHolderId: number;
+  readonly refetch: () => void;
   readonly onClose: () => void;
 };
 
@@ -24,11 +33,35 @@ type SetPermitHolderToInactiveModalProps = {
  */
 export default function SetPermitHolderToInactiveModal({
   isOpen,
+  permitHolderId,
+  refetch,
   onClose,
 }: SetPermitHolderToInactiveModalProps) {
   // Reason for setting permit holder as inactive state
   const [inactiveReason, setInactiveReason] = useState<string>('');
 
+  const toast = useToast();
+
+  // API Call to setApplicantAsInactive
+  const [setApplicantAsInactive] = useMutation<
+    SetApplicantAsInactiveResponse,
+    SetApplicantAsInactiveRequest
+  >(SET_APPLICANT_AS_INACTIVE, {
+    onCompleted: data => {
+      if (data.setApplicantAsInactive.ok) {
+        toast({
+          status: 'success',
+          description: `Applicant status has been set to inactive.`,
+        });
+      }
+    },
+    onError: error => {
+      toast({
+        status: 'error',
+        description: error.message,
+      });
+    },
+  });
   // Close modal handler
   const handleClose = () => {
     setInactiveReason('');
@@ -37,8 +70,14 @@ export default function SetPermitHolderToInactiveModal({
 
   // Sets permit holder status to inactive and closes modal
   // TODO: API hookup
-  const handleSubmit = (event: SyntheticEvent) => {
+  const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
+    if (inactiveReason)
+      await setApplicantAsInactive({
+        variables: { input: { id: permitHolderId, reason: inactiveReason } },
+      });
+    setInactiveReason('');
+    refetch();
     onClose();
   };
 

--- a/components/admin/permit-holders/table/ConfirmSetInactiveModal.tsx
+++ b/components/admin/permit-holders/table/ConfirmSetInactiveModal.tsx
@@ -23,7 +23,7 @@ import {
 //Props
 type SetPermitHolderToInactiveModalProps = {
   readonly isOpen: boolean;
-  readonly permitHolderId: number;
+  readonly applicantId: number;
   readonly refetch: () => void;
   readonly onClose: () => void;
 };
@@ -33,7 +33,7 @@ type SetPermitHolderToInactiveModalProps = {
  */
 export default function SetPermitHolderToInactiveModal({
   isOpen,
-  permitHolderId,
+  applicantId,
   refetch,
   onClose,
 }: SetPermitHolderToInactiveModalProps) {
@@ -72,10 +72,16 @@ export default function SetPermitHolderToInactiveModal({
   // TODO: API hookup
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
-    if (inactiveReason)
+    if (inactiveReason) {
       await setApplicantAsInactive({
-        variables: { input: { id: permitHolderId, reason: inactiveReason } },
+        variables: { input: { id: applicantId, reason: inactiveReason } },
       });
+    } else {
+      toast({
+        status: 'error',
+        description: 'Inactive reason cannot be blank.',
+      });
+    }
     setInactiveReason('');
     refetch();
     onClose();

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -449,7 +449,7 @@ const PermitHolders: NextPage = () => {
       {permitHolderToUpdateStatus?.status === 'ACTIVE' && (
         <SetPermitHolderToInactiveModal
           isOpen={isSetPermitHolderStatusModalOpen}
-          permitHolderId={permitHolderToUpdateStatus.id}
+          applicantId={permitHolderToUpdateStatus.id}
           refetch={refetch}
           onClose={onCloseSetPermitHolderStatusModal}
         />

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -92,6 +92,7 @@ const PermitHolders: NextPage = () => {
       },
       // ! Temporary fix to force permit holder row updates when navigating (skip cache)
       fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
       onCompleted: ({ applicants: { result, totalCount } }) => {
         setPermitHolderData(
           result.map(
@@ -448,6 +449,8 @@ const PermitHolders: NextPage = () => {
       {permitHolderToUpdateStatus?.status === 'ACTIVE' && (
         <SetPermitHolderToInactiveModal
           isOpen={isSetPermitHolderStatusModalOpen}
+          permitHolderId={permitHolderToUpdateStatus.id}
+          refetch={refetch}
           onClose={onCloseSetPermitHolderStatusModal}
         />
       )}

--- a/tools/admin/permit-holders/permit-holders-table.ts
+++ b/tools/admin/permit-holders/permit-holders-table.ts
@@ -5,6 +5,8 @@ import {
   Permit,
   PermitStatus,
   ApplicantStatus,
+  MutationSetApplicantAsInactiveArgs,
+  SetApplicantAsInactiveResult,
 } from '@lib/graphql/types';
 
 /** Array of permit statuses */
@@ -101,4 +103,20 @@ export type GetPermitHoldersResponse = {
     result: ReadonlyArray<PermitHolder>;
     totalCount: number;
   };
+};
+
+export const SET_APPLICANT_AS_INACTIVE = gql`
+  mutation setApplicantAsInactive($input: SetApplicantAsInactiveInput!) {
+    setApplicantAsInactive(input: $input) {
+      ok
+    }
+  }
+`;
+
+// Generate applicants report query arguments
+export type SetApplicantAsInactiveRequest = MutationSetApplicantAsInactiveArgs;
+
+// Generate applicants report query result
+export type SetApplicantAsInactiveResponse = {
+  setApplicantAsInactive: SetApplicantAsInactiveResult;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Hookup set as inactive modal to setApplicantAsInactive endpoint](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=776057668aee4f44b28869c5e23b4ec1)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Hooked up the inactive modal to actually change the status of the applicant via the backend gql mutation

[Working Video](https://www.loom.com/share/8875d24cb09b43ce8478d17c6cab8979)

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
