### PR TITLE
[Fix] Prevent API updates to applications if review step is completed

### DIFF
--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -6,6 +6,7 @@ import {
   ApplicationFieldTooLongError,
   UpdatedFieldsMissingError,
   EmptyFieldsMissingError,
+  ApplicationNotFoundError,
 } from '@lib/applications/errors'; // Application errors
 import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant errors
 import { DBErrorCode, getUniqueConstraintFailedFields } from '@lib/db/errors'; // Database errors
@@ -719,6 +720,24 @@ export const updateApplicationGeneralInformation: Resolver<
   const { input } = args;
   const { id, receiveEmailUpdates, postalCode, ...data } = input;
 
+  // Prevent reviewed requests from being updated
+  const application = await prisma.application.findUnique({
+    where: { id },
+    select: {
+      applicationProcessing: {
+        select: {
+          reviewRequestCompleted: true,
+        },
+      },
+    },
+  });
+  if (!application) {
+    throw new ApplicationNotFoundError(`Application with ID ${id} not found`);
+  }
+  if (application.applicationProcessing.reviewRequestCompleted) {
+    throw new ApolloError('Reviewed requests cannot be updated');
+  }
+
   let updatedApplication;
   try {
     updatedApplication = await prisma.application.update({
@@ -752,6 +771,24 @@ export const updateNewApplicationGeneralInformation: Resolver<
   // TODO: Validation
   const { input } = args;
   const { id, receiveEmailUpdates, postalCode, dateOfBirth, gender, otherGender, ...data } = input;
+
+  // Prevent reviewed requests from being updated
+  const application = await prisma.application.findUnique({
+    where: { id },
+    select: {
+      applicationProcessing: {
+        select: {
+          reviewRequestCompleted: true,
+        },
+      },
+    },
+  });
+  if (!application) {
+    throw new ApplicationNotFoundError(`Application with ID ${id} not found`);
+  }
+  if (application.applicationProcessing.reviewRequestCompleted) {
+    throw new ApolloError('Reviewed requests cannot be updated');
+  }
 
   let updatedApplication;
   try {
@@ -806,11 +843,23 @@ export const updateApplicationDoctorInformation: Resolver<
 
   const application = await prisma.application.findUnique({
     where: { id },
-    select: { type: true },
+    select: {
+      type: true,
+      applicationProcessing: {
+        select: {
+          reviewRequestCompleted: true,
+        },
+      },
+    },
   });
 
   if (!application) {
     throw new ApolloError('Application not found');
+  }
+
+  // Prevent reviewed requests from being updated
+  if (application.applicationProcessing.reviewRequestCompleted) {
+    throw new ApolloError('Reviewed requests cannot be updated');
   }
 
   const { type } = application;
@@ -933,10 +982,21 @@ export const updateApplicationPaymentInformation: Resolver<
 
   const application = await prisma.application.findUnique({
     where: { id },
-    select: { paidThroughShopify: true },
+    select: {
+      paidThroughShopify: true,
+      applicationProcessing: {
+        select: {
+          reviewRequestCompleted: true,
+        },
+      },
+    },
   });
   if (!application) {
     throw new ApolloError('Application does not exist');
+  }
+  // Prevent reviewed requests from being updated
+  if (application.applicationProcessing.reviewRequestCompleted) {
+    throw new ApolloError('Reviewed requests cannot be updated');
   }
 
   // Payment info should not be updated for applications paid through Shopify
@@ -979,6 +1039,24 @@ export const updateApplicationReasonForReplacement: Resolver<
   // TODO: Validation
   const { input } = args;
   const { id, ...data } = input;
+
+  // Prevent reviewed requests from being updated
+  const application = await prisma.application.findUnique({
+    where: { id },
+    select: {
+      applicationProcessing: {
+        select: {
+          reviewRequestCompleted: true,
+        },
+      },
+    },
+  });
+  if (!application) {
+    throw new ApplicationNotFoundError(`Application with ID ${id} not found`);
+  }
+  if (application.applicationProcessing.reviewRequestCompleted) {
+    throw new ApolloError('Reviewed requests cannot be updated');
+  }
 
   let updatedApplication;
   try {

--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -1,4 +1,4 @@
-import { createObjectCsvStringifier, createObjectCsvWriter } from 'csv-writer';
+import { createObjectCsvStringifier } from 'csv-writer';
 import { Resolver } from '@lib/graphql/resolvers';
 import {
   QueryGeneratePermitHoldersReportArgs,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Prevent API updates to applications if review step is completed](https://www.notion.so/uwblueprintexecs/Prevent-API-updates-to-applications-if-review-step-is-completed-a99759aafc7f4f99994bd9cc1807e17f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Queried for `reviewRequestCompleted` and threw error if value is true.

 Tested locally and the following error is thrown when trying to update while the review request step is marked as completed:

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/51224641/166132084-ebf2fb98-80c9-455a-b65a-f11fdec4f4eb.png">



<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* All the update resolvers in `lib/applications/resolvers.ts` throw if `reviewRequestCompleted` is true ~~except for `updateApplicationPhysicianAssessment` and `updateApplicationAdditionalInformation`. These resolvers aren't hooked up anywhere on the frontend afaik and don't seem related.~~


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket