### PR TITLE
[Fix] Disable edit on cards when review request completed

### DIFF
--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -83,15 +83,22 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
       </GridItem>
       <GridItem colStart={1} colSpan={5} textAlign="left">
         <VStack width="100%" spacing="20px" align="stretch">
-          <PersonalInformationCard applicationId={id} />
-          {type !== 'REPLACEMENT' && <DoctorInformationCard applicationId={id} />}
+          <PersonalInformationCard applicationId={id} editDisabled={reviewRequestCompleted} />
+          {type !== 'REPLACEMENT' && (
+            <DoctorInformationCard applicationId={id} editDisabled={reviewRequestCompleted} />
+          )}
         </VStack>
       </GridItem>
       <GridItem colStart={6} colSpan={7}>
         <VStack width="100%" spacing="20px" align="stretch">
           {status === 'IN_PROGRESS' && <ProcessingTasksCard applicationId={id} />}
-          {type === 'REPLACEMENT' && <ReasonForReplacementCard applicationId={id} />}
-          <PaymentInformationCard applicationId={id} editDisabled={paidThroughShopify} />
+          {type === 'REPLACEMENT' && (
+            <ReasonForReplacementCard applicationId={id} editDisabled={reviewRequestCompleted} />
+          )}
+          <PaymentInformationCard
+            applicationId={id}
+            editDisabled={paidThroughShopify || reviewRequestCompleted}
+          />
         </VStack>
       </GridItem>
     </Layout>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Cards Still Editable after Review Request step complete](https://www.notion.so/uwblueprintexecs/Cards-Still-Editable-after-Review-Request-step-complete-921c45f0f2ea496a977c6bd4b7ef91e6)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add `editDisabled` condition to all cards


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 
<img width="1239" alt="" src="https://user-images.githubusercontent.com/35577524/166147422-4451f260-e541-4487-bd97-41a401721423.png">
<img width="1190" alt="" src="https://user-images.githubusercontent.com/35577524/166147427-93ab3c5a-f511-4c69-8c9f-b40f268f7138.png">



## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
