### PR TITLE
[Improvement] Additional Notes API + Hookup

### DIFF
--- a/components/admin/permit-holders/Header.tsx
+++ b/components/admin/permit-holders/Header.tsx
@@ -129,7 +129,12 @@ export default function PermitHolderHeader({
       )}
 
       {/* Additional notes modal */}
-      <AdditionalNotesModal isOpen={isNotesModalOpen} notes="" onClose={onCloseNotesModal} />
+      <AdditionalNotesModal
+        isOpen={isNotesModalOpen}
+        notes=""
+        applicantId={id}
+        onClose={onCloseNotesModal}
+      />
     </>
   );
 }

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -8,6 +8,7 @@ import {
   MutationUpdateApplicantDoctorInformationArgs,
   MutationUpdateApplicantGeneralInformationArgs,
   MutationUpdateApplicantGuardianInformationArgs,
+  MutationUpdateApplicantNotesArgs,
   MutationVerifyIdentityArgs,
   QueryApplicantArgs,
   QueryApplicantsArgs,
@@ -16,6 +17,7 @@ import {
   UpdateApplicantDoctorInformationResult,
   UpdateApplicantGeneralInformationResult,
   UpdateApplicantGuardianInformationResult,
+  UpdateApplicantNotesResult,
   VerifyIdentityResult,
 } from '@lib/graphql/types'; // GraphQL types
 import { DateUtils } from 'react-day-picker'; // Date utils
@@ -482,4 +484,35 @@ export const verifyIdentity: Resolver<MutationVerifyIdentityArgs, VerifyIdentity
     failureReason: null,
     applicantId: applicant.id,
   };
+};
+
+/**
+ * Update Applicant Notes to string provided
+ * @returns Status of the operation (ok)
+ */
+export const updateApplicantNotes: Resolver<
+  MutationUpdateApplicantNotesArgs,
+  UpdateApplicantNotesResult
+> = async (_parent, args, { prisma }) => {
+  // TODO: Validation
+  const { input } = args;
+  const { id, notes } = input;
+
+  let updatedApplicant;
+  try {
+    updatedApplicant = await prisma.applicant.update({
+      where: { id },
+      data: {
+        notes: notes,
+      },
+    });
+  } catch {
+    // TODO: Error handling
+  }
+
+  if (!updatedApplicant) {
+    throw new ApolloError('Unable to update applicant notes');
+  }
+
+  return { ok: true };
 };

--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -182,4 +182,14 @@ export default gql`
     APP_DOES_NOT_EXPIRE_WITHIN_30_DAYS
     USER_HOLDS_TEMPORARY_PERMIT
   }
+
+  # Update Additional Notes for Applicant
+  input UpdateApplicantNotesInput {
+    id: Int!
+    notes: String!
+  }
+
+  type UpdateApplicantNotesResult {
+    ok: Boolean!
+  }
 `;

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -15,6 +15,7 @@ import {
   updateApplicantGuardianInformation,
   setApplicantAsActive,
   setApplicantAsInactive,
+  updateApplicantNotes,
   verifyIdentity,
 } from '@lib/applicants/resolvers'; // Applicant resolvers
 import {
@@ -144,6 +145,7 @@ const resolvers = {
     // Applicants
     updateApplicantGeneralInformation: authorize(updateApplicantGeneralInformation, ['SECRETARY']),
     updateApplicantDoctorInformation: authorize(updateApplicantDoctorInformation, ['SECRETARY']),
+    updateApplicantNotes: authorize(updateApplicantNotes, ['SECRETARY']),
     updateApplicantGuardianInformation: authorize(updateApplicantGuardianInformation, [
       'SECRETARY',
     ]),

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -42,6 +42,7 @@ export default gql`
     setApplicantAsActive(input: SetApplicantAsActiveInput!): SetApplicantAsActiveResult
     setApplicantAsInactive(input: SetApplicantAsInactiveInput!): SetApplicantAsInactiveResult
     verifyIdentity(input: VerifyIdentityInput!): VerifyIdentityResult!
+    updateApplicantNotes(input: UpdateApplicantNotesInput!): UpdateApplicantNotesResult!
 
     # Applications
     createNewApplication(input: CreateNewApplicationInput!): CreateNewApplicationResult

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -540,6 +540,7 @@ export type Mutation = {
   setApplicantAsActive: Maybe<SetApplicantAsActiveResult>;
   setApplicantAsInactive: Maybe<SetApplicantAsInactiveResult>;
   verifyIdentity: VerifyIdentityResult;
+  updateApplicantNotes: UpdateApplicantNotesResult;
   createNewApplication: Maybe<CreateNewApplicationResult>;
   createRenewalApplication: Maybe<CreateRenewalApplicationResult>;
   createExternalRenewalApplication: CreateExternalRenewalApplicationResult;
@@ -594,6 +595,11 @@ export type MutationSetApplicantAsInactiveArgs = {
 
 export type MutationVerifyIdentityArgs = {
   input: VerifyIdentityInput;
+};
+
+
+export type MutationUpdateApplicantNotesArgs = {
+  input: UpdateApplicantNotesInput;
 };
 
 
@@ -1153,6 +1159,16 @@ export type UpdateApplicantGuardianInformationInput = {
 
 export type UpdateApplicantGuardianInformationResult = {
   __typename?: 'UpdateApplicantGuardianInformationResult';
+  ok: Scalars['Boolean'];
+};
+
+export type UpdateApplicantNotesInput = {
+  id: Scalars['Int'];
+  notes: Scalars['String'];
+};
+
+export type UpdateApplicantNotesResult = {
+  __typename?: 'UpdateApplicantNotesResult';
   ok: Scalars['Boolean'];
 };
 

--- a/tools/admin/permit-holders/additional-notes.ts
+++ b/tools/admin/permit-holders/additional-notes.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client';
+import { MutationUpdateApplicantNotesArgs, UpdateApplicantNotesResult } from '@lib/graphql/types';
+
+/** Update additional notes section */
+export const UPDATE_APPLICANT_NOTES = gql`
+  mutation UpdateApplicantNotes($input: UpdateApplicantNotesInput!) {
+    updateApplicantNotes(input: $input) {
+      ok
+    }
+  }
+`;
+
+export type UpdateApplicantNotesRequest = MutationUpdateApplicantNotesArgs;
+
+export type UpdateApplicantNotesResponse = {
+  updateApplicantNotes: UpdateApplicantNotesResult;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Hookup set as inactive modal to setApplicantAsInactive endpoint](https://www.notion.so/uwblueprintexecs/Hookup-set-as-inactive-modal-to-setApplicantAsInactive-endpoint-776057668aee4f44b28869c5e23b4ec1)

## Implementation
* Added `updateApplicantNotes` API to resolvers
* Added API call and hookup from `Additional Notes Modal`

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket