### PR TITLE
[Feature] Create Additional Information Edit Modal

### DIFF
--- a/components/admin/requests/additional-questions/Card.tsx
+++ b/components/admin/requests/additional-questions/Card.tsx
@@ -1,28 +1,33 @@
 import { FC, useState } from 'react';
-import { useQuery } from '@apollo/client';
-import { Box, Text, SimpleGrid, VStack } from '@chakra-ui/react'; // Chakra UI
+import { useMutation, useQuery } from '@apollo/client';
+import { Box, Text, SimpleGrid, VStack, Button } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/LayoutCard'; // Custom Card component
 import {
   GetAdditionalInformationRequest,
   GetAdditionalInformationResponse,
   GET_ADDITIONAL_INFORMATION,
+  UpdateAdditionalInformationResponse,
+  UpdateAdditionalInformationRequest,
+  UPDATE_ADDITIONAL_INFORMATION,
   AdditionalInformationFormData,
 } from '@tools/admin/requests/additional-questions';
+import EditAdditionalInformationModal from './EditModal';
 
 type Props = {
   readonly applicationId: number;
   readonly isUpdated?: boolean;
+  readonly editDisabled?: boolean;
   /** Whether card is a subsection */
   readonly isSubsection?: boolean;
 };
 
 const Card: FC<Props> = props => {
-  const { applicationId, isUpdated, isSubsection } = props;
+  const { applicationId, isUpdated, editDisabled, isSubsection } = props;
 
   const [additionalInformation, setAdditionalInformation] =
     useState<AdditionalInformationFormData | null>(null);
 
-  useQuery<GetAdditionalInformationResponse, GetAdditionalInformationRequest>(
+  const { refetch } = useQuery<GetAdditionalInformationResponse, GetAdditionalInformationRequest>(
     GET_ADDITIONAL_INFORMATION,
     {
       variables: { id: applicationId },
@@ -35,7 +40,32 @@ const Card: FC<Props> = props => {
     }
   );
 
+  const [updateAdditionalInformation] = useMutation<
+    UpdateAdditionalInformationResponse,
+    UpdateAdditionalInformationRequest
+  >(UPDATE_ADDITIONAL_INFORMATION);
+
   if (additionalInformation === null) return null;
+
+  /** Handler for saving additional information */
+  const handleSave = async (data: AdditionalInformationFormData) => {
+    if (data.requiresWiderParkingSpace === null || data.usesAccessibleConvertedVan === null) {
+      // TODO: Improve error handling
+      return;
+    }
+
+    await updateAdditionalInformation({
+      variables: {
+        input: {
+          id: applicationId,
+          ...data,
+          requiresWiderParkingSpace: data.requiresWiderParkingSpace,
+          usesAccessibleConvertedVan: data.usesAccessibleConvertedVan,
+        },
+      },
+    });
+    refetch();
+  };
 
   const {
     usesAccessibleConvertedVan,
@@ -51,7 +81,18 @@ const Card: FC<Props> = props => {
       header={`Additional Information`}
       updated={isUpdated}
       divider
-      editModal={false}
+      editModal={
+        !editDisabled && (
+          <EditAdditionalInformationModal
+            additionalInformation={additionalInformation}
+            onSave={handleSave}
+          >
+            <Button color="primary" variant="ghost" textDecoration="underline">
+              <Text textStyle="body-bold">Edit</Text>
+            </Button>
+          </EditAdditionalInformationModal>
+        )
+      }
       isSubsection={isSubsection}
     >
       <VStack align="left" spacing="12px">

--- a/components/admin/requests/additional-questions/Card.tsx
+++ b/components/admin/requests/additional-questions/Card.tsx
@@ -84,7 +84,13 @@ const Card: FC<Props> = props => {
       editModal={
         !editDisabled && (
           <EditAdditionalInformationModal
-            additionalInformation={additionalInformation}
+            additionalInformation={{
+              usesAccessibleConvertedVan,
+              accessibleConvertedVanLoadingMethod,
+              requiresWiderParkingSpace,
+              requiresWiderParkingSpaceReason,
+              otherRequiresWiderParkingSpaceReason,
+            }}
             onSave={handleSave}
           >
             <Button color="primary" variant="ghost" textDecoration="underline">

--- a/components/admin/requests/additional-questions/EditModal.tsx
+++ b/components/admin/requests/additional-questions/EditModal.tsx
@@ -17,7 +17,7 @@ import AdditionalQuestionsForm from '@components/admin/requests/additional-quest
 type Props = {
   readonly children: ReactNode;
   readonly additionalInformation: AdditionalInformationFormData;
-  readonly onSave: (applicationData: any) => void;
+  readonly onSave: (additionalInformation: AdditionalInformationFormData) => void;
 };
 
 export default function EditAdditionalInformationModal({
@@ -43,20 +43,7 @@ export default function EditAdditionalInformationModal({
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
     // TODO: Refactor to work with form validation (wrap in a Formik component)
-    const {
-      usesAccessibleConvertedVan,
-      accessibleConvertedVanLoadingMethod,
-      requiresWiderParkingSpace,
-      requiresWiderParkingSpaceReason,
-      otherRequiresWiderParkingSpaceReason,
-    } = additionalInformation;
-    onSave({
-      usesAccessibleConvertedVan,
-      accessibleConvertedVanLoadingMethod,
-      requiresWiderParkingSpace,
-      requiresWiderParkingSpaceReason,
-      otherRequiresWiderParkingSpaceReason,
-    });
+    onSave(additionalInformation);
     onClose();
   };
 

--- a/components/admin/requests/additional-questions/EditModal.tsx
+++ b/components/admin/requests/additional-questions/EditModal.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState, ReactNode, SyntheticEvent } from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  useDisclosure,
+  Text,
+  Box,
+} from '@chakra-ui/react'; // Chakra UI
+import { AdditionalInformationFormData } from '@tools/admin/requests/additional-questions';
+import AdditionalQuestionsForm from '@components/admin/requests/additional-questions/Form';
+
+type Props = {
+  readonly children: ReactNode;
+  readonly additionalInformation: AdditionalInformationFormData;
+  readonly onSave: (applicationData: any) => void;
+};
+
+export default function EditAdditionalInformationModal({
+  children,
+  additionalInformation: currentAdditionalInformation,
+  onSave,
+}: Props) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [additionalInformation, setAdditionalInformation] = useState<AdditionalInformationFormData>(
+    currentAdditionalInformation || {
+      usesAccessibleConvertedVan: null,
+      accessibleConvertedVanLoadingMethod: null,
+      requiresWiderParkingSpace: null,
+      requiresWiderParkingSpaceReason: null,
+      otherRequiresWiderParkingSpaceReason: null,
+    }
+  );
+
+  useEffect(() => {
+    setAdditionalInformation(currentAdditionalInformation);
+  }, [currentAdditionalInformation, isOpen]);
+
+  const handleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    // TODO: Refactor to work with form validation (wrap in a Formik component)
+    const {
+      usesAccessibleConvertedVan,
+      accessibleConvertedVanLoadingMethod,
+      requiresWiderParkingSpace,
+      requiresWiderParkingSpaceReason,
+      otherRequiresWiderParkingSpaceReason,
+    } = additionalInformation;
+    onSave({
+      usesAccessibleConvertedVan,
+      accessibleConvertedVanLoadingMethod,
+      requiresWiderParkingSpace,
+      requiresWiderParkingSpaceReason,
+      otherRequiresWiderParkingSpaceReason,
+    });
+    onClose();
+  };
+
+  return (
+    <>
+      <Box onClick={onOpen}>{children}</Box>
+
+      <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
+        <ModalOverlay />
+        <form onSubmit={handleSubmit}>
+          <ModalContent paddingX="36px">
+            <ModalHeader
+              textStyle="display-medium-bold"
+              paddingBottom="12px"
+              paddingTop="24px"
+              paddingX="4px"
+            >
+              <Text as="h2" textStyle="display-medium-bold">
+                {'Edit Payment, Shipping and Billing Details'}
+              </Text>
+            </ModalHeader>
+            <ModalBody paddingY="20px" paddingX="4px">
+              <AdditionalQuestionsForm
+                data={additionalInformation}
+                onChange={setAdditionalInformation}
+              />
+            </ModalBody>
+            <ModalFooter paddingBottom="24px" paddingX="4px">
+              <Button colorScheme="gray" variant="solid" onClick={onClose}>
+                {'Cancel'}
+              </Button>
+              <Button variant="solid" type="submit" ml={'12px'}>
+                {'Save'}
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -7,7 +7,6 @@ import DoctorInformationCard from '@components/admin/requests/doctor-information
 import PaymentInformationCard from '@components/admin/requests/payment-information/Card'; // Payment information card
 import PersonalInformationCard from '@components/admin/requests/permit-holder-information/Card'; // Personal information card
 import ProcessingTasksCard from '@components/admin/requests/processing/TasksCard'; // Processing tasks card
-import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card'; // Additional Information card
 import { authorize } from '@tools/authorization'; // Page authorization
 import { useQuery } from '@apollo/client'; // Apollo Client hooks
 import {
@@ -96,7 +95,6 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
           {type === 'REPLACEMENT' && (
             <ReasonForReplacementCard applicationId={id} editDisabled={reviewRequestCompleted} />
           )}
-          {type !== 'REPLACEMENT' && <AdditionalInformationCard applicationId={id} />}
           <PaymentInformationCard
             applicationId={id}
             editDisabled={paidThroughShopify || reviewRequestCompleted}

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -7,6 +7,7 @@ import DoctorInformationCard from '@components/admin/requests/doctor-information
 import PaymentInformationCard from '@components/admin/requests/payment-information/Card'; // Payment information card
 import PersonalInformationCard from '@components/admin/requests/permit-holder-information/Card'; // Personal information card
 import ProcessingTasksCard from '@components/admin/requests/processing/TasksCard'; // Processing tasks card
+import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card'; // Additional Information card
 import { authorize } from '@tools/authorization'; // Page authorization
 import { useQuery } from '@apollo/client'; // Apollo Client hooks
 import {
@@ -95,6 +96,7 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
           {type === 'REPLACEMENT' && (
             <ReasonForReplacementCard applicationId={id} editDisabled={reviewRequestCompleted} />
           )}
+          {type !== 'REPLACEMENT' && <AdditionalInformationCard applicationId={id} />}
           <PaymentInformationCard
             applicationId={id}
             editDisabled={paidThroughShopify || reviewRequestCompleted}

--- a/tools/admin/requests/additional-questions.ts
+++ b/tools/admin/requests/additional-questions.ts
@@ -1,5 +1,11 @@
 import { gql } from '@apollo/client';
-import { NewApplication, QueryApplicationArgs, RenewalApplication } from '@lib/graphql/types';
+import {
+  MutationUpdateApplicationAdditionalInformationArgs,
+  NewApplication,
+  QueryApplicationArgs,
+  RenewalApplication,
+  UpdateApplicationAdditionalInformationResult,
+} from '@lib/graphql/types';
 
 /** Additional questions in forms */
 export type AdditionalInformationFormData = Pick<
@@ -46,4 +52,21 @@ export type GetAdditionalInformationResponse = {
     | 'requiresWiderParkingSpaceReason'
     | 'otherRequiresWiderParkingSpaceReason'
   >;
+};
+
+/** Update additional information of application */
+export const UPDATE_ADDITIONAL_INFORMATION = gql`
+  mutation UpdateAdditionalInformationInformation(
+    $input: UpdateApplicationAdditionalInformationInput!
+  ) {
+    updateApplicationAdditionalInformation(input: $input) {
+      ok
+    }
+  }
+`;
+
+export type UpdateAdditionalInformationRequest = MutationUpdateApplicationAdditionalInformationArgs;
+
+export type UpdateAdditionalInformationResponse = {
+  updateApplicationAdditionaltInformation: UpdateApplicationAdditionalInformationResult;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Create AdditionalInformation EditModal](https://www.notion.so/uwblueprintexecs/Create-AdditionalInformation-EditModal-f22ad680cd5942ee85311c99a7610e0b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Built edit modal
* Added `UPDATE_ADDITIONAL_INFORMATION` mutation 
* Connected edit modal to card and displayed card on the requests page

## Demo

https://user-images.githubusercontent.com/51224641/166408238-649e5f10-69b2-48d7-b1d7-da4264488c79.mov

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Form validation needs to be added and the edit modal will need to be refactored accordingly (needs to be wrapped in a Formik component). I think this can be addressed in the form validation PR once this is merged in.
* As seen in the demo gif, the additional information form on staging does not conditionally render the other fields in the form. This is addressed in the form validation PR here https://github.com/uwblueprint/richmond-centre-for-disability/blob/ad/feature/form-validation/components/admin/requests/additional-questions/Form.tsx


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
