### PR TITLE
[Improvement] Added Loading State Spinners to Request & Permit Holder Tables

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -2,7 +2,20 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { useEffect } from 'react'; // React
-import { Box, Flex, Table as ChakraTable, Th, Td, Thead, Tbody, Tr } from '@chakra-ui/react'; // Chakra UI
+import {
+  Box,
+  Flex,
+  Table as ChakraTable,
+  Th,
+  Td,
+  Thead,
+  Tbody,
+  Tr,
+  Center,
+  VStack,
+  Spinner,
+  Text,
+} from '@chakra-ui/react'; // Chakra UI
 import { ArrowUpIcon, ArrowDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import { useTable, useSortBy, Column } from 'react-table'; // React Table
 import { SortOptions } from '@tools/types'; // Sorting types
@@ -12,12 +25,13 @@ import { getSortOptions } from '@tools/admin/table'; // Get the sort options fro
 type Props<T extends object> = {
   readonly columns: Array<Column<T>>; // Depends on shape of data
   readonly data: Array<T>; // Depends on shape of data
+  readonly loading?: boolean;
   readonly onChangeSortOrder?: (sort: SortOptions) => unknown; // Callback after changing sorting
   readonly onRowClick?: (row: T) => unknown;
 };
 
 export default function Table<T extends object>(props: Props<T>) {
-  const { columns, data, onChangeSortOrder, onRowClick } = props;
+  const { columns, data, loading, onChangeSortOrder, onRowClick } = props;
 
   // Table rendering functions
   const {
@@ -45,69 +59,81 @@ export default function Table<T extends object>(props: Props<T>) {
 
   return (
     <Box>
-      <ChakraTable {...getTableProps()}>
-        <Thead>
-          {headerGroups.map(headerGroup => (
-            <Tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
-              {headerGroup.headers.map(column => (
-                <Th
-                  height="40px"
-                  paddingX="0"
-                  paddingY="8px"
-                  fontSize="18px"
-                  color="text.secondary"
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
-                  width={column.width}
-                  minWidth={column.minWidth}
-                  maxWidth={column.maxWidth}
-                  key={column.id}
-                >
-                  <Flex>
-                    <Box height="24px" display="inline">
-                      {column.render('Header')}
-                    </Box>
-                    <Box height="24px" display="inline" marginLeft="4px">
-                      {column.isSorted ? (
-                        column.isSortedDesc ? (
-                          <ArrowDownIcon aria-label="sorted descending" />
-                        ) : (
-                          <ArrowUpIcon aria-label="sorted ascending" />
-                        )
-                      ) : null}
-                    </Box>
-                  </Flex>
-                </Th>
-              ))}
-            </Tr>
-          ))}
-        </Thead>
-        <Tbody {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Tr
-                {...row.getRowProps()}
-                key={row.id}
-                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                cursor={onRowClick ? 'pointer' : undefined}
-                _hover={onRowClick && { background: 'background.interactive' }}
-              >
-                {row.cells.map((cell, i) => (
-                  <Td
-                    height="80px"
+      {loading && (
+        <Center height="240px">
+          <VStack>
+            <Spinner color="primary" boxSize="100px" thickness="8px" speed="0.65s" mb="10px" />
+            <Text textStyle="display-small-semibold" color="secondary" fontSize="xl">
+              Loading Data...
+            </Text>
+          </VStack>
+        </Center>
+      )}
+      {!loading && (
+        <ChakraTable {...getTableProps()}>
+          <Thead>
+            {headerGroups.map(headerGroup => (
+              <Tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
+                {headerGroup.headers.map(column => (
+                  <Th
+                    height="40px"
                     paddingX="0"
+                    paddingY="8px"
+                    fontSize="18px"
                     color="text.secondary"
-                    {...cell.getCellProps()}
-                    key={`cell-${i}`}
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    width={column.width}
+                    minWidth={column.minWidth}
+                    maxWidth={column.maxWidth}
+                    key={column.id}
                   >
-                    {cell.render('Cell')}
-                  </Td>
+                    <Flex>
+                      <Box height="24px" display="inline">
+                        {column.render('Header')}
+                      </Box>
+                      <Box height="24px" display="inline" marginLeft="4px">
+                        {column.isSorted ? (
+                          column.isSortedDesc ? (
+                            <ArrowDownIcon aria-label="sorted descending" />
+                          ) : (
+                            <ArrowUpIcon aria-label="sorted ascending" />
+                          )
+                        ) : null}
+                      </Box>
+                    </Flex>
+                  </Th>
                 ))}
               </Tr>
-            );
-          })}
-        </Tbody>
-      </ChakraTable>
+            ))}
+          </Thead>
+          <Tbody {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Tr
+                  {...row.getRowProps()}
+                  key={row.id}
+                  onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                  cursor={onRowClick ? 'pointer' : undefined}
+                  _hover={onRowClick && { background: 'background.interactive' }}
+                >
+                  {row.cells.map((cell, i) => (
+                    <Td
+                      height="80px"
+                      paddingX="0"
+                      color="text.secondary"
+                      {...cell.getCellProps()}
+                      key={`cell-${i}`}
+                    >
+                      {cell.render('Cell')}
+                    </Td>
+                  ))}
+                </Tr>
+              );
+            })}
+          </Tbody>
+        </ChakraTable>
+      )}
     </Box>
   );
 }

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -59,7 +59,7 @@ export default function Table<T extends object>(props: Props<T>) {
 
   return (
     <Box>
-      {loading && (
+      {loading ? (
         <Center height="240px">
           <VStack>
             <Spinner color="primary" boxSize="100px" thickness="8px" speed="0.65s" mb="10px" />
@@ -68,8 +68,7 @@ export default function Table<T extends object>(props: Props<T>) {
             </Text>
           </VStack>
         </Center>
-      )}
-      {!loading && (
+      ) : (
         <ChakraTable {...getTableProps()}>
           <Thead>
             {headerGroups.map(headerGroup => (

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -153,7 +153,7 @@ const Requests: NextPage = () => {
   const [recordsCount, setRecordsCount] = useState(0);
 
   // Make query to applications resolver
-  const { refetch } = useQuery<GetApplicationsResponse, GetApplicationsRequest>(
+  const { refetch, loading } = useQuery<GetApplicationsResponse, GetApplicationsRequest>(
     GET_APPLICATIONS_QUERY,
     {
       variables: {
@@ -383,6 +383,7 @@ const Requests: NextPage = () => {
             <Table
               columns={COLUMNS}
               data={requestsData}
+              loading={loading}
               onChangeSortOrder={setSortOrder}
               onRowClick={({ id }) => router.push(`/admin/request/${id}`)}
             />

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -75,7 +75,7 @@ const PermitHolders: NextPage = () => {
   const debouncedSearchFilter = useDebounce<string>(searchFilter, 500);
 
   // GQL Query
-  const { refetch } = useQuery<GetPermitHoldersResponse, GetPermitHoldersRequest>(
+  const { refetch, loading } = useQuery<GetPermitHoldersResponse, GetPermitHoldersRequest>(
     GET_PERMIT_HOLDERS_QUERY,
     {
       variables: {
@@ -430,6 +430,7 @@ const PermitHolders: NextPage = () => {
             <Table
               columns={COLUMNS}
               data={permitHolderData || []}
+              loading={loading}
               onChangeSortOrder={sortOrder => {
                 setSortOrder(sortOrder);
               }}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Loading States for Request & Permit Holder Tables](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8&p=4c73535599df45d6baaad79829933e80)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added Loading Component to Table
* Called Loading component with loading parameter from `useQuery`

## [Design Video](https://www.loom.com/share/71562fb0364c476b9ec48b6805c5c6fd)

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
