### PR TITLE
[Improvement] Add Loading States to Processing Task Card

### DIFF
--- a/components/admin/requests/processing/ReviewInformationStep.tsx
+++ b/components/admin/requests/processing/ReviewInformationStep.tsx
@@ -33,6 +33,7 @@ type Props = {
   readonly applicationId: number;
   readonly onConfirmed: () => void;
   readonly onUndo: () => void;
+  readonly loading: boolean;
 };
 
 export default function ReviewInformationStep({
@@ -41,6 +42,7 @@ export default function ReviewInformationStep({
   applicationId,
   onConfirmed,
   onUndo,
+  loading,
 }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -98,7 +100,16 @@ export default function ReviewInformationStep({
     <>
       {isCompleted ? (
         <UndoReviewRequestModal onUndoConfirmed={onUndo}>
-          <Button color={'black'} variant="ghost" textDecoration="underline black">
+          <Button
+            color={'black'}
+            variant="ghost"
+            textDecoration="underline black"
+            isDisabled={loading}
+            isLoading={loading}
+            loadingText="Undo Review"
+            fontWeight="normal"
+            fontSize="14px"
+          >
             <Text textStyle="caption" color="black">
               Undo Review
             </Text>
@@ -111,8 +122,12 @@ export default function ReviewInformationStep({
           bg="background.gray"
           _hover={isDisabled ? undefined : { bg: 'background.grayHover' }}
           color="black"
-          disabled={isDisabled}
+          disabled={isDisabled || loading}
           onClick={onOpen}
+          isLoading={loading}
+          loadingText="Review information"
+          fontWeight="normal"
+          fontSize="14px"
         >
           <Text textStyle="xsmall-medium">Review information</Text>
         </Button>

--- a/components/admin/requests/processing/TaskCardUploadStep.tsx
+++ b/components/admin/requests/processing/TaskCardUploadStep.tsx
@@ -12,12 +12,19 @@ type Props = {
   readonly onUploadFile: (selectedFile: File) => void; // handle file upload
   readonly isDisabled: boolean;
   readonly onUndo: () => void;
+  readonly loading: boolean;
 };
 
 /**
  * POA form upload component allowing users to upload POA form PDF file
  */
-export const TaskCardUploadStep: FC<Props> = ({ isDisabled, fileUrl, onUploadFile, onUndo }) => {
+export const TaskCardUploadStep: FC<Props> = ({
+  isDisabled,
+  fileUrl,
+  loading,
+  onUploadFile,
+  onUndo,
+}) => {
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   /**
@@ -83,6 +90,7 @@ export const TaskCardUploadStep: FC<Props> = ({ isDisabled, fileUrl, onUploadFil
               size={'xs'}
               icon={<CloseIcon boxSize={'0.5em'} />}
               onClick={onUndo}
+              isLoading={loading}
             />
           </HStack>
         </VStack>
@@ -97,6 +105,11 @@ export const TaskCardUploadStep: FC<Props> = ({ isDisabled, fileUrl, onUploadFil
             color="black"
             disabled={isDisabled}
             onClick={handleClick}
+            isDisabled={loading}
+            isLoading={loading}
+            loadingText="Upload document"
+            fontWeight="normal"
+            fontSize="14px"
           >
             <Text textStyle="xsmall-medium">Upload document</Text>
           </Button>

--- a/components/admin/requests/processing/TasksCard.tsx
+++ b/components/admin/requests/processing/TasksCard.tsx
@@ -301,7 +301,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                     bg="background.gray"
                     _hover={{ bg: 'background.grayHover' }}
                     color="black"
-                    disabled={assignAppNumberLoading}
+                    isDisabled={assignAppNumberLoading}
                     isLoading={assignAppNumberLoading}
                     loadingText="Assign number"
                     fontWeight="normal"
@@ -315,6 +315,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   variant="ghost"
                   textDecoration="underline black"
                   onClick={() => handleAssignAppNumber(null)}
+                  isDisabled={assignAppNumberLoading}
                   isLoading={assignAppNumberLoading}
                   loadingText="Undo"
                   fontWeight="normal"
@@ -369,6 +370,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   _hover={{ bg: 'background.grayHover' }}
                   color="black"
                   onClick={() => handleHolepunchParkingPermit(true)}
+                  isDisabled={holepunchParkingPermitLoading}
                   isLoading={holepunchParkingPermitLoading}
                   loadingText="Mark as complete"
                   fontWeight="normal"
@@ -421,6 +423,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   _hover={{ bg: 'background.grayHover' }}
                   color="black"
                   onClick={() => handleCreateWalletCard(true)}
+                  isDisabled={createWalletCardLoading}
                   isLoading={createWalletCardLoading}
                   loadingText="Mark as complete"
                   fontWeight="normal"

--- a/components/admin/requests/processing/TasksCard.tsx
+++ b/components/admin/requests/processing/TasksCard.tsx
@@ -63,15 +63,16 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
 
   const [showTaskLog, setShowTaskLog] = useState(false);
 
-  const [assignAppNumber] = useMutation<AssignAppNumberResponse, AssignAppNumberRequest>(
-    ASSIGN_APP_NUMBER_MUTATION
-  );
+  const [assignAppNumber, { loading: assignAppNumberLoading }] = useMutation<
+    AssignAppNumberResponse,
+    AssignAppNumberRequest
+  >(ASSIGN_APP_NUMBER_MUTATION);
   const handleAssignAppNumber = async (appNumber: number | null) => {
     await assignAppNumber({ variables: { input: { applicationId, appNumber } } });
     refetch();
   };
 
-  const [holepunchParkingPermit] =
+  const [holepunchParkingPermit, { loading: holepunchParkingPermitLoading }] =
     useMutation<HolepunchParkingPermitResponse, HolepunchParkingPermitRequest>(
       HOLEPUNCH_APP_MUTATION
     );
@@ -80,15 +81,16 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
     refetch();
   };
 
-  const [createWalletCard] = useMutation<CreateWalletCardResponse, CreateWalletCardRequest>(
-    CREATE_WALLET_CARD_MUTATION
-  );
+  const [createWalletCard, { loading: createWalletCardLoading }] = useMutation<
+    CreateWalletCardResponse,
+    CreateWalletCardRequest
+  >(CREATE_WALLET_CARD_MUTATION);
   const handleCreateWalletCard = async (walletCardCreated: boolean) => {
     await createWalletCard({ variables: { input: { applicationId, walletCardCreated } } });
     refetch();
   };
 
-  const [reviewRequestInformation] = useMutation<
+  const [reviewRequestInformation, { loading: reviewRequestInformationLoading }] = useMutation<
     ReviewRequestInformationResponse,
     ReviewRequestInformationRequest
   >(REVIEW_REQUEST_INFORMATION_MUTATION);
@@ -109,7 +111,8 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
   const [uploadDocuments, { loading: uploadDocumentsLoading }] =
     useMutation<UploadDocumentsResponse, UploadDocumentsRequest>(UPLOAD_DOCUMENTS_MUTATION);
 
-  const [mailOut] = useMutation<MailOutResponse, MailOutRequest>(MAIL_OUT_APP_MUTATION);
+  const [mailOut, { loading: mailOutLoading }] =
+    useMutation<MailOutResponse, MailOutRequest>(MAIL_OUT_APP_MUTATION);
   const handleMailOut = async (appMailed: boolean) => {
     await mailOut({ variables: { input: { applicationId, appMailed } } });
     refetch();
@@ -298,6 +301,11 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                     bg="background.gray"
                     _hover={{ bg: 'background.grayHover' }}
                     color="black"
+                    disabled={assignAppNumberLoading}
+                    isLoading={assignAppNumberLoading}
+                    loadingText="Assign number"
+                    fontWeight="normal"
+                    fontSize="14px"
                   >
                     <Text textStyle="xsmall-medium">Assign number</Text>
                   </Button>
@@ -307,6 +315,10 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   variant="ghost"
                   textDecoration="underline black"
                   onClick={() => handleAssignAppNumber(null)}
+                  isLoading={assignAppNumberLoading}
+                  loadingText="Undo"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="caption" color="black">
                     Undo
@@ -339,6 +351,11 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   variant="ghost"
                   textDecoration="underline black"
                   onClick={() => handleHolepunchParkingPermit(false)}
+                  isDisabled={holepunchParkingPermitLoading}
+                  isLoading={holepunchParkingPermitLoading}
+                  loadingText="Undo"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="caption" color="black">
                     Undo
@@ -352,6 +369,10 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   _hover={{ bg: 'background.grayHover' }}
                   color="black"
                   onClick={() => handleHolepunchParkingPermit(true)}
+                  isLoading={holepunchParkingPermitLoading}
+                  loadingText="Mark as complete"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="xsmall-medium">Mark as complete</Text>
                 </Button>
@@ -382,6 +403,11 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   variant="ghost"
                   textDecoration="underline black"
                   onClick={() => handleCreateWalletCard(false)}
+                  isDisabled={createWalletCardLoading}
+                  isLoading={createWalletCardLoading}
+                  loadingText="Undo"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="caption" color="black">
                     Undo
@@ -395,6 +421,10 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   _hover={{ bg: 'background.grayHover' }}
                   color="black"
                   onClick={() => handleCreateWalletCard(true)}
+                  isLoading={createWalletCardLoading}
+                  loadingText="Mark as complete"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="xsmall-medium">Mark as complete</Text>
                 </Button>
@@ -428,6 +458,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                 onUndo={() => {
                   handleReviewRequestInformation(false);
                 }}
+                loading={reviewRequestInformationLoading}
               />
             </ProcessingTaskStep>
 
@@ -511,6 +542,7 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                 fileUrl={documentsUrl}
                 onUploadFile={handleSubmitDocuments}
                 onUndo={handleUndoDocumentsUpload}
+                loading={uploadDocumentsLoading}
               />
             </ProcessingTaskStep>
 
@@ -535,6 +567,11 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   variant="ghost"
                   textDecoration="underline black"
                   onClick={() => handleMailOut(false)}
+                  disabled={mailOutLoading}
+                  isLoading={mailOutLoading}
+                  loadingText="Undo"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="caption" color="black">
                     Undo
@@ -547,8 +584,12 @@ export default function ProcessingTasksCard({ applicationId }: ProcessingTasksCa
                   bg="background.gray"
                   _hover={documentsUrl === null ? undefined : { bg: 'background.grayHover' }}
                   color="black"
-                  disabled={documentsUrl === null}
+                  disabled={documentsUrl === null || mailOutLoading}
                   onClick={() => handleMailOut(true)}
+                  isLoading={mailOutLoading}
+                  loadingText="Mark as complete"
+                  fontWeight="normal"
+                  fontSize="14px"
                 >
                   <Text textStyle="xsmall-medium">Mark as complete</Text>
                 </Button>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Loading states for processing tasks card](https://www.notion.so/uwblueprintexecs/Loading-states-for-processing-tasks-card-10c896afd09e478ebb77b2af5c4ab77d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added loading states to mark as complete buttons as well as undo buttons

![loading-state-processing-card-demo](https://user-images.githubusercontent.com/55823764/167747914-5782054e-a5ec-4085-8cb4-c2d2675ad291.gif)


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
