### PR TITLE
[Fix] Prevent applicants from submitting multiple renewal requests

### DIFF
--- a/pages/renew.tsx
+++ b/pages/renew.tsx
@@ -44,6 +44,9 @@ export default function Renew() {
   // Toast message
   const toast = useToast();
 
+  // Loading state
+  const [loading, setLoading] = useState(false);
+
   // Whether each section was updated
   const [updatedAddress, setUpdatedAddress] = useState(false); // Whether address was updated
   const [updatedContactInfo, setUpdatedContactInfo] = useState(false); // Whether contact info was updated
@@ -125,7 +128,7 @@ export default function Renew() {
   };
 
   // Submit application mutation
-  const [submitApplication, { loading }] = useMutation<
+  const [submitApplication] = useMutation<
     CreateExternalRenewalApplicationResponse,
     CreateExternalRenewalApplicationRequest
   >(CREATE_EXTERNAL_RENEWAL_APPLICATION_MUTATION, {
@@ -144,6 +147,7 @@ export default function Renew() {
       }
     },
     onError: error => {
+      setLoading(false);
       toast({
         status: 'error',
         description: error.message,
@@ -181,6 +185,8 @@ export default function Renew() {
       });
       return;
     }
+
+    setLoading(true);
 
     await submitApplication({
       variables: {
@@ -575,6 +581,7 @@ export default function Renew() {
                 onClick={handleSubmit}
                 isLoading={loading}
                 disabled={
+                  loading ||
                   !applicantId ||
                   !certified ||
                   invalidPersonalAddress ||


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Prevent-applicants-from-submitting-multiple-renewal-requests-860357cc14be4ec8a9f7643e71b6856c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Replace the current loading state of the submit button for external applications with loading state that captures the delay in initializing the Shopify cart and redirecting to the checkout


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Tested with success and error paths (injected placeholder error into resolver)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
