### PR TITLE
[Fix] Format postal code presentation and strip before writing to DB

### DIFF
--- a/components/admin/Address.tsx
+++ b/components/admin/Address.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { Box, Text } from '@chakra-ui/react';
 import { Province } from '@lib/graphql/types';
+import { formatPostalCode } from '@lib/utils/format';
 
 type Props = {
   readonly address: {
@@ -30,7 +31,7 @@ const Address: FC<Props> = props => {
         {country}
       </Text>
       <Text as="p" textStyle="body-regular" textAlign="left">
-        {postalCode}
+        {formatPostalCode(postalCode)}
       </Text>
     </Box>
   );

--- a/components/admin/requests/guardian-information/Card.tsx
+++ b/components/admin/requests/guardian-information/Card.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useState } from 'react';
 import EditGuardianInformationModal from '@components/admin/requests/guardian-information/EditModal';
 import { AddIcon } from '@chakra-ui/icons';
+import Address from '@components/admin/Address';
 
 type GuardianInformationProps = {
   readonly applicationId: number;
@@ -132,19 +133,16 @@ export default function GuardianInformationCard({
             </Text>
           </Box>
           <Box>
-            <Text as="p" textStyle="body-regular">
-              {guardian.addressLine2 ? `${guardian.addressLine2} - ` : ''}
-              {guardian.addressLine1}
-            </Text>
-            <Text as="p" textStyle="body-regular">
-              {`${guardian.city} ${guardian.province}`}
-            </Text>
-            <Text as="p" textStyle="body-regular">
-              {guardian.country}
-            </Text>
-            <Text as="p" textStyle="body-regular">
-              {guardian.postalCode}
-            </Text>
+            <Address
+              address={{
+                addressLine1: guardian.addressLine1,
+                addressLine2: guardian.addressLine2,
+                city: guardian.city,
+                province: guardian.province,
+                country: guardian.country,
+                postalCode: guardian.postalCode,
+              }}
+            />
           </Box>
         </VStack>
       </>

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -24,7 +24,7 @@ import { DateUtils } from 'react-day-picker'; // Date utils
 import { SortOrder } from '@tools/types'; // Sorting Type
 import { PermitType } from '@prisma/client';
 import { verifyIdentitySchema } from '@lib/applicants/verify-identity/validation';
-import { stripPhoneNumber } from '@lib/utils/format';
+import { stripPhoneNumber, stripPostalCode } from '@lib/utils/format';
 
 /**
  * Query and filter RCD applicants from the internal facing app.
@@ -239,6 +239,7 @@ export const updateApplicantGeneralInformation: Resolver<
   const { input } = args;
   const { id, ...data } = input;
   data.phone = stripPhoneNumber(data.phone);
+  data.postalCode = stripPostalCode(data.postalCode);
 
   let updatedApplicant;
   try {
@@ -269,6 +270,7 @@ export const updateApplicantDoctorInformation: Resolver<
   const { input } = args;
   const { id, mspNumber, ...data } = input;
   data.phone = stripPhoneNumber(data.phone);
+  data.postalCode = stripPostalCode(data.postalCode);
 
   let updatedApplicant;
   try {
@@ -309,6 +311,7 @@ export const updateApplicantGuardianInformation: Resolver<
   const { input } = args;
   const { id, omitGuardianPoa, ...data } = input;
   data.phone = stripPhoneNumber(data.phone);
+  data.postalCode = stripPostalCode(data.postalCode);
 
   let updatedApplicant;
   try {

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -11,7 +11,7 @@ import {
 import { ApplicantNotFoundError } from '@lib/applicants/errors'; // Applicant errors
 import { DBErrorCode, getUniqueConstraintFailedFields } from '@lib/db/errors'; // Database errors
 import { SortOrder } from '@tools/types'; // Sorting type
-import { stripPhoneNumber, formatFullName, formatPostalCode } from '@lib/utils/format'; // Formatting utils
+import { stripPhoneNumber, formatFullName, stripPostalCode } from '@lib/utils/format'; // Formatting utils
 import {
   Application,
   CreateExternalRenewalApplicationResult,
@@ -276,9 +276,9 @@ export const createNewApplication: Resolver<
         }),
         ...data,
         phone: stripPhoneNumber(phone),
-        postalCode: formatPostalCode(postalCode),
-        shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
-        billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
+        postalCode: stripPostalCode(postalCode),
+        shippingPostalCode: shippingPostalCode && stripPostalCode(shippingPostalCode),
+        billingPostalCode: billingPostalCode && stripPostalCode(billingPostalCode),
         newApplication: {
           create: {
             dateOfBirth,
@@ -297,7 +297,7 @@ export const createNewApplication: Resolver<
             physicianAddressLine1,
             physicianAddressLine2,
             physicianCity,
-            physicianPostalCode: formatPostalCode(physicianPostalCode),
+            physicianPostalCode: stripPostalCode(physicianPostalCode),
             ...(!omitGuardianPoa && {
               guardianFirstName,
               guardianMiddleName,
@@ -307,7 +307,7 @@ export const createNewApplication: Resolver<
               guardianAddressLine1,
               guardianAddressLine2,
               guardianCity,
-              guardianPostalCode: guardianPostalCode && formatPostalCode(guardianPostalCode),
+              guardianPostalCode: guardianPostalCode && stripPostalCode(guardianPostalCode),
               poaFormS3ObjectKey,
             }),
             usesAccessibleConvertedVan,
@@ -390,9 +390,9 @@ export const createRenewalApplication: Resolver<
         donationAmount: donationAmount || 0,
         ...data,
         phone: stripPhoneNumber(phone),
-        postalCode: formatPostalCode(postalCode),
-        shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
-        billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
+        postalCode: stripPostalCode(postalCode),
+        shippingPostalCode: shippingPostalCode && stripPostalCode(shippingPostalCode),
+        billingPostalCode: billingPostalCode && stripPostalCode(billingPostalCode),
         applicant: {
           connect: { id: applicantId },
         },
@@ -405,7 +405,7 @@ export const createRenewalApplication: Resolver<
             physicianAddressLine1,
             physicianAddressLine2,
             physicianCity,
-            physicianPostalCode: formatPostalCode(physicianPostalCode),
+            physicianPostalCode: stripPostalCode(physicianPostalCode),
             usesAccessibleConvertedVan,
             accessibleConvertedVanLoadingMethod,
             requiresWiderParkingSpace,
@@ -527,7 +527,7 @@ export const createExternalRenewalApplication: Resolver<
         addressLine2: updatedAddress ? addressLine2 : applicant.addressLine2,
         city: updatedAddress && city ? city : applicant.city,
         postalCode:
-          updatedAddress && postalCode ? formatPostalCode(postalCode) : applicant.postalCode,
+          updatedAddress && postalCode ? stripPostalCode(postalCode) : applicant.postalCode,
         processingFee: process.env.PROCESSING_FEE,
         donationAmount: 0, // ? Investigate
         paymentMethod: 'SHOPIFY',
@@ -543,7 +543,7 @@ export const createExternalRenewalApplication: Resolver<
         shippingCity: applicant.city,
         shippingProvince: applicant.province,
         shippingCountry: applicant.country,
-        shippingPostalCode: applicant.postalCode,
+        shippingPostalCode: stripPostalCode(applicant.postalCode),
         // TODO: Replace billing info with Shopify checkout inputs
         billingAddressSameAsHomeAddress: true,
         billingFullName: formatFullName(
@@ -556,7 +556,7 @@ export const createExternalRenewalApplication: Resolver<
         billingCity: applicant.city,
         billingProvince: applicant.province,
         billingCountry: applicant.country,
-        billingPostalCode: applicant.postalCode,
+        billingPostalCode: stripPostalCode(applicant.postalCode),
         applicant: {
           connect: { id: applicantId },
         },
@@ -579,7 +579,7 @@ export const createExternalRenewalApplication: Resolver<
             physicianCity: updatedPhysician && physicianCity ? physicianCity : physician.city,
             physicianPostalCode:
               updatedPhysician && physicianPostalCode
-                ? formatPostalCode(physicianPostalCode)
+                ? stripPostalCode(physicianPostalCode)
                 : physician.postalCode,
             usesAccessibleConvertedVan,
             accessibleConvertedVanLoadingMethod,
@@ -671,9 +671,9 @@ export const createReplacementApplication: Resolver<
         processingFee: process.env.PROCESSING_FEE,
         donationAmount: donationAmount || 0,
         phone: stripPhoneNumber(phone),
-        postalCode: formatPostalCode(postalCode),
-        shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
-        billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
+        postalCode: stripPostalCode(postalCode),
+        shippingPostalCode: shippingPostalCode && stripPostalCode(shippingPostalCode),
+        billingPostalCode: billingPostalCode && stripPostalCode(billingPostalCode),
         ...data,
         applicant: {
           connect: { id: applicantId },
@@ -759,7 +759,7 @@ export const updateApplicationGeneralInformation: Resolver<
         // Only set to `undefined` if `receiveEmailUpdates` is null
         receiveEmailUpdates: receiveEmailUpdates ?? undefined,
         phone: stripPhoneNumber(phone),
-        postalCode: formatPostalCode(postalCode),
+        postalCode: stripPostalCode(postalCode),
         ...data,
       },
     });
@@ -813,7 +813,7 @@ export const updateNewApplicationGeneralInformation: Resolver<
         // Only set to `undefined` if `receiveEmailUpdates` is null
         receiveEmailUpdates: receiveEmailUpdates ?? undefined,
         phone: stripPhoneNumber(phone),
-        postalCode: formatPostalCode(postalCode),
+        postalCode: stripPostalCode(postalCode),
         newApplication: {
           update: {
             dateOfBirth,
@@ -895,7 +895,7 @@ export const updateApplicationDoctorInformation: Resolver<
               physicianAddressLine1,
               physicianAddressLine2,
               physicianCity,
-              physicianPostalCode: formatPostalCode(physicianPostalCode),
+              physicianPostalCode: stripPostalCode(physicianPostalCode),
             },
           },
         }),
@@ -909,7 +909,7 @@ export const updateApplicationDoctorInformation: Resolver<
               physicianAddressLine1,
               physicianAddressLine2,
               physicianCity,
-              physicianPostalCode: formatPostalCode(physicianPostalCode),
+              physicianPostalCode: stripPostalCode(physicianPostalCode),
             },
           },
         }),
@@ -964,7 +964,7 @@ export const updateApplicationGuardianInformation: Resolver<
           guardianAddressLine1: addressLine1,
           guardianAddressLine2: addressLine2,
           guardianCity: city,
-          guardianPostalCode: postalCode,
+          guardianPostalCode: stripPostalCode(postalCode),
           poaFormS3ObjectKey,
         },
       });
@@ -1111,8 +1111,8 @@ export const updateApplicationPaymentInformation: Resolver<
       where: { id },
       data: {
         donationAmount: donationAmount || 0,
-        shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
-        billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
+        shippingPostalCode: shippingPostalCode && stripPostalCode(shippingPostalCode),
+        billingPostalCode: billingPostalCode && stripPostalCode(billingPostalCode),
         ...data,
       },
     });

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1407,25 +1407,6 @@ export type UpdateNewApplicationGeneralInformationInput = {
   postalCode: Scalars['String'];
 };
 
-export type UpsertPhysicianInput = {
-  mspNumber: Scalars['Int'];
-  name: Scalars['String'];
-  addressLine1: Scalars['String'];
-  addressLine2: Maybe<Scalars['String']>;
-  city: Scalars['String'];
-  province: Maybe<Province>;
-  postalCode: Scalars['String'];
-  phone: Scalars['String'];
-  status: Maybe<PhysicianStatus>;
-  notes: Maybe<Scalars['String']>;
-};
-
-export type UpsertPhysicianResult = {
-  __typename?: 'UpsertPhysicianResult';
-  ok: Scalars['Boolean'];
-  physicianId: Scalars['Int'];
-};
-
 export type VerifyIdentityFailureReason =
   | 'IDENTITY_VERIFICATION_FAILED'
   | 'APP_DOES_NOT_EXPIRE_WITHIN_30_DAYS'

--- a/lib/physicians/schema.ts
+++ b/lib/physicians/schema.ts
@@ -21,22 +21,4 @@ export default gql`
     country: String!
     postalCode: String!
   }
-
-  input UpsertPhysicianInput {
-    mspNumber: Int!
-    name: String!
-    addressLine1: String!
-    addressLine2: String
-    city: String!
-    province: Province
-    postalCode: String!
-    phone: String!
-    status: PhysicianStatus
-    notes: String
-  }
-
-  type UpsertPhysicianResult {
-    ok: Boolean!
-    physicianId: Int!
-  }
 `;

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -19,12 +19,23 @@ export const formatPhoneNumber = (phone: string): string => {
 };
 
 /**
- * Format Canadian postal code by removing all non-alphanumeric characters.
+ * Strip Canadian postal code by capitalizing alphabetic characters and removing all non-alphanumeric characters.
+ * @param {string} postalCode postal code to be formatted
+ * @returns {string} formatted postal code
+ */
+export const stripPostalCode = (postalCode: string): string => {
+  const upperCasePostalCode = postalCode.toUpperCase();
+  return upperCasePostalCode.replace(/[^A-Za-z\d]/g, '');
+};
+
+/**
+ * Format Canadian postal code by adding space and capitalizing alphabetic characters
  * @param {string} postalCode postal code to be formatted
  * @returns {string} formatted postal code
  */
 export const formatPostalCode = (postalCode: string): string => {
-  return postalCode.replace(/[^A-Za-z\d]/g, '');
+  const upperCasePostalCode = postalCode.toUpperCase();
+  return `${upperCasePostalCode.substring(0, 3)} ${upperCasePostalCode.substring(3)}`;
 };
 
 /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Format-postal-code-presentation-and-strip-before-updating-DB-1d0029ed691c421e9dfd5721c51aec14)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Renamed a formatting function `formatPostalCode` to `stripPostalCode` (strips whitespace, capitalizes alpha characters)
* Created a new formatting function `formatPostalCode` that capitalizes alpha characters and inserts a space to format postal code. Eg. a1b2c3 => A1B 2C3
* Stripped postal codes prior to writing to DB for all instances in resolvers
* Fixed some postal code formatting inconsistencies on frontend


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Also removed an unused GQL schema


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
