### PR TITLE
[Fix] Add phone number formatting

### DIFF
--- a/components/admin/permit-holders/doctor-information/Card.tsx
+++ b/components/admin/permit-holders/doctor-information/Card.tsx
@@ -13,7 +13,7 @@ import {
   UpdateDoctorInformationResponse,
   UPDATE_DOCTOR_INFORMATION,
 } from '@tools/admin/permit-holders/doctor-information';
-import { formatFullName } from '@lib/utils/format';
+import { formatFullName, formatPhoneNumber } from '@lib/utils/format';
 import Address from '@components/admin/Address';
 import { useMemo } from 'react';
 
@@ -146,7 +146,7 @@ export default function DoctorInformationCard(props: DoctorInformationProps) {
             {`MSP Number: ${mspNumber}`}
           </Text>
           <Text as="p" textStyle="body-regular" textAlign="left">
-            {`Phone: ${phone}`}
+            {`Phone: ${formatPhoneNumber(phone)}`}
           </Text>
         </VStack>
         <Divider />

--- a/components/admin/permit-holders/guardian-information/Card.tsx
+++ b/components/admin/permit-holders/guardian-information/Card.tsx
@@ -10,7 +10,7 @@ import {
 import { FC, useCallback } from 'react';
 import { Text } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
-import { formatFullName } from '@lib/utils/format';
+import { formatFullName, formatPhoneNumber } from '@lib/utils/format';
 import { Guardian, UpdateApplicantGuardianInformationInput } from '@lib/graphql/types';
 import Address from '@components/admin/Address';
 import EditGuardianInformationModal from '@components/admin/requests/guardian-information/EditModal';
@@ -86,7 +86,7 @@ const GuardianInformationCard: FC<Props> = props => {
             {formatFullName(firstName, middleName, lastName)}
           </Text>
           <Text as="p" textStyle="body-regular" textAlign="left">
-            {`Phone: ${phone}`}
+            {`Phone: ${formatPhoneNumber(phone)}`}
           </Text>
           <Text as="p" textStyle="body-regular" textAlign="left">
             {`Relationship: ${relationship}`}

--- a/components/admin/permit-holders/permit-holder-information/Card.tsx
+++ b/components/admin/permit-holders/permit-holder-information/Card.tsx
@@ -12,6 +12,7 @@ import {
 import EditUserInformationModal from '@components/admin/permit-holders/permit-holder-information/EditModal'; // Edit User Information Modal
 import PermitHolderInfoCard from '@components/admin/LayoutCard'; // Custom Card component
 import { formatDateYYYYMMDD } from '@lib/utils/date'; // Date formatter util
+import { formatPhoneNumber } from '@lib/utils/format'; // String formatter util
 import {
   ApplicantCardData,
   ApplicantFormData,
@@ -139,7 +140,7 @@ export default function PermitHolderInformationCard(props: PersonalInformationPr
             Contact Information
           </Text>
           <Text as="p" textStyle="body-regular">
-            {phone}
+            {formatPhoneNumber(phone)}
           </Text>
           <Tooltip
             hasArrow

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -24,6 +24,7 @@ import { DateUtils } from 'react-day-picker'; // Date utils
 import { SortOrder } from '@tools/types'; // Sorting Type
 import { PermitType } from '@prisma/client';
 import { verifyIdentitySchema } from '@lib/applicants/verify-identity/validation';
+import { stripPhoneNumber } from '@lib/utils/format';
 
 /**
  * Query and filter RCD applicants from the internal facing app.
@@ -237,6 +238,7 @@ export const updateApplicantGeneralInformation: Resolver<
   // TODO: Validation
   const { input } = args;
   const { id, ...data } = input;
+  data.phone = stripPhoneNumber(data.phone);
 
   let updatedApplicant;
   try {
@@ -266,6 +268,7 @@ export const updateApplicantDoctorInformation: Resolver<
   // TODO: Validation
   const { input } = args;
   const { id, mspNumber, ...data } = input;
+  data.phone = stripPhoneNumber(data.phone);
 
   let updatedApplicant;
   try {
@@ -305,6 +308,7 @@ export const updateApplicantGuardianInformation: Resolver<
 > = async (_parent, args, { prisma }) => {
   const { input } = args;
   const { id, omitGuardianPoa, ...data } = input;
+  data.phone = stripPhoneNumber(data.phone);
 
   let updatedApplicant;
   try {

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -215,6 +215,7 @@ export const createNewApplication: Resolver<
   // TODO: Validation
   const { input } = args;
   const {
+    phone,
     dateOfBirth,
     gender,
     otherGender,
@@ -274,6 +275,7 @@ export const createNewApplication: Resolver<
           },
         }),
         ...data,
+        phone: stripPhoneNumber(phone),
         postalCode: formatPostalCode(postalCode),
         shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
         billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
@@ -291,7 +293,7 @@ export const createNewApplication: Resolver<
             physicianFirstName,
             physicianLastName,
             physicianMspNumber,
-            physicianPhone,
+            physicianPhone: stripPhoneNumber(physicianPhone),
             physicianAddressLine1,
             physicianAddressLine2,
             physicianCity,
@@ -300,7 +302,7 @@ export const createNewApplication: Resolver<
               guardianFirstName,
               guardianMiddleName,
               guardianLastName,
-              guardianPhone,
+              guardianPhone: guardianPhone && stripPhoneNumber(guardianPhone),
               guardianRelationship,
               guardianAddressLine1,
               guardianAddressLine2,
@@ -354,6 +356,7 @@ export const createRenewalApplication: Resolver<
   const { input } = args;
   const {
     applicantId,
+    phone,
     postalCode,
     physicianFirstName,
     physicianLastName,
@@ -386,6 +389,7 @@ export const createRenewalApplication: Resolver<
         processingFee: process.env.PROCESSING_FEE,
         donationAmount: donationAmount || 0,
         ...data,
+        phone: stripPhoneNumber(phone),
         postalCode: formatPostalCode(postalCode),
         shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
         billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
@@ -397,7 +401,7 @@ export const createRenewalApplication: Resolver<
             physicianFirstName,
             physicianLastName,
             physicianMspNumber,
-            physicianPhone,
+            physicianPhone: stripPhoneNumber(physicianPhone),
             physicianAddressLine1,
             physicianAddressLine2,
             physicianCity,
@@ -564,7 +568,9 @@ export const createExternalRenewalApplication: Resolver<
               updatedPhysician && physicianLastName ? physicianLastName : physician.lastName,
             physicianMspNumber:
               updatedPhysician && physicianMspNumber ? physicianMspNumber : physician.mspNumber,
-            physicianPhone: updatedPhysician && physicianPhone ? physicianPhone : physician.phone,
+            physicianPhone: stripPhoneNumber(
+              updatedPhysician && physicianPhone ? physicianPhone : physician.phone
+            ),
             physicianAddressLine1:
               updatedPhysician && addressLine1 ? addressLine1 : physician.addressLine1,
             physicianAddressLine2: updatedPhysician
@@ -626,6 +632,7 @@ export const createReplacementApplication: Resolver<
   const { input } = args;
   const {
     applicantId,
+    phone,
     postalCode,
     reason,
     lostTimestamp,
@@ -663,6 +670,7 @@ export const createReplacementApplication: Resolver<
         type: 'REPLACEMENT',
         processingFee: process.env.PROCESSING_FEE,
         donationAmount: donationAmount || 0,
+        phone: stripPhoneNumber(phone),
         postalCode: formatPostalCode(postalCode),
         shippingPostalCode: shippingPostalCode && formatPostalCode(shippingPostalCode),
         billingPostalCode: billingPostalCode && formatPostalCode(billingPostalCode),
@@ -723,7 +731,7 @@ export const updateApplicationGeneralInformation: Resolver<
 > = async (_parent, args, { prisma }) => {
   // TODO: Validation
   const { input } = args;
-  const { id, receiveEmailUpdates, postalCode, ...data } = input;
+  const { id, receiveEmailUpdates, phone, postalCode, ...data } = input;
 
   // Prevent reviewed requests from being updated
   const application = await prisma.application.findUnique({
@@ -750,6 +758,7 @@ export const updateApplicationGeneralInformation: Resolver<
       data: {
         // Only set to `undefined` if `receiveEmailUpdates` is null
         receiveEmailUpdates: receiveEmailUpdates ?? undefined,
+        phone: stripPhoneNumber(phone),
         postalCode: formatPostalCode(postalCode),
         ...data,
       },
@@ -775,7 +784,8 @@ export const updateNewApplicationGeneralInformation: Resolver<
 > = async (_parent, args, { prisma }) => {
   // TODO: Validation
   const { input } = args;
-  const { id, receiveEmailUpdates, postalCode, dateOfBirth, gender, otherGender, ...data } = input;
+  const { id, receiveEmailUpdates, phone, postalCode, dateOfBirth, gender, otherGender, ...data } =
+    input;
 
   // Prevent reviewed requests from being updated
   const application = await prisma.application.findUnique({
@@ -802,6 +812,7 @@ export const updateNewApplicationGeneralInformation: Resolver<
       data: {
         // Only set to `undefined` if `receiveEmailUpdates` is null
         receiveEmailUpdates: receiveEmailUpdates ?? undefined,
+        phone: stripPhoneNumber(phone),
         postalCode: formatPostalCode(postalCode),
         newApplication: {
           update: {
@@ -880,7 +891,7 @@ export const updateApplicationDoctorInformation: Resolver<
               physicianFirstName,
               physicianLastName,
               physicianMspNumber,
-              physicianPhone,
+              physicianPhone: stripPhoneNumber(physicianPhone),
               physicianAddressLine1,
               physicianAddressLine2,
               physicianCity,
@@ -894,7 +905,7 @@ export const updateApplicationDoctorInformation: Resolver<
               physicianFirstName,
               physicianLastName,
               physicianMspNumber,
-              physicianPhone,
+              physicianPhone: stripPhoneNumber(physicianPhone),
               physicianAddressLine1,
               physicianAddressLine2,
               physicianCity,
@@ -948,7 +959,7 @@ export const updateApplicationGuardianInformation: Resolver<
           guardianFirstName: firstName,
           guardianMiddleName: middleName,
           guardianLastName: lastName,
-          guardianPhone: phone,
+          guardianPhone: stripPhoneNumber(phone),
           guardianRelationship: relationship,
           guardianAddressLine1: addressLine1,
           guardianAddressLine2: addressLine2,

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -43,7 +43,7 @@ import { SortOptions, SortOrder } from '@tools/types'; // Sorting types
 import { Column } from 'react-table'; // Column type for table
 import useDebounce from '@tools/hooks/useDebounce'; // Debouncer
 import { useEffect } from 'react'; // React
-import { formatFullName } from '@lib/utils/format'; // String formatter util
+import { formatFullName, formatPhoneNumber } from '@lib/utils/format'; // String formatter util
 import { formatDate } from '@lib/utils/date'; // Date formatter util
 import SetPermitHolderToInactiveModal from '@components/admin/permit-holders/table/ConfirmSetInactiveModal'; // Set Permit Holder To Inactive modal
 import SetPermitHolderToActiveModal from '@components/admin/permit-holders/table/ConfirmSetActiveModal'; // Set Permit Holder To Active modal
@@ -226,6 +226,7 @@ const PermitHolders: NextPage = () => {
         disableSortBy: true,
         width: 140,
         maxWidth: 140,
+        Cell: ({ value }) => formatPhoneNumber(value),
       },
       {
         Header: 'Recent APP',


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Add-formatting-with-hyphens-to-phone-number-fields-strip-before-saving-to-DB-d4f25d4de5094fc4be0095671d0c218a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Strip phone numbers of all non-numeric characters before writing to DB (backend)
* Format all phone numbers (add hyphens) on frontend


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
