### PR TITLE
[Feature] Add form validation to Physician’s Assessment Card + Edit Modal

### DIFF
--- a/components/admin/requests/physician-assessment/Card.tsx
+++ b/components/admin/requests/physician-assessment/Card.tsx
@@ -25,6 +25,7 @@ import PermitTypeBadge from '@components/admin/PermitTypeBadge';
 import { formatDateYYYYMMDD } from '@lib/utils/format';
 import { titlecase } from '@tools/string';
 import EditPhysicianAssessmentModal from './EditModal';
+import { physicianAssessmentSchema } from '@lib/physicians/validation';
 
 type Props = {
   readonly applicationId: number;
@@ -63,18 +64,13 @@ const Card: FC<Props> = props => {
 
   /** Handler for saving physician assessment */
   const handleSave = async (data: PhysicianAssessment) => {
-    if (data.patientCondition === null || data.permitType === null) {
-      // TODO: Improve error handling
-      return;
-    }
+    const validatedData = await physicianAssessmentSchema.validate(data);
 
     await updatePhysicianAssessment({
       variables: {
         input: {
           id: applicationId,
-          ...data,
-          patientCondition: data.patientCondition,
-          permitType: data.permitType,
+          ...validatedData,
         },
       },
     });

--- a/components/admin/requests/physician-assessment/EditModal.tsx
+++ b/components/admin/requests/physician-assessment/EditModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ReactNode, SyntheticEvent } from 'react';
+import { ReactNode } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -13,6 +13,8 @@ import {
 } from '@chakra-ui/react'; // Chakra UI
 import { PhysicianAssessment } from '@tools/admin/requests/physician-assessment';
 import PhysicianAssessmentForm from './Form';
+import { Form, Formik } from 'formik';
+import { editPhysicianAssessmentSchema } from '@lib/physicians/validation';
 
 type Props = {
   readonly children: ReactNode;
@@ -22,59 +24,57 @@ type Props = {
 
 export default function EditPhysicianAssessmentModal({
   children,
-  physicianAssessment: currentPhysicianAssessment,
+  physicianAssessment,
   onSave,
 }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [physicianAssessment, setPhysicianAssessment] = useState<PhysicianAssessment>(
-    currentPhysicianAssessment
-  );
 
-  useEffect(() => {
-    setPhysicianAssessment(currentPhysicianAssessment);
-  }, [currentPhysicianAssessment, isOpen]);
-
-  const handleSubmit = (event: SyntheticEvent) => {
-    event.preventDefault();
-    // TODO: Refactor to work with form validation (wrap in a Formik component)
-    onSave(physicianAssessment);
+  const handleSubmit = async (values: { physicianAssessment: PhysicianAssessment }) => {
+    const validatedValues = await editPhysicianAssessmentSchema.validate(values);
+    onSave(validatedValues.physicianAssessment);
     onClose();
   };
-
   return (
     <>
       <Box onClick={onOpen}>{children}</Box>
 
       <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside" size="3xl">
         <ModalOverlay />
-        <form onSubmit={handleSubmit}>
-          <ModalContent paddingX="36px">
-            <ModalHeader
-              textStyle="display-medium-bold"
-              paddingBottom="12px"
-              paddingTop="24px"
-              paddingX="4px"
-            >
-              <Text as="h2" textStyle="display-medium-bold">
-                {'Edit Payment, Shipping and Billing Details'}
-              </Text>
-            </ModalHeader>
-            <ModalBody paddingY="20px" paddingX="4px">
-              <PhysicianAssessmentForm
-                physicianAssessment={physicianAssessment}
-                onChange={setPhysicianAssessment}
-              />
-            </ModalBody>
-            <ModalFooter paddingBottom="24px" paddingX="4px">
-              <Button colorScheme="gray" variant="solid" onClick={onClose}>
-                {'Cancel'}
-              </Button>
-              <Button variant="solid" type="submit" ml={'12px'}>
-                {'Save'}
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </form>
+        <Formik
+          initialValues={{
+            physicianAssessment,
+          }}
+          validationSchema={editPhysicianAssessmentSchema}
+          onSubmit={handleSubmit}
+        >
+          {({ values, isValid }) => (
+            <Form noValidate>
+              <ModalContent paddingX="36px">
+                <ModalHeader
+                  textStyle="display-medium-bold"
+                  paddingBottom="12px"
+                  paddingTop="24px"
+                  paddingX="4px"
+                >
+                  <Text as="h2" textStyle="display-medium-bold">
+                    {'Edit Payment, Shipping and Billing Details'}
+                  </Text>
+                </ModalHeader>
+                <ModalBody paddingY="20px" paddingX="4px">
+                  <PhysicianAssessmentForm physicianAssessment={values.physicianAssessment} />
+                </ModalBody>
+                <ModalFooter paddingBottom="24px" paddingX="4px">
+                  <Button colorScheme="gray" variant="solid" onClick={onClose}>
+                    {'Cancel'}
+                  </Button>
+                  <Button variant="solid" type="submit" ml={'12px'} isDisabled={!isValid}>
+                    {'Save'}
+                  </Button>
+                </ModalFooter>
+              </ModalContent>
+            </Form>
+          )}
+        </Formik>
       </Modal>
     </>
   );

--- a/components/admin/requests/physician-assessment/Form.tsx
+++ b/components/admin/requests/physician-assessment/Form.tsx
@@ -1,4 +1,3 @@
-import { Text, Stack, FormHelperText, Box, Divider, Radio } from '@chakra-ui/react'; // Chakra UI
 import DateField from '@components/form/DateField';
 import RadioGroupField from '@components/form/RadioGroupField';
 import TextArea from '@components/form/TextAreaField';
@@ -7,7 +6,6 @@ import { PhysicianAssessment } from '@tools/admin/requests/physician-assessment'
 import {
   FormControl,
   FormLabel,
-  Input,
   Text,
   Stack,
   FormHelperText,
@@ -15,14 +13,13 @@ import {
   Divider,
   RadioGroup,
   Radio,
-  Textarea,
-  CheckboxGroup,
   Checkbox,
 } from '@chakra-ui/react'; // Chakra UI
-import { MobilityAid, PatientCondition, PermitType } from '@lib/graphql/types';
-import { formatDateYYYYMMDD } from '@lib/utils/format';
-import { PhysicianAssessment } from '@tools/admin/requests/physician-assessment';
-import { ChangeEventHandler, useState } from 'react';
+import { useState } from 'react';
+import TextAreaField from '@components/form/TextAreaField';
+import CheckboxGroupField from '@components/form/CheckboxGroupField';
+import { useFormikContext } from 'formik';
+import { formatDate } from '@lib/utils/format';
 
 type PhysicianAssessmentFormProps = {
   readonly physicianAssessment: PhysicianAssessment;
@@ -41,6 +38,8 @@ export default function PhysicianAssessmentForm({
     !!physicianAssessment?.mobilityAids?.length
   );
 
+  const { setFieldValue } = useFormikContext();
+
   return (
     <>
       <Box paddingBottom="32px">
@@ -57,6 +56,7 @@ export default function PhysicianAssessmentForm({
             name="physicianAssessment.disabilityCertificationDate"
             label="Physician’s certification date"
             required
+            value={formatDate(new Date(physicianAssessment.disabilityCertificationDate), true)}
           >
             <FormHelperText color="text.secondary">{'Format: YYYY-MM-DD'}</FormHelperText>
           </DateField>
@@ -121,10 +121,7 @@ export default function PhysicianAssessmentForm({
               onChange={value => {
                 setMobilityAidsRequired(value === '1' ? true : false);
                 if (value === '0') {
-                  onChange({
-                    ...physicianAssessment,
-                    mobilityAids: [],
-                  });
+                  setFieldValue('physicianAssessment.mobilityAids', []);
                 }
               }}
             >
@@ -136,43 +133,31 @@ export default function PhysicianAssessmentForm({
           </FormControl>
 
           {mobilityAidsRequired && (
-            <FormControl isRequired>
-              <FormLabel>{'What mobility aids are you currently using?'}</FormLabel>
-              <CheckboxGroup
-                value={physicianAssessment.mobilityAids || undefined}
-                onChange={value => {
-                  onChange({
-                    ...physicianAssessment,
-                    mobilityAids: value as MobilityAid[],
-                  });
-                }}
-              >
-                <Stack>
-                  <Checkbox value={'MANUAL_CHAIR'}>{'Manual Wheelchair'}</Checkbox>
-                  <Checkbox value={'ELECTRIC_CHAIR'}>{'Power Wheelchair'}</Checkbox>
-                  <Checkbox value={'SCOOTER'}>{'Scooter'}</Checkbox>
-                  <Checkbox value={'WALKER'}>{'Walker'}</Checkbox>
-                  <Checkbox value={'CRUTCHES'}>{'Crutches'}</Checkbox>
-                  <Checkbox value={'CANE'}>{'Cane'}</Checkbox>
-                  <Checkbox value={'OTHERS'}>{'Others'}</Checkbox>
-                </Stack>
-              </CheckboxGroup>
-            </FormControl>
+            <CheckboxGroupField
+              name="physicianAssessment.mobilityAids"
+              label="What mobility aids are you currently using?"
+              required
+            >
+              <Stack>
+                <Checkbox value={'MANUAL_CHAIR'}>{'Manual Wheelchair'}</Checkbox>
+                <Checkbox value={'ELECTRIC_CHAIR'}>{'Power Wheelchair'}</Checkbox>
+                <Checkbox value={'SCOOTER'}>{'Scooter'}</Checkbox>
+                <Checkbox value={'WALKER'}>{'Walker'}</Checkbox>
+                <Checkbox value={'CRUTCHES'}>{'Crutches'}</Checkbox>
+                <Checkbox value={'CANE'}>{'Cane'}</Checkbox>
+                <Checkbox value={'OTHERS'}>{'Others'}</Checkbox>
+              </Stack>
+            </CheckboxGroupField>
           )}
 
-          {physicianAssessment?.mobilityAids?.includes('OTHERS') && (
-            <FormControl isRequired>
-              <FormLabel>{'Description'}</FormLabel>
-              <Textarea
-                value={physicianAssessment.otherMobilityAids || undefined}
-                onChange={event =>
-                  onChange({
-                    ...physicianAssessment,
-                    otherMobilityAids: event.target.value,
-                  })
-                }
+          {physicianAssessment.mobilityAids?.includes('OTHERS') && (
+            <Box>
+              <TextAreaField
+                name="physicianAssessment.otherMobilityAids"
+                label="Description"
+                required
               />
-            </FormControl>
+            </Box>
           )}
         </Stack>
       </Box>
@@ -204,6 +189,11 @@ export default function PhysicianAssessmentForm({
             name="physicianAssessment.temporaryPermitExpiry"
             label="Temporary permit will expire on"
             required
+            value={
+              physicianAssessment.temporaryPermitExpiry
+                ? formatDate(new Date(physicianAssessment.temporaryPermitExpiry), true)
+                : ''
+            }
           >
             <FormHelperText color="text.secondary">{'Format: YYYY-MM-DD'}</FormHelperText>
           </DateField>

--- a/lib/physicians/validation.ts
+++ b/lib/physicians/validation.ts
@@ -1,5 +1,5 @@
-import { PatientCondition, PermitType } from '@prisma/client';
-import { date, mixed, object, string } from 'yup';
+import { MobilityAid, PatientCondition, PermitType } from '@prisma/client';
+import { date, mixed, object, string, array } from 'yup';
 
 /**
  * Validation schema for physician assessment form
@@ -7,6 +7,9 @@ import { date, mixed, object, string } from 'yup';
 export const physicianAssessmentSchema = object({
   disability: string().required('Please enter a disabling condition'),
   disabilityCertificationDate: date()
+    .transform((_value, originalValue) => {
+      return new Date(originalValue);
+    })
     .max(new Date(), 'Date must be in the past')
     .required('Please enter a valid certification date'),
   patientCondition: mixed<PatientCondition>()
@@ -25,14 +28,40 @@ export const physicianAssessmentSchema = object({
   permitType: mixed<PermitType>()
     .oneOf(Object.values(PermitType))
     .required('Please select a mobility impairment type'),
-  temporaryPermitExpiry: date().when('permitType', {
-    is: 'TEMPORARY',
-    then: date()
-      .typeError('Please select an expiry date')
-      .min(new Date(Date.now() - 86400000), 'Date must be in the future') //set min date to yesterday so expiry is on or after current day
-      .required('Please select an expiry date'),
-    otherwise: date().nullable().default(null),
-  }),
+  temporaryPermitExpiry: date()
+    .transform((_value, originalValue) => {
+      return new Date(originalValue);
+    })
+    .when('permitType', {
+      is: 'TEMPORARY',
+      then: date()
+        .typeError('Please select an expiry date')
+        .min(new Date(Date.now() - 86400000), 'Date must be in the future') //set min date to yesterday so expiry is on or after current day
+        .required('Please select an expiry date'),
+      otherwise: date().nullable().default(null),
+    }),
+  mobilityAids: array(
+    mixed<MobilityAid>()
+      .oneOf(Object.values(MobilityAid))
+      .required('Please select a mobility impairment type')
+  ).required(),
+  otherMobilityAids: string()
+    .nullable()
+    .default(null)
+    .when('mobilityAids', mobilityAids => {
+      return mobilityAids.includes('OTHERS')
+        ? string()
+            .typeError('Please enter a description for the mobility aids')
+            .required('Please enter a description for the mobility aids') // add required validation
+        : string().nullable().default(null);
+    }),
+});
+
+/**
+ * Validation schema for edit reason for replacement form
+ */
+export const editPhysicianAssessmentSchema = object({
+  physicianAssessment: physicianAssessmentSchema,
 });
 
 /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add form validation to Physician’s Assessment Card + Edit Modal](https://www.notion.so/uwblueprintexecs/Add-form-validation-to-Physician-s-Assessment-Card-Edit-Modal-d28a20aa43564fcc82b9755e58444ad9)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Replaced form fields with the custom Formik field components
* Integrated Formik into `EditModal` to work with the modified form 
* Update Yup validation schema to include the new mobility section fields and to resolve a bug with the date fields

## Demo
Most of the validation can't be triggered (and thus demoed) since some fields inputs can't be emptied (e.g. radio button can't be unselected). 

https://user-images.githubusercontent.com/51224641/170395051-a2708c4d-5147-498e-9966-018cf9bb4345.mov

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
