### PR TITLE
[Feature] Payment form backend validation

### DIFF
--- a/components/admin/requests/payment-information/Card.tsx
+++ b/components/admin/requests/payment-information/Card.tsx
@@ -44,7 +44,7 @@ const Card: FC<Props> = props => {
     }
   );
 
-  const [updatePaymentInformation, { data }] = useMutation<
+  const [updatePaymentInformation] = useMutation<
     UpdatePaymentInformationResponse,
     UpdatePaymentInformationRequest
   >(UPDATE_PAYMENT_INFORMATION);
@@ -57,10 +57,12 @@ const Card: FC<Props> = props => {
   const handleSave = async (paymentInformationFormData: PaymentInformationFormData) => {
     const validatedData = await paymentInformationSchema.validate(paymentInformationFormData);
 
-    await updatePaymentInformation({
+    const { data } = await updatePaymentInformation({
       variables: { input: { id: applicationId, ...validatedData } },
     });
+
     refetch();
+    return data;
   };
 
   const {
@@ -116,7 +118,6 @@ const Card: FC<Props> = props => {
               billingPostalCode,
             }}
             onSave={handleSave}
-            error={data?.updateApplicationPaymentInformation.error}
           >
             <Button color="primary" variant="ghost" textDecoration="underline">
               <Text textStyle="body-bold">Edit</Text>

--- a/components/admin/requests/payment-information/Card.tsx
+++ b/components/admin/requests/payment-information/Card.tsx
@@ -44,7 +44,7 @@ const Card: FC<Props> = props => {
     }
   );
 
-  const [updatePaymentInformation] = useMutation<
+  const [updatePaymentInformation, { data }] = useMutation<
     UpdatePaymentInformationResponse,
     UpdatePaymentInformationRequest
   >(UPDATE_PAYMENT_INFORMATION);
@@ -54,8 +54,8 @@ const Card: FC<Props> = props => {
   }
 
   /** Form save handler */
-  const handleSave = async (data: PaymentInformationFormData) => {
-    const validatedData = await paymentInformationSchema.validate(data);
+  const handleSave = async (paymentInformationFormData: PaymentInformationFormData) => {
+    const validatedData = await paymentInformationSchema.validate(paymentInformationFormData);
 
     await updatePaymentInformation({
       variables: { input: { id: applicationId, ...validatedData } },
@@ -116,6 +116,7 @@ const Card: FC<Props> = props => {
               billingPostalCode,
             }}
             onSave={handleSave}
+            error={data?.updateApplicationPaymentInformation.error}
           >
             <Button color="primary" variant="ghost" textDecoration="underline">
               <Text textStyle="body-bold">Edit</Text>

--- a/components/admin/requests/payment-information/EditModal.tsx
+++ b/components/admin/requests/payment-information/EditModal.tsx
@@ -10,9 +10,6 @@ import {
   useDisclosure,
   Text,
   Box,
-  Alert,
-  AlertIcon,
-  AlertTitle,
 } from '@chakra-ui/react'; // Chakra UI
 import {
   PaymentInformationFormData,
@@ -21,6 +18,7 @@ import {
 import PaymentDetailsForm from '@components/admin/requests/payment-information/Form';
 import { Form, Formik } from 'formik';
 import { editPaymentInformationSchema } from '@lib/applications/validation';
+import ValidationErrorAlert from '@components/form/ValidationErrorAlert';
 
 type EditPaymentDetailsModalProps = {
   readonly children: ReactNode;
@@ -85,12 +83,7 @@ export default function EditPaymentDetailsModal({
                 <ModalBody paddingY="20px" paddingX="4px">
                   <PaymentDetailsForm paymentInformation={values.paymentInformation} />
                 </ModalBody>
-                {error && (
-                  <Alert status="error" mt="12px" pt="20px" pb="20px">
-                    <AlertIcon />
-                    <AlertTitle>{error}</AlertTitle>
-                  </Alert>
-                )}
+                <ValidationErrorAlert error={error} />
                 <ModalFooter paddingBottom="24px" paddingX="4px">
                   <Button colorScheme="gray" variant="solid" onClick={onModalClose}>
                     {'Cancel'}

--- a/components/admin/requests/payment-information/EditModal.tsx
+++ b/components/admin/requests/payment-information/EditModal.tsx
@@ -10,6 +10,9 @@ import {
   useDisclosure,
   Text,
   Box,
+  Alert,
+  AlertIcon,
+  AlertTitle,
 } from '@chakra-ui/react'; // Chakra UI
 import { PaymentInformationFormData } from '@tools/admin/requests/payment-information';
 import PaymentDetailsForm from '@components/admin/requests/payment-information/Form';
@@ -20,19 +23,23 @@ type EditPaymentDetailsModalProps = {
   readonly children: ReactNode;
   readonly paymentInformation: PaymentInformationFormData;
   readonly onSave: (applicationData: any) => void;
+  readonly error?: string; //should the type instead be string | undefined or something?
 };
 
 export default function EditPaymentDetailsModal({
   children,
   paymentInformation,
   onSave,
+  error,
 }: EditPaymentDetailsModalProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const handleSubmit = (values: { paymentInformation: PaymentInformationFormData }) => {
     // TODO: Backend errors
     onSave(values.paymentInformation);
-    onClose();
+    if (!error) {
+      onClose();
+    }
   };
 
   return (
@@ -67,6 +74,12 @@ export default function EditPaymentDetailsModal({
                 <ModalBody paddingY="20px" paddingX="4px">
                   <PaymentDetailsForm paymentInformation={values.paymentInformation} />
                 </ModalBody>
+                {error && (
+                  <Alert status="error" marginBottom="24px" pt="8px">
+                    <AlertIcon />
+                    <AlertTitle>{error}</AlertTitle>
+                  </Alert>
+                )}
                 <ModalFooter paddingBottom="24px" paddingX="4px">
                   <Button colorScheme="gray" variant="solid" onClick={onClose}>
                     {'Cancel'}

--- a/components/admin/requests/payment-information/EditModal.tsx
+++ b/components/admin/requests/payment-information/EditModal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -14,7 +14,10 @@ import {
   AlertIcon,
   AlertTitle,
 } from '@chakra-ui/react'; // Chakra UI
-import { PaymentInformationFormData } from '@tools/admin/requests/payment-information';
+import {
+  PaymentInformationFormData,
+  UpdatePaymentInformationResponse,
+} from '@tools/admin/requests/payment-information';
 import PaymentDetailsForm from '@components/admin/requests/payment-information/Form';
 import { Form, Formik } from 'formik';
 import { editPaymentInformationSchema } from '@lib/applications/validation';
@@ -22,23 +25,31 @@ import { editPaymentInformationSchema } from '@lib/applications/validation';
 type EditPaymentDetailsModalProps = {
   readonly children: ReactNode;
   readonly paymentInformation: PaymentInformationFormData;
-  readonly onSave: (applicationData: any) => void;
-  readonly error?: string; //should the type instead be string | undefined or something?
+  readonly onSave: (
+    applicationData: any
+  ) => Promise<UpdatePaymentInformationResponse | undefined | null>;
 };
 
 export default function EditPaymentDetailsModal({
   children,
   paymentInformation,
   onSave,
-  error,
 }: EditPaymentDetailsModalProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [error, setError] = useState<string>('');
 
-  const handleSubmit = (values: { paymentInformation: PaymentInformationFormData }) => {
-    // TODO: Backend errors
-    onSave(values.paymentInformation);
-    if (!error) {
-      onClose();
+  const onModalClose = () => {
+    onClose();
+    setError('');
+  };
+
+  const handleSubmit = async (values: { paymentInformation: PaymentInformationFormData }) => {
+    const result = await onSave(values.paymentInformation);
+
+    if (result?.updateApplicationPaymentInformation.ok) {
+      onModalClose();
+    } else {
+      setError(result?.updateApplicationPaymentInformation.error ?? '');
     }
   };
 
@@ -47,7 +58,7 @@ export default function EditPaymentDetailsModal({
       <Box onClick={onOpen}>{children}</Box>
 
       <Modal
-        onClose={onClose}
+        onClose={onModalClose}
         isOpen={isOpen}
         scrollBehavior="inside"
         size="3xl" // TODO: change to custom size
@@ -75,13 +86,13 @@ export default function EditPaymentDetailsModal({
                   <PaymentDetailsForm paymentInformation={values.paymentInformation} />
                 </ModalBody>
                 {error && (
-                  <Alert status="error" marginBottom="24px" pt="8px">
+                  <Alert status="error" mt="12px" pt="20px" pb="20px">
                     <AlertIcon />
                     <AlertTitle>{error}</AlertTitle>
                   </Alert>
                 )}
                 <ModalFooter paddingBottom="24px" paddingX="4px">
-                  <Button colorScheme="gray" variant="solid" onClick={onClose}>
+                  <Button colorScheme="gray" variant="solid" onClick={onModalClose}>
                     {'Cancel'}
                   </Button>
                   <Button variant="solid" type="submit" ml={'12px'} isDisabled={!isValid}>

--- a/components/form/ValidationErrorAlert.tsx
+++ b/components/form/ValidationErrorAlert.tsx
@@ -1,0 +1,18 @@
+import { Alert, AlertIcon, AlertTitle } from '@chakra-ui/react';
+
+type ValidationErrorAlertProps = {
+  readonly error?: string;
+};
+
+export default function ValidationErrorAlert({ error }: ValidationErrorAlertProps) {
+  return (
+    <>
+      {error && (
+        <Alert status="error" mt="12px" pt="20px" pb="20px">
+          <AlertIcon />
+          <AlertTitle>{error}</AlertTitle>
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/components/form/ValidationErrorAlert.tsx
+++ b/components/form/ValidationErrorAlert.tsx
@@ -4,6 +4,11 @@ type ValidationErrorAlertProps = {
   readonly error?: string;
 };
 
+/**
+ * Alert to display backend form validation errors
+ * @param props validation error to be shown
+ * @returns Alert displaying backend form validation error
+ */
 export default function ValidationErrorAlert({ error }: ValidationErrorAlertProps) {
   return (
     <>

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -44,10 +44,7 @@ import {
   UpdateApplicationReasonForReplacementResult,
 } from '@lib/graphql/types';
 import { flattenApplication } from '@lib/applications/utils';
-import {
-  additionalQuestionsMutationSchema,
-  paymentInformationMutationSchema,
-} from '@lib/applications/validation';
+import { paymentInformationMutationSchema } from '@lib/applications/validation';
 import { ValidationError } from 'yup';
 
 /**
@@ -1000,10 +997,9 @@ export const updateApplicationAdditionalInformation: Resolver<
   MutationUpdateApplicationAdditionalInformationArgs,
   UpdateApplicationAdditionalInformationResult
 > = async (_parent, args, { prisma }) => {
+  // TODO: Validation
   const { input } = args;
-
-  const validatedInput = await additionalQuestionsMutationSchema.validate(input);
-  const { id, ...data } = validatedInput;
+  const { id, ...data } = input;
 
   // Get existing application type (should be NEW/RENEWAL)
   const application = await prisma.application.findUnique({
@@ -1018,6 +1014,7 @@ export const updateApplicationAdditionalInformation: Resolver<
     },
   });
   if (!application) {
+    // TODO: Improve validation
     throw new ApolloError('Application not found');
   }
   // Prevent reviewed requests from being updated

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -44,7 +44,11 @@ import {
   UpdateApplicationReasonForReplacementResult,
 } from '@lib/graphql/types';
 import { flattenApplication } from '@lib/applications/utils';
-import { paymentInformationMutationSchema } from '@lib/applications/validation';
+import {
+  additionalQuestionsMutationSchema,
+  paymentInformationMutationSchema,
+} from '@lib/applications/validation';
+import { ValidationError } from 'yup';
 
 /**
  * Query an application by ID
@@ -996,9 +1000,10 @@ export const updateApplicationAdditionalInformation: Resolver<
   MutationUpdateApplicationAdditionalInformationArgs,
   UpdateApplicationAdditionalInformationResult
 > = async (_parent, args, { prisma }) => {
-  // TODO: Validation
   const { input } = args;
-  const { id, ...data } = input;
+
+  const validatedInput = await additionalQuestionsMutationSchema.validate(input);
+  const { id, ...data } = validatedInput;
 
   // Get existing application type (should be NEW/RENEWAL)
   const application = await prisma.application.findUnique({
@@ -1013,7 +1018,6 @@ export const updateApplicationAdditionalInformation: Resolver<
     },
   });
   if (!application) {
-    // TODO: Improve validation
     throw new ApolloError('Application not found');
   }
   // Prevent reviewed requests from being updated
@@ -1067,12 +1071,21 @@ export const updateApplicationPaymentInformation: Resolver<
 > = async (_parent, args, { prisma }) => {
   const { input } = args;
 
-  const validatedInput = await paymentInformationMutationSchema.validate(input);
-  const { donationAmount, shippingPostalCode, billingPostalCode, ...validatedData } =
-    validatedInput;
+  try {
+    await paymentInformationMutationSchema.validate({ ...input, id: 'abcde' });
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return {
+        ok: false,
+        error: err.message,
+      };
+    }
+  }
+
+  const { id, donationAmount, shippingPostalCode, billingPostalCode, ...validatedData } = input;
 
   const application = await prisma.application.findUnique({
-    where: { id: validatedInput.id },
+    where: { id },
     select: {
       paidThroughShopify: true,
       applicationProcessing: {
@@ -1082,9 +1095,11 @@ export const updateApplicationPaymentInformation: Resolver<
       },
     },
   });
+
   if (!application) {
     throw new ApolloError('Application does not exist');
   }
+
   // Prevent reviewed requests from being updated
   if (application.applicationProcessing.reviewRequestCompleted) {
     throw new ApolloError('Reviewed requests cannot be updated');

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -1072,7 +1072,7 @@ export const updateApplicationPaymentInformation: Resolver<
   const { input } = args;
 
   try {
-    await paymentInformationMutationSchema.validate({ ...input, id: 'abcde' });
+    await paymentInformationMutationSchema.validate(input);
   } catch (err) {
     if (err instanceof ValidationError) {
       return {

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -1128,7 +1128,7 @@ export const updateApplicationPaymentInformation: Resolver<
     throw new ApolloError('Application payment information was unable to be updated');
   }
 
-  return { ok: true };
+  return { ok: true, error: null };
 };
 
 /**

--- a/lib/applications/schema.ts
+++ b/lib/applications/schema.ts
@@ -740,6 +740,7 @@ export default gql`
 
   type UpdateApplicationPaymentInformationResult {
     ok: Boolean!
+    error: String
   }
 
   # Update reason for replacement section of application

--- a/lib/applications/validation.ts
+++ b/lib/applications/validation.ts
@@ -60,6 +60,15 @@ export const editAdditionalQuestionsSchema = object({
 });
 
 /**
+ * Validation schema for payment information mutation
+ */
+export const additionalQuestionsMutationSchema = additionalQuestionsSchema.concat(
+  object({
+    id: number().required(),
+  })
+);
+
+/**
  * Payment information form validation schema
  */
 export const paymentInformationSchema = object({
@@ -179,8 +188,11 @@ export const editPaymentInformationSchema = object({
   paymentInformation: paymentInformationSchema,
 });
 
+/**
+ * Validation schema for payment information mutation
+ */
 export const paymentInformationMutationSchema = paymentInformationSchema.shape({
-  id: number().required(),
+  id: number().required(), //TODO: positive number
 });
 
 /**

--- a/lib/applications/validation.ts
+++ b/lib/applications/validation.ts
@@ -179,6 +179,10 @@ export const editPaymentInformationSchema = object({
   paymentInformation: paymentInformationSchema,
 });
 
+export const paymentInformationMutationSchema = paymentInformationSchema.shape({
+  id: number().required(),
+});
+
 /**
  * Reason for replacement form validation schema
  */

--- a/lib/applications/validation.ts
+++ b/lib/applications/validation.ts
@@ -60,15 +60,6 @@ export const editAdditionalQuestionsSchema = object({
 });
 
 /**
- * Validation schema for payment information mutation
- */
-export const additionalQuestionsMutationSchema = additionalQuestionsSchema.concat(
-  object({
-    id: number().required(),
-  })
-);
-
-/**
  * Payment information form validation schema
  */
 export const paymentInformationSchema = object({

--- a/lib/applications/validation.ts
+++ b/lib/applications/validation.ts
@@ -192,7 +192,7 @@ export const editPaymentInformationSchema = object({
  * Validation schema for payment information mutation
  */
 export const paymentInformationMutationSchema = paymentInformationSchema.shape({
-  id: number().required(), //TODO: positive number
+  id: number().positive('Application not found').required('Application not found'),
 });
 
 /**

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1274,6 +1274,7 @@ export type UpdateApplicationPaymentInformationInput = {
 export type UpdateApplicationPaymentInformationResult = {
   __typename?: 'UpdateApplicationPaymentInformationResult';
   ok: Scalars['Boolean'];
+  error: Maybe<Scalars['String']>;
 };
 
 export type UpdateApplicationPhysicianAssessmentInput = {

--- a/tools/admin/requests/payment-information.ts
+++ b/tools/admin/requests/payment-information.ts
@@ -95,6 +95,7 @@ export const UPDATE_PAYMENT_INFORMATION = gql`
   mutation UpdateApplicationPaymentInformation($input: UpdateApplicationPaymentInformationInput!) {
     updateApplicationPaymentInformation(input: $input) {
       ok
+      error
     }
   }
 `;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Payment Information Backend Validation](https://www.notion.so/uwblueprintexecs/Payment-Information-Backend-Validation-374e1d1d86f94226a23c88d54d7d0e7d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Returned response from payment information mutation to the edit modal so that it can display error and not close the modal if there is an error.
* Added an error field to return type from graphql mutation so the form validation error can be returned to the frontend.

Example of how a backend form validation error appears in the edit modal. Note that the error shown was manually triggered.

https://user-images.githubusercontent.com/35577524/170796209-65ad4712-a4b4-4900-b9a4-dea5db01deb4.mov


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
