### PR TITLE
[Fix] Fix incorrect default sorting order for requests table

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react'; // Chakra UI
 import { ArrowUpIcon, ArrowDownIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import { useTable, useSortBy, Column } from 'react-table'; // React Table
-import { SortOptions } from '@tools/types'; // Sorting types
+import { SortOptions, SortOrder } from '@tools/types'; // Sorting types
 import { getSortOptions } from '@tools/admin/table'; // Get the sort options from the React Table sortBy state
 
 // Table Props
@@ -26,12 +26,14 @@ type Props<T extends object> = {
   readonly columns: Array<Column<T>>; // Depends on shape of data
   readonly data: Array<T>; // Depends on shape of data
   readonly loading?: boolean;
+  /** Initial sort options */
+  readonly initialSort?: SortOptions;
   readonly onChangeSortOrder?: (sort: SortOptions) => unknown; // Callback after changing sorting
   readonly onRowClick?: (row: T) => unknown;
 };
 
 export default function Table<T extends object>(props: Props<T>) {
-  const { columns, data, loading, onChangeSortOrder, onRowClick } = props;
+  const { columns, data, loading, initialSort, onChangeSortOrder, onRowClick } = props;
 
   // Table rendering functions
   const {
@@ -46,6 +48,13 @@ export default function Table<T extends object>(props: Props<T>) {
       columns,
       data,
       manualSortBy: true,
+      initialState: {
+        sortBy:
+          initialSort?.map(([field, sortOrder]) => ({
+            id: field,
+            desc: sortOrder === SortOrder.DESC,
+          })) ?? [],
+      },
     },
     useSortBy
   );

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -166,6 +166,9 @@ export const applications: Resolver<
         }
       });
       orderBy = sortingOrder;
+    } else {
+      // Set created at DESC to be default sort order
+      orderBy = [{ createdAt: SortOrder.DESC }];
     }
 
     where = {

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -388,6 +388,7 @@ const Requests: NextPage = () => {
                   columns={COLUMNS}
                   data={requestsData}
                   loading={loading}
+                  initialSort={sortOrder}
                   onChangeSortOrder={setSortOrder}
                   onRowClick={({ id }) => router.push(`/admin/request/${id}`)}
                 />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Default-sorting-on-requests-page-is-incorrect-ceb45ef380b64d0fbc03a244691f97a1)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add `initialSort` prop to `Table` component
* Set the default sort order for the `applications` API to descending by created at time. This way, when the user does not have any sorting selected for the table, the applications are still displayed in an intuitive order


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
