### PR TITLE
[Fix] Fix default sorting in permit holder table

### DIFF
--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -436,6 +436,7 @@ const PermitHolders: NextPage = () => {
                   columns={COLUMNS}
                   data={permitHolderData || []}
                   loading={loading}
+                  initialSort={sortOrder}
                   onChangeSortOrder={sortOrder => {
                     setSortOrder(sortOrder);
                   }}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix default sorting for permit holders table](https://www.notion.so/uwblueprintexecs/Fix-default-sorting-for-permit-holders-table-0ac456fac1ee4fa8ba707511c190db7d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Adding new initial sort prop to permit holder table 

<img width="1537" alt="Screen Shot 2022-06-14 at 8 30 50 PM" src="https://user-images.githubusercontent.com/55823764/173711561-07a544f5-bf71-48a1-9467-e0d1c4cdd96a.png">



<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
