### PR TITLE
[Fix] Show notes in permit holder additional notes modal

### DIFF
--- a/components/admin/permit-holders/Header.tsx
+++ b/components/admin/permit-holders/Header.tsx
@@ -27,12 +27,13 @@ type PermitHolderHeaderProps = {
     name: string;
     status: ApplicantStatus;
     inactiveReason?: string;
+    notes: string;
   };
   readonly refetch: () => void;
 };
 
 export default function PermitHolderHeader({
-  applicant: { id, name, status, inactiveReason },
+  applicant: { id, name, status, inactiveReason, notes },
   refetch,
 }: PermitHolderHeaderProps) {
   // Set Permit Holder Inactive/Active modal state
@@ -133,9 +134,10 @@ export default function PermitHolderHeader({
       {/* Additional notes modal */}
       <AdditionalNotesModal
         isOpen={isNotesModalOpen}
-        notes=""
+        notes={notes}
         applicantId={id}
         onClose={onCloseNotesModal}
+        refetch={refetch}
       />
     </>
   );

--- a/components/admin/permit-holders/additional-notes/Modal.tsx
+++ b/components/admin/permit-holders/additional-notes/Modal.tsx
@@ -23,9 +23,16 @@ type Props = {
   readonly notes: string;
   readonly applicantId: number;
   readonly onClose: () => void;
+  readonly refetch: () => void;
 };
 
-const AdditionalNotesModal: FC<Props> = ({ isOpen, notes: notesInput, applicantId, onClose }) => {
+const AdditionalNotesModal: FC<Props> = ({
+  isOpen,
+  notes: notesInput,
+  applicantId,
+  onClose,
+  refetch,
+}) => {
   const [notes, setNotes] = useState('');
 
   useEffect(() => {
@@ -49,6 +56,7 @@ const AdditionalNotesModal: FC<Props> = ({ isOpen, notes: notesInput, applicantI
 
   const handleSave = async () => {
     await updateApplicantNotes({ variables: { input: { id: applicantId, notes } } });
+    refetch();
     onClose();
   };
 
@@ -76,7 +84,7 @@ const AdditionalNotesModal: FC<Props> = ({ isOpen, notes: notesInput, applicantI
           <Button onClick={onClose} colorScheme="gray" variant="solid" isLoading={submitting}>
             Cancel
           </Button>
-          <Button _hover={{ bg: 'secondary.criticalHover' }} ml={'12px'} onClick={handleSave}>
+          <Button ml={'12px'} onClick={handleSave} isLoading={submitting}>
             Save Note
           </Button>
         </ModalFooter>

--- a/lib/applicants/schema.ts
+++ b/lib/applicants/schema.ts
@@ -32,6 +32,8 @@ export default gql`
     status: ApplicantStatus!
     inactiveReason: String
 
+    notes: String
+
     mostRecentPermit: Permit
     activePermit: Permit
     permits: [Permit!]!

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -41,6 +41,7 @@ export type Applicant = {
   postalCode: Scalars['String'];
   status: ApplicantStatus;
   inactiveReason: Maybe<Scalars['String']>;
+  notes: Maybe<Scalars['String']>;
   mostRecentPermit: Maybe<Permit>;
   activePermit: Maybe<Permit>;
   permits: Array<Permit>;

--- a/pages/admin/permit-holder/[id].tsx
+++ b/pages/admin/permit-holder/[id].tsx
@@ -42,6 +42,7 @@ export default function PermitHolder({ id: idString }: Props) {
     lastName,
     status,
     inactiveReason,
+    notes,
     mostRecentApplication: currentApplication,
     permits: appHistory,
     medicalInformation,
@@ -57,6 +58,7 @@ export default function PermitHolder({ id: idString }: Props) {
             name: formatFullName(firstName, middleName, lastName),
             status,
             inactiveReason: inactiveReason || undefined,
+            notes: notes || '',
           }}
           refetch={refetch}
         />

--- a/tools/admin/permit-holders/view-permit-holder.ts
+++ b/tools/admin/permit-holders/view-permit-holder.ts
@@ -16,6 +16,7 @@ export const GET_APPLICANT_QUERY = gql`
       lastName
       status
       inactiveReason
+      notes
 
       # Medical information
       medicalInformation {
@@ -112,7 +113,7 @@ export type GetApplicantRequest = QueryApplicantArgs;
 export type GetApplicantResponse = {
   applicant: Pick<
     Applicant,
-    'firstName' | 'middleName' | 'lastName' | 'status' | 'inactiveReason'
+    'firstName' | 'middleName' | 'lastName' | 'status' | 'inactiveReason' | 'notes'
   > & {
     medicalInformation: MedicalInformationSectionData;
     guardian: GuardianInformationCardData;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Show-notes-in-permit-holder-additional-notes-modal-d551b3a4abb14e32b9b192c04caf0261)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add `notes` field to `applicant` GraphQL query for additional notes
* Show currently saved additional notes in the additional notes modal upon opening


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
