### PR TITLE
[Fix] Search permit holder typeahead fixes

### DIFF
--- a/components/Typeahead.tsx
+++ b/components/Typeahead.tsx
@@ -39,8 +39,9 @@ export default function Typeahead<T extends TypeaheadModel>(props: Required<Prop
       <AsyncTypeahead
         filterBy={filterBy}
         id="async-typeahead"
+        delay={300}
         isLoading={false} // always false to hide spinner in input field when loading
-        minLength={3}
+        minLength={1}
         onSearch={onSearch}
         labelKey={labelKey}
         options={results}

--- a/components/admin/requests/create/SelectedPermitHolderCard.tsx
+++ b/components/admin/requests/create/SelectedPermitHolderCard.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
   Center,
 } from '@chakra-ui/react'; // Chakra UI
-import { formatFullName } from '@lib/utils/format'; // Date formatter util
+import { formatFullName, formatPhoneNumber } from '@lib/utils/format'; // Date formatter util
 import { formatDate } from '@lib/utils/date';
 import { useQuery } from '@apollo/client';
 import {
@@ -112,7 +112,7 @@ export default function SelectedPermitHolderCard(props: SelectedPermitHolderCard
           </Box>
         </Flex>
         <Divider />
-        <VStack spacing="12px" align="left">
+        <VStack spacing="12px" align="flex-start">
           <HStack spacing="12px">
             <Text as="h4" textStyle="body-bold">
               Personal Information
@@ -126,7 +126,7 @@ export default function SelectedPermitHolderCard(props: SelectedPermitHolderCard
           </Text>
         </VStack>
         <Divider />
-        <VStack spacing="12px" align="left">
+        <VStack spacing="12px" align="flex-start">
           <HStack spacing="12px">
             <Text as="h4" textStyle="body-bold">
               Contact Information
@@ -150,11 +150,11 @@ export default function SelectedPermitHolderCard(props: SelectedPermitHolderCard
             </Link>
           </Tooltip>
           <Text as="p" textStyle="body-regular">
-            {phone}
+            {formatPhoneNumber(phone)}
           </Text>
         </VStack>
         <Divider />
-        <VStack spacing="12px" align="left">
+        <VStack spacing="12px" align="flex-start">
           <HStack spacing="12px">
             <Box>
               <Text as="h4" textStyle="body-bold">

--- a/pages/admin/request/create-new.tsx
+++ b/pages/admin/request/create-new.tsx
@@ -329,7 +329,9 @@ export default function CreateNew() {
                 {` (User ID: `}
                 <Box as="span" color="primary">
                   <Link href={`/admin/permit-holder/${applicantId}`}>
-                    <a>{applicantId}</a>
+                    <a target="_blank" rel="noopener noreferrer">
+                      {applicantId}
+                    </a>
                   </Link>
                 </Box>
                 {`)`}

--- a/pages/admin/request/create-renewal.tsx
+++ b/pages/admin/request/create-renewal.tsx
@@ -242,7 +242,9 @@ export default function CreateRenewal() {
                 {` (User ID: `}
                 <Box as="span" color="primary">
                   <Link href={`/admin/permit-holder/${applicantId}`}>
-                    <a>{applicantId}</a>
+                    <a target="_blank" rel="noopener noreferrer">
+                      {applicantId}
+                    </a>
                   </Link>
                 </Box>
                 {`)`}

--- a/pages/admin/request/create-replacement.tsx
+++ b/pages/admin/request/create-replacement.tsx
@@ -183,7 +183,9 @@ export default function CreateReplacement() {
                 {` (User ID: `}
                 <Box as="span" color="primary">
                   <Link href={`/admin/permit-holder/${applicantId}`}>
-                    <a>{applicantId}</a>
+                    <a target="_blank" rel="noopener noreferrer">
+                      {applicantId}
+                    </a>
                   </Link>
                 </Box>
                 {`)`}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Search-permit-holder-card-fixes-8d398dcc153644bb8cd1ec9566272113)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- [x] Cannot search by user ID
- [x] Cannot search by middle name
- [x] Phone number formatting is wrong
- [x] Email spans full width, it should not


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
