### PR TITLE
[Fix] Prevent RCD email from breaking into two lines

### DIFF
--- a/components/applicant/Layout.tsx
+++ b/components/applicant/Layout.tsx
@@ -170,7 +170,7 @@ function Footer() {
               </Text>
               <Text textStyle="caption">Tel: 604-232-2404</Text>
               <a href="mailto:parkingpermit@rcdrichmond.org">
-                <Text textStyle="caption" wordBreak="break-all">
+                <Text textStyle="caption" whiteSpace="nowrap">
                   Email: parkingpermit@rcdrichmond.org
                 </Text>
               </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,13 +115,13 @@ export default function Landing() {
               by hand, or want to request a new parking permit, please download the appropriate form
               below.
             </Text>
-            <Text as="p" textStyle="body-regular" align="left" mt="24px" wordBreak="break-all">
+            <Text as="p" textStyle="body-regular" align="left" mt="24px">
               After completing the form, either email (
-              <span style={{ wordBreak: 'break-all' }}>
-                <b>
-                  <a href="mailto:rcdparkingpermit@richmond.org">parkingpermit@rcdrichmond.org</a>
-                </b>
-              </span>
+              <a href="mailto:rcdparkingpermit@richmond.org">
+                <Text as="span" fontWeight="bold" whiteSpace="nowrap">
+                  parkingpermit@rcdrichmond.org
+                </Text>
+              </a>
               ), mail or drop it off in person to RCD!
             </Text>
           </Box>
@@ -213,11 +213,11 @@ export default function Landing() {
               604-232-2404
             </Text>{' '}
             or via email at{' '}
-            <span style={{ wordBreak: 'break-all' }}>
-              <b>
-                <a href="mailto:rcdparkingpermit@richmond.org">parkingpermit@rcdrichmond.org</a>
-              </b>
-            </span>
+            <a href="mailto:rcdparkingpermit@richmond.org">
+              <Text as="span" fontWeight="bold" whiteSpace="nowrap">
+                parkingpermit@rcdrichmond.org
+              </Text>
+            </a>
           </Text>
         </Box>
       </GridItem>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Prevent-RCD-email-from-line-breaking-cf6b2946c5fb42018173bd19d78a3e7d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
