### PR TITLE
[Feature] Build privacy policy and terms and conditions pages

### DIFF
--- a/components/applicant/Layout.tsx
+++ b/components/applicant/Layout.tsx
@@ -191,16 +191,20 @@ function Footer() {
       >
         <Text textStyle="body-regular">© 2021 Richmond Centre for Disability</Text>
         <Box>
-          <a href="#">
-            <Text display="inline-block" textStyle="body-regular" marginRight={7} color="primary">
-              Privacy Policy
-            </Text>
-          </a>
-          <a href="#">
-            <Text display="inline-block" textStyle="body-regular" color="primary">
-              Terms & Conditions
-            </Text>
-          </a>
+          <Link href="/privacy-policy">
+            <a>
+              <Text display="inline-block" textStyle="body-regular" marginRight={7} color="primary">
+                Privacy Policy
+              </Text>
+            </a>
+          </Link>
+          <Link href="/terms-and-conditions">
+            <a>
+              <Text display="inline-block" textStyle="body-regular" color="primary">
+                Terms & Conditions
+              </Text>
+            </a>
+          </Link>
         </Box>
       </Flex>
     </Center>

--- a/components/applicant/renewals/TOSModal.tsx
+++ b/components/applicant/renewals/TOSModal.tsx
@@ -15,6 +15,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'; // Chakra UI
 import RenewalFlow from '@containers/RenewalFlow'; // Request container
+import { Children, ReactNode } from 'react';
+import { Link as ChakraLink } from '@chakra-ui/react';
 
 export default function TOSModal() {
   // TOS acceptance timestamp
@@ -67,9 +69,14 @@ export default function TOSModal() {
             services to those who have accepted its terms.`}
           </TOSSection>
           <TOSSection sectionTitle={`Privacy policy`}>
-            {`Before you continue using RCD Parking Permit Self-service portal, we advise you to read
-            our privacy policy [link to privacy policy] regarding our user data collection. It will
-            help you better understand our practices.`}
+            <Text as="p" textStyle="body-regular" textAlign="left">
+              Before you continue using RCD Parking Permit Self-service portal, we advise you to
+              read our{' '}
+              <Link href="/privacy-policy">
+                <ChakraLink color="primary">privacy policy</ChakraLink>
+              </Link>{' '}
+              regarding our user data collection. It will help you better understand our practices.
+            </Text>
           </TOSSection>
           <TOSSection sectionTitle={`User information`}>
             {`As a user of this website, you may be asked to provide private information. You are
@@ -134,7 +141,7 @@ export default function TOSModal() {
 
 type TOSSectionProps = {
   readonly sectionTitle: string;
-  readonly children: string | ReadonlyArray<string>;
+  readonly children: ReactNode;
   readonly isLast?: boolean;
 };
 
@@ -146,12 +153,16 @@ function TOSSection(props: TOSSectionProps) {
       <Text as="h6" textStyle="body-bold">
         {sectionTitle}
       </Text>
-      {typeof children === 'string' ? (
-        <Text as="p" textStyle="body-regular" marginBottom={isLast ? 0 : '27px'}>
-          {children}
-        </Text>
+      {Children.count(children) === 1 ? (
+        typeof children === 'string' ? (
+          <Text as="p" textStyle="body-regular" marginBottom={isLast ? 0 : '27px'}>
+            {children}
+          </Text>
+        ) : (
+          children
+        )
       ) : (
-        children.map((paragraph, i) => (
+        Children.map(children, (paragraph, i) => (
           <Text key={`paragraph-${i}`} as="p" textStyle="body-regular" marginBottom="27px">
             {paragraph}
           </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,7 @@ export default function Landing() {
           <VStack
             width="100%"
             alignItems={{ sm: 'center', lg: 'flex-start' }}
-            pb={{ sm: 0, lg: '80px' }}
+            pb={{ sm: 0, lg: '112px' }}
           >
             <Link href="/renew">
               <a>

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,0 +1,336 @@
+import Layout from '@components/applicant/Layout';
+import { NextPage } from 'next';
+import { GridItem, ListItem, Text, UnorderedList, VStack } from '@chakra-ui/react';
+
+const PrivacyPolicy: NextPage = () => {
+  return (
+    <Layout>
+      <GridItem colSpan={12} colStart={1} marginBottom="120px">
+        <VStack align="flex-start" spacing="24px" textAlign="left">
+          <Text as="h1" textStyle="display-large">
+            Personal Information Protection Policy
+          </Text>
+          {/* Intro section */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="p" textStyle="body-regular">
+              At Richmond Centre for Disability (RCD), we are committed to providing our members and
+              service recipients (users) with exceptional service. As providing this service
+              involves the collection, use and disclosure of some personal information about our
+              users and members, protecting their personal information is one of our highest
+              priorities.
+            </Text>
+            <Text as="p" textStyle="body-regular">
+              While we have always respected our users and members privacy and safeguarded their
+              personal information, we have strengthened our commitment to protecting personal
+              information as a result of British Columbia’s Personal Information Protection Act
+              (PIPA). PIPA, which came into effect on January 1, 2004, sets out the ground rules for
+              how B.C. businesses and not-for-profit organizations may collect, use, and disclose
+              personal information.
+            </Text>
+            <Text as="p" textStyle="body-regular">
+              We will inform our users and members of why and how we collect, use, and disclose
+              their personal information, obtain their consent where required, and only handle their
+              personal information in a manner that a reasonable person would consider appropriate
+              in the circumstances.
+            </Text>
+            <Text as="p" textStyle="body-regular">
+              This Personal Information Protection Policy, in compliance with PIPA, outlines the
+              principles and practices we will follow in protecting users’ and members’ personal
+              information. Our privacy commitment includes ensuring the accuracy, confidentiality,
+              and security of our users’ and members’ personal information and allowing our users
+              and members to request access to, and correction of, their personal information.
+            </Text>
+          </VStack>
+          {/* Scope of policy */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Scope of this Policy
+            </Text>
+            <Text as="p" textStyle="body-regular">
+              This policy also applies to any service providers collecting, using, or disclosing
+              personal information on behalf of RCD.
+            </Text>
+          </VStack>
+          {/* Definitions */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Definitions
+            </Text>
+            <Text as="p" textStyle="body-regular">
+              <b>
+                <i>Personal Information</i>
+              </b>{' '}
+              – means information about an identifiable individual{' '}
+              <i>
+                including name, date of birth, home address, phone number, email address, gender,
+                medical information, and credit history
+              </i>
+              .
+            </Text>
+          </VStack>
+          {/* Policy 1 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 1 – Collecting Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                1.1 Unless the purposes for collecting personal information are obvious and the user
+                and member voluntarily provides his or her personal information for those purposes,
+                we will communicate the purposes for which personal information is being collected,
+                either orally or in writing, before or at the time of collection.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                1.2 We will only collect user and member information that is necessary to fulfill
+                the following purposes:
+                <UnorderedList>
+                  <ListItem>To verify identity;</ListItem>
+                  <ListItem>To deliver requested products and services;</ListItem>
+                  <ListItem>To enrol the individual in a program;</ListItem>
+                  <ListItem>To send out association membership information;</ListItem>
+                  <ListItem>To contact for fundraising;</ListItem>
+                  <ListItem>To ensure a high standard of service;</ListItem>
+                  <ListItem>To meet regulatory requirements;</ListItem>
+                  <ListItem>To collect and process payments.</ListItem>
+                </UnorderedList>
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 2 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 2 – Consent
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                2.1 We will obtain user and member consent to collect, use or disclose personal
+                information (except where, as noted below, we are authorized to do so without
+                consent).
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                2.2 Consent can be provided orally, in writing, electronically, through an
+                authorized representative or it can be implied where the purpose for collecting
+                using or disclosing the personal information would be considered obvious and the
+                user and member voluntarily provides personal information for that purpose.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                2.3 Consent may also be implied where a user and member is given notice and a
+                reasonable opportunity to opt-out of his or her personal information being used for
+                mail-outs, the marketing of new services or products, fundraising and the user and
+                member does not opt-out.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                2.4 Subject to certain exceptions (e.g., the personal information is necessary to
+                provide the service or product, or the withdrawal of consent would frustrate the
+                performance of a legal obligation), users and members can withhold or withdraw their
+                consent for RCD to use their personal information in certain ways. A user’s,
+                customer’s, member’s decision to withhold or withdraw their consent to certain uses
+                of personal information may restrict our ability to provide a particular service or
+                product. If so, we will explain the situation to assist the user and member in
+                making the decision.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                2.5 We may collect, use or disclose personal information without the user’s,
+                customer’s, member’s knowledge or consent in the following limited circumstances:
+                <UnorderedList>
+                  <ListItem>
+                    When the collection, use or disclosure of personal information is permitted or
+                    required by law;
+                  </ListItem>
+                  <ListItem>
+                    In an emergency that threatens an individual&apos;s life, health, or personal
+                    security;
+                  </ListItem>
+                  <ListItem>
+                    When the personal information is available from a public source (e.g., a
+                    telephone directory);
+                  </ListItem>
+                  <ListItem>When we require legal advice from a lawyer;</ListItem>
+                  <ListItem>
+                    For the purposes of collecting a debt; • To protect ourselves from fraud;
+                  </ListItem>
+                  <ListItem>
+                    To investigate an anticipated breach of an agreement or a contravention of law.
+                  </ListItem>
+                </UnorderedList>
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 3 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 3 – Using and Disclosing Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                3.1 We will only use or disclose user and member personal information where
+                necessary to fulfill the purposes identified at the time of collection:
+                <UnorderedList>
+                  <ListItem>
+                    To conduct user and member surveys in order to enhance the provision of our
+                    services;
+                  </ListItem>
+                  <ListItem>
+                    To contact our users and members directly about products and services that may
+                    be of interest;
+                  </ListItem>
+                </UnorderedList>
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                3.2 We will not use or disclose user and member personal information for any
+                additional purpose unless we obtain consent to do so.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                3.3 We will not sell user and member lists or personal information to other parties.
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 4 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 4 – Retaining Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                4.1 If we use user and member personal information to make a decision that directly
+                affects the user and member, we will retain that personal information for at least
+                one year so that the user and member has a reasonable opportunity to request access
+                to it.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                4.2 Subject to policy 4.1, we will retain user and member personal information only
+                as long as necessary to fulfill the identified purposes or a legal or business
+                purpose.
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 5 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 5 – Ensuring Accuracy of Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                5.1 We will make reasonable efforts to ensure that user and member personal
+                information is accurate and complete where it may be used to make a decision about
+                the user and member or disclosed to another organization.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                5.2 Users and members may request correction to their personal information in order
+                to ensure its accuracy and completeness. A request to correct personal information
+                must be made in writing and provide sufficient detail to identify the personal
+                information and the correction being sought.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                5.3 If the personal information is demonstrated to be inaccurate or incomplete, we
+                will correct the information as required and send the corrected information to any
+                organization to which we disclosed the personal information in the previous year. If
+                the correction is not made, we will note the users’ and members’ correction request
+                in the file.
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 6 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 6 – Securing Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                6.1 We are committed to ensuring the security of user and member personal
+                information in order to protect it from unauthorized access, collection, use,
+                disclosure, copying, modification or disposal or similar risks.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                6.2 The following security measures will be followed to ensure that user and member
+                personal information is appropriately protected: the use of locked filing cabinets;
+                the use of user IDs, passwords, encryption, firewalls; restricting employee access
+                to personal information as appropriate.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                6.3 We will use appropriate security measures when destroying user’s, customer’s,
+                member’s personal information such as: shredding documents, deleting electronically
+                stored information.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                6.4 We will continually review and update our security policies and controls as
+                technology changes to ensure ongoing personal information security.
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 7 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 7 – Providing Users and members Access to Personal Information
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                7.1 Users and members have a right to access their personal information, subject to
+                limited exceptions.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                7.2 A request to access personal information must be made in writing and provide
+                sufficient detail to identify the personal information being sought.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                7.3 Upon request, we will also tell users and members how we use their personal
+                information and to whom it has been disclosed if applicable.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                7.4 We will make the requested information available within 30 business days, or
+                provide written notice of an extension where additional time is required to fulfill
+                the request.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                7.5 A minimal fee may be charged for providing access to personal information. Where
+                a fee may apply, we will inform the user and member of the cost and request further
+                direction from the user and member on whether or not we should proceed with the
+                request.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                7.6 If a request is refused in full or in part, we will notify the user and member
+                in writing, providing the reasons for refusal and the recourse available to the user
+                and member.
+              </Text>
+            </VStack>
+          </VStack>
+          {/* Policy 8 */}
+          <VStack align="flex-start" spacing="24px">
+            <Text as="h2" textStyle="body-bold">
+              Policy 8 – Questions and Complaints: RCD Executive Director
+            </Text>
+            <VStack align="flex-start" spacing="0">
+              <Text as="p" textStyle="body-regular">
+                8.1 The RCD Executive Director is responsible for ensuring RCD’s compliance with
+                this policy and the Personal Information Protection Act.
+              </Text>
+              <Text as="p" textStyle="body-regular">
+                8.2 Users and members should direct any complaints, concerns or questions regarding
+                RCD’s compliance in writing to RCD Executive Director.
+              </Text>
+              <VStack align="flex-start" spacing="0">
+                <Text as="p" textStyle="body-regular">
+                  Contact information for RCD Executive Director:
+                </Text>
+                <Text as="p" textStyle="body-regular">
+                  Ella Huang
+                </Text>
+                <Text as="p" textStyle="body-regular">
+                  Executive Director
+                </Text>
+                <Text as="p" textStyle="body-regular">
+                  Email: ella@rcdrichmond.org RCD
+                </Text>
+                <Text as="p" textStyle="body-regular">
+                  General Enquiry Email: rcd@rcdrichmond.org
+                </Text>
+              </VStack>
+            </VStack>
+          </VStack>
+        </VStack>
+      </GridItem>
+    </Layout>
+  );
+};
+
+export default PrivacyPolicy;

--- a/pages/terms-and-conditions.tsx
+++ b/pages/terms-and-conditions.tsx
@@ -1,7 +1,9 @@
 import Layout from '@components/applicant/Layout';
 import { NextPage } from 'next';
 import { GridItem, Text, VStack } from '@chakra-ui/react';
-import { FC } from 'react';
+import { Children, FC, ReactNode } from 'react';
+import Link from 'next/link';
+import { Link as ChakraLink } from '@chakra-ui/react';
 
 const TermsAndConditions: NextPage = () => {
   return (
@@ -22,9 +24,14 @@ const TermsAndConditions: NextPage = () => {
             services to those who have accepted its terms.`}
           </Section>
           <Section title={`Privacy policy`}>
-            {`Before you continue using RCD Parking Permit Self-service portal, we advise you to read
-            our privacy policy [link to privacy policy] regarding our user data collection. It will
-            help you better understand our practices.`}
+            <Text as="p" textStyle="body-regular" textAlign="left">
+              Before you continue using RCD Parking Permit Self-service portal, we advise you to
+              read our{' '}
+              <Link href="/privacy-policy">
+                <ChakraLink color="primary">privacy policy</ChakraLink>
+              </Link>{' '}
+              regarding our user data collection. It will help you better understand our practices.
+            </Text>
           </Section>
           <Section title={`User information`}>
             {`As a user of this website, you may be asked to provide private information. You are
@@ -65,7 +72,7 @@ const TermsAndConditions: NextPage = () => {
   );
 };
 
-const Section: FC<{ title: string; children: string | ReadonlyArray<string> }> = props => {
+const Section: FC<{ title: string; children: ReactNode }> = props => {
   const { title, children } = props;
 
   return (
@@ -73,13 +80,17 @@ const Section: FC<{ title: string; children: string | ReadonlyArray<string> }> =
       <Text textStyle="body-bold" textAlign="left">
         {title}
       </Text>
-      {typeof children === 'string' ? (
-        <Text as="p" textStyle="body-regular" textAlign="left">
-          {children}
-        </Text>
+      {Children.count(children) === 1 ? (
+        typeof children === 'string' ? (
+          <Text as="p" textStyle="body-regular" textAlign="left">
+            {children}
+          </Text>
+        ) : (
+          children
+        )
       ) : (
         <VStack align="flex-start" spacing="24px">
-          {children.map((paragraph, i) => (
+          {Children.map(children, (paragraph, i) => (
             <Text key={`paragraph-${i}`} as="p" textStyle="body-regular" textAlign="left">
               {paragraph}
             </Text>

--- a/pages/terms-and-conditions.tsx
+++ b/pages/terms-and-conditions.tsx
@@ -1,0 +1,93 @@
+import Layout from '@components/applicant/Layout';
+import { NextPage } from 'next';
+import { GridItem, Text, VStack } from '@chakra-ui/react';
+import { FC } from 'react';
+
+const TermsAndConditions: NextPage = () => {
+  return (
+    <Layout>
+      <GridItem colSpan={12} colStart={1}>
+        <VStack align="flex-start" spacing="24px">
+          <Text textStyle="display-large">Terms and Conditions</Text>
+          <Text as="p" textStyle="body-bold" marginBottom="12px" textAlign="left">
+            {`Please read these terms of use ("terms of use", "agreement") carefully before using The
+            Permit Renewal service website (“website”, "service") operated by the Richmond Centre
+            for Disability ("us", 'we", "our").`}
+          </Text>
+          <Section title={`Conditions of use`}>
+            {`By using this website, you certify that you have read and reviewed this Agreement and
+            that you agree to comply with its terms. If you do not want to be bound by the terms of
+            this Agreement, you are advised to leave the website accordingly. Richmond Centre for
+            Disability (RCD) only grants use and access of this website, its products, and its
+            services to those who have accepted its terms.`}
+          </Section>
+          <Section title={`Privacy policy`}>
+            {`Before you continue using RCD Parking Permit Self-service portal, we advise you to read
+            our privacy policy [link to privacy policy] regarding our user data collection. It will
+            help you better understand our practices.`}
+          </Section>
+          <Section title={`User information`}>
+            {`As a user of this website, you may be asked to provide private information. You are
+            responsible for ensuring the accuracy of this information, and you are responsible for
+            maintaining the safety and security of your identifying information. You are also
+            responsible for all activities that occur under your login.`}
+            {`If you think there are any
+            possible issues regarding the security of your private information on the website,
+            inform us immediately so we may address it accordingly. We reserve all rights to
+            terminate accounts, edit or remove content and cancel orders in their sole discretion.`}
+          </Section>
+          <Section title={`Applicable law`}>
+            {`By visiting this website, you agree that the laws of British Columbia province, without
+            regard to principles of conflict laws, will govern these terms and conditions, or any
+            dispute of any sort that might come between Richmond Centre for Disability and you, or
+            its business partners and associates.`}
+          </Section>
+          <Section title={`Disputes`}>
+            {`Any dispute related in any way to your visit to this website from us shall be arbitrated
+            by British Columbia province court and you consent to exclusive jurisdiction and venue
+            of such courts.`}
+          </Section>
+          <Section title={`Indemnification`}>
+            {`You agree to indemnify RCD and its affiliates and hold RCD harmless against legal claims
+            and demands that may arise from your use or misuse of our services. We reserve the right
+            to select our own legal counsel.`}
+          </Section>
+          <Section title={`Limitation on liability`}>
+            {`RCD is not liable for any damages that may occur to you as a result of your misuse of
+            our website. RCD reserves the right to edit, modify, and change this Agreement any time.
+            We shall let our users know of these changes through electronic mail. This Agreement is
+            an understanding between RCD and the user, and this supersedes and replaces all prior
+            agreements regarding the use of this website.`}
+          </Section>
+        </VStack>
+      </GridItem>
+    </Layout>
+  );
+};
+
+const Section: FC<{ title: string; children: string | ReadonlyArray<string> }> = props => {
+  const { title, children } = props;
+
+  return (
+    <VStack align="flex-start" spacing="0">
+      <Text textStyle="body-bold" textAlign="left">
+        {title}
+      </Text>
+      {typeof children === 'string' ? (
+        <Text as="p" textStyle="body-regular" textAlign="left">
+          {children}
+        </Text>
+      ) : (
+        <VStack align="flex-start" spacing="24px">
+          {children.map((paragraph, i) => (
+            <Text key={`paragraph-${i}`} as="p" textStyle="body-regular" textAlign="left">
+              {paragraph}
+            </Text>
+          ))}
+        </VStack>
+      )}
+    </VStack>
+  );
+};
+
+export default TermsAndConditions;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Create-privacy-policy-and-terms-and-conditions-pages-a039808a23d74699af69bbceb759ca6c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add privacy policy and terms and conditions pages
* Fix spacing issue on landing page


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
