### PR TITLE
[Fix] Disable GraphQL playground in production

### DIFF
--- a/lib/graphql/apollo.ts
+++ b/lib/graphql/apollo.ts
@@ -15,11 +15,15 @@ const schema = applyMiddleware(
 
 export const apolloServer = new ApolloServer({
   schema,
-  playground: {
-    settings: {
-      'schema.polling.enable': false, // Disable infinite schema introspection
-      'request.credentials': 'include', // Include auth token in requests
-    },
-  },
+  playground:
+    process.env.NODE_ENV === 'development'
+      ? {
+          settings: {
+            'schema.polling.enable': false, // Disable infinite schema introspection
+            'request.credentials': 'include', // Include auth token in requests
+          },
+        }
+      : false,
+  introspection: process.env.NODE_ENV === 'development',
   context,
 });

--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,18 @@ const { i18n } = require('./next-i18next.config'); // Internationalization
 
 module.exports = {
   i18n,
+  async redirects() {
+    const redirects = [];
+
+    if (process.env.NODE_ENV !== 'development') {
+      // Disable GraphQL playground in production
+      redirects.push({
+        source: '/api/graphql',
+        destination: '/',
+        permanent: true,
+      });
+    }
+
+    return redirects;
+  },
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Disable-access-to-GQL-playground-on-prod-217d3847229c46b5bab34538834f5819)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
