### PR TITLE
[Fix] Get most recent permit by latest expiry date

### DIFF
--- a/lib/applicants/utils.ts
+++ b/lib/applicants/utils.ts
@@ -34,7 +34,7 @@ export const getMostRecentPermit = async (applicantId: number): Promise<Permit |
       where: { id: applicantId },
     })
     .permits({
-      orderBy: { createdAt: SortOrder.DESC },
+      orderBy: { expiryDate: SortOrder.DESC },
       take: 1,
     });
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Change-most-recent-permit-logic-to-use-expiry-date-a54811dbba814fa7947956132fc36201)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
