### PR TITLE
[Improvement] Split address fields in permit holders report

### DIFF
--- a/tools/admin/reports.ts
+++ b/tools/admin/reports.ts
@@ -65,7 +65,7 @@ export const APPLICATIONS_COLUMNS: Array<{
 export const PERMIT_HOLDERS_COLUMNS: Array<{
   name: string;
   value: PermitHoldersReportColumn;
-  reportColumnId: string;
+  reportColumnId: string | Array<[string, string]>;
 }> = [
   {
     name: 'User ID',
@@ -85,7 +85,13 @@ export const PERMIT_HOLDERS_COLUMNS: Array<{
   {
     name: 'Home Address',
     value: 'HOME_ADDRESS',
-    reportColumnId: 'homeAddress',
+    reportColumnId: [
+      ['Address Line 1', 'addressLine1'],
+      ['Address Line 2', 'addressLine2'],
+      ['City', 'city'],
+      ['Province', 'province'],
+      ['Postal Code', 'postalCode'],
+    ],
   },
   {
     name: 'Email',
@@ -110,7 +116,13 @@ export const PERMIT_HOLDERS_COLUMNS: Array<{
   {
     name: 'Guardian/POA Address',
     value: 'GUARDIAN_POA_ADDRESS',
-    reportColumnId: 'guardianPOAAddress',
+    reportColumnId: [
+      ['Guardian/POA Address Line 1', 'guardianAddressLine1'],
+      ['Guardian/POA Address Line 2', 'guardianAddressLine2'],
+      ['Guardian/POA City', 'guardianCity'],
+      ['Guardian/POA Province', 'guardianProvince'],
+      ['Guardian/POA Postal Code', 'guardianPostalCode'],
+    ],
   },
   {
     name: 'Recent APP Number',


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Split-address-into-multiple-fields-in-permit-holders-report-b8f5b1b7db694148a80485307cd2e900)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Split address and guardian address fields in permit holders report


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
