### PR TITLE
[Fix] Restrict permit expiry filter to only active permits

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -162,6 +162,7 @@ export const applicants: Resolver<
               lte: expiryDateRangeTo?.toISOString(),
             },
           },
+          { active: true },
         ],
       },
     };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Audit-production-permits-for-invalid-entries-9bbacafd2fc840b9a1af82b46952cd00)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
