### PR TITLE
[Fix] Show applicants even if they do not have an active permit

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -147,25 +147,27 @@ export const applicants: Resolver<
 
     // Permit status and expiry date range filters both look at the permit expiryDate.
     // For this reason we need to filter on expiryDate twice to take both filters in account.
-    const permitFilter = {
-      some: {
-        AND: [
-          {
-            expiryDate: {
-              gte: expiryDateLowerBound?.toISOString(),
-              lte: expiryDateUpperBound?.toISOString(),
+    const permitFilter =
+      expiryDateLowerBound || expiryDateUpperBound || expiryDateRangeFrom || expiryDateRangeTo
+        ? {
+            some: {
+              AND: [
+                {
+                  expiryDate: {
+                    gte: expiryDateLowerBound?.toISOString(),
+                    lte: expiryDateUpperBound?.toISOString(),
+                  },
+                },
+                {
+                  expiryDate: {
+                    gte: expiryDateRangeFrom?.toISOString(),
+                    lte: expiryDateRangeTo?.toISOString(),
+                  },
+                },
+              ],
             },
-          },
-          {
-            expiryDate: {
-              gte: expiryDateRangeFrom?.toISOString(),
-              lte: expiryDateRangeTo?.toISOString(),
-            },
-          },
-          { active: true },
-        ],
-      },
-    };
+          }
+        : undefined;
 
     // Update default filter since there were filter arguments
     where = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Show-applicants-even-if-they-do-not-have-an-active-permit-feb7ecac86bb4e6887e9502f2b4550b1)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Fixes a bug where applicants that didn't have active permits would not be shown in the permit holders table


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
