### PR TITLE
[Fix] Fix permit holders not rendering if no recent permit

### DIFF
--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -221,7 +221,12 @@ const PermitHolders: NextPage = () => {
         Header: 'Recent APP',
         accessor: 'mostRecentPermit',
         disableSortBy: true,
-        Cell: ({ value: { expiryDate, rcdPermitId } }) => {
+        Cell: ({ value }) => {
+          if (!value) {
+            return 'N/A';
+          }
+
+          const { expiryDate, rcdPermitId } = value;
           const permitStatus = getPermitExpiryStatus(new Date(expiryDate));
           return (
             <Flex>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-permit-holders-page-breaking-if-permit-holders-do-not-have-most-recent-permit-14c9fc36c17f46de866b3fe5a60a015c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
