### PR TITLE
[Fix] Fix inconsistent applicant flow copy

### DIFF
--- a/components/applicant/renewals/RenewalForm/ContactInformationSection.tsx
+++ b/components/applicant/renewals/RenewalForm/ContactInformationSection.tsx
@@ -66,7 +66,7 @@ const ContactInformationSection: FC = () => {
             {/* Check whether applicant has updated contact info */}
             <RadioGroupField
               name="updatedContactInfo"
-              label="Have you changed your contact information since you received or renewed your last parking pass?"
+              label="Have you changed your contact information since you received or renewed your last parking permit?"
               required
               value={
                 values.updatedContactInfo === null ? undefined : Number(values.updatedContactInfo)

--- a/components/applicant/renewals/RenewalForm/PersonalAddressSection.tsx
+++ b/components/applicant/renewals/RenewalForm/PersonalAddressSection.tsx
@@ -71,7 +71,7 @@ const PersonalAddressSection: FC = () => {
             {/* Check whether applicant has updated address */}
             <RadioGroupField
               name="updatedAddress"
-              label="Has your address changed since you received your last parking pass?"
+              label="Has your address changed since you received your last parking permit?"
               required
               value={values.updatedAddress === null ? undefined : Number(values.updatedAddress)}
             >

--- a/components/applicant/renewals/RenewalForm/index.tsx
+++ b/components/applicant/renewals/RenewalForm/index.tsx
@@ -205,7 +205,7 @@ const RenewalForm: FC = () => {
                 isChecked={certified}
                 onChange={event => setCertified(event.target.checked)}
               >
-                {`I certify that I am the holder of the accessible parking pass for which this
+                {`I certify that I am the holder of the accessible parking permit for which this
   application for renewal is submitted, and that I have personally provided all of the
   information required in this application.`}
               </Checkbox>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Change-Parking-Pass-in-Q-1-2-to-Parking-Permit-db368e3c470443a6b183ece92ca420af)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Fix copy in applicant flow so that we use "parking permit" everywhere instead of "parking pass"


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
