### PR TITLE
[Fix] Show validation error messages on form mount

### DIFF
--- a/components/admin/permit-holders/permit-holder-information/EditModal.tsx
+++ b/components/admin/permit-holders/permit-holder-information/EditModal.tsx
@@ -76,6 +76,7 @@ export default function EditUserInformationModal({
           }}
           validationSchema={permitHolderInformationSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form noValidate>

--- a/components/admin/requests/additional-questions/EditModal.tsx
+++ b/components/admin/requests/additional-questions/EditModal.tsx
@@ -61,6 +61,7 @@ export default function EditAdditionalInformationModal({
           initialValues={{ additionalInformation: additionalInformation }}
           validationSchema={editAdditionalQuestionsSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form style={{ width: '100%' }} noValidate>

--- a/components/admin/requests/doctor-information/EditModal.tsx
+++ b/components/admin/requests/doctor-information/EditModal.tsx
@@ -80,6 +80,7 @@ export default function EditDoctorInformationModal({
           initialValues={{ doctorInformation }}
           validationSchema={editPhysicianInformationSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ isValid }) => (
             <Form style={{ width: '100%' }} noValidate>

--- a/components/admin/requests/guardian-information/EditModal.tsx
+++ b/components/admin/requests/guardian-information/EditModal.tsx
@@ -136,6 +136,7 @@ const EditGuardianInformationModal: FC<Props> = ({ children, guardianInformation
           }}
           validationSchema={editGuardianInformationSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form style={{ width: '100%' }} noValidate>

--- a/components/admin/requests/payment-information/EditModal.tsx
+++ b/components/admin/requests/payment-information/EditModal.tsx
@@ -66,6 +66,7 @@ export default function EditPaymentDetailsModal({
           initialValues={{ paymentInformation }}
           validationSchema={editPaymentInformationSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form style={{ width: '100%' }} noValidate>

--- a/components/admin/requests/permit-holder-information/EditModal.tsx
+++ b/components/admin/requests/permit-holder-information/EditModal.tsx
@@ -79,6 +79,7 @@ export default function EditPermitHolderInformationModal({
           initialValues={{ permitHolder: { ...permitHolderInformation } }}
           validationSchema={editRequestPermitHolderInformationSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form style={{ width: '100%' }} noValidate>

--- a/components/admin/requests/physician-assessment/EditModal.tsx
+++ b/components/admin/requests/physician-assessment/EditModal.tsx
@@ -63,6 +63,7 @@ export default function EditPhysicianAssessmentModal({
           }}
           validationSchema={editPhysicianAssessmentSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form noValidate>

--- a/components/admin/requests/reason-for-replacement/EditModal.tsx
+++ b/components/admin/requests/reason-for-replacement/EditModal.tsx
@@ -64,6 +64,7 @@ export default function EditReasonForReplacementModal({
           }}
           validationSchema={editReasonForReplacementFormSchema}
           onSubmit={handleSubmit}
+          validateOnMount
         >
           {({ values, isValid }) => (
             <Form noValidate>

--- a/components/applicant/renewals/IdentityVerification.tsx
+++ b/components/applicant/renewals/IdentityVerification.tsx
@@ -124,6 +124,7 @@ const IdentityVerification: FC = () => {
             }}
             validationSchema={verifyIdentitySchema}
             onSubmit={handleSubmit}
+            validateOnMount
           >
             {({ values, isValid }) => (
               <Form style={{ width: '100%' }} noValidate>

--- a/components/applicant/renewals/RenewalForm/AdditionalInformationSection.tsx
+++ b/components/applicant/renewals/RenewalForm/AdditionalInformationSection.tsx
@@ -48,6 +48,7 @@ const AdditionalInformationSection: FC = () => {
       initialValues={{ ...additionalInformation }}
       validationSchema={additionalQuestionsSchema}
       onSubmit={handleSubmit}
+      validateOnMount
     >
       {({ values, isValid }) => (
         <Form noValidate>

--- a/components/applicant/renewals/RenewalForm/ContactInformationSection.tsx
+++ b/components/applicant/renewals/RenewalForm/ContactInformationSection.tsx
@@ -59,6 +59,7 @@ const ContactInformationSection: FC = () => {
       }}
       validationSchema={applicantFacingRenewalContactSchema}
       onSubmit={handleSubmit}
+      validateOnMount
     >
       {({ values, isValid }) => (
         <Form noValidate>

--- a/components/applicant/renewals/RenewalForm/DoctorInformationSection.tsx
+++ b/components/applicant/renewals/RenewalForm/DoctorInformationSection.tsx
@@ -87,6 +87,7 @@ const DoctorInformationSection: FC = () => {
       }}
       validationSchema={applicantFacingRenewalDoctorSchema}
       onSubmit={handleSubmit}
+      validateOnMount
     >
       {({ values, isValid }) => (
         <Form noValidate>

--- a/components/applicant/renewals/RenewalForm/DonationSection.tsx
+++ b/components/applicant/renewals/RenewalForm/DonationSection.tsx
@@ -35,6 +35,7 @@ const DonationSection: FC = () => {
       }}
       validationSchema={applicantFacingRenewalDonationSchema}
       onSubmit={handleSubmit}
+      validateOnMount
     >
       {({ values, isValid }) => (
         <Form noValidate>

--- a/components/applicant/renewals/RenewalForm/PersonalAddressSection.tsx
+++ b/components/applicant/renewals/RenewalForm/PersonalAddressSection.tsx
@@ -64,6 +64,7 @@ const PersonalAddressSection: FC = () => {
       }}
       validationSchema={applicantFacingRenewalPersonalAddressSchema}
       onSubmit={handleSubmit}
+      validateOnMount
     >
       {({ values, isValid }) => (
         <Form noValidate>

--- a/components/form/CheckboxField.tsx
+++ b/components/form/CheckboxField.tsx
@@ -13,13 +13,13 @@ const CheckboxField: FC<Props> = props => {
   const isChecked = field.value;
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <Checkbox {...field} isChecked={isChecked} {...checkboxProps}>
         {children}
       </Checkbox>
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
     </FormControl>

--- a/components/form/CheckboxGroupField.tsx
+++ b/components/form/CheckboxGroupField.tsx
@@ -24,14 +24,14 @@ const CheckboxGroupField: FC<Props> = props => {
   };
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       <CheckboxGroup {...field} onChange={handleChange} {...checkboxGroupProps}>
         {children}
       </CheckboxGroup>
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
     </FormControl>

--- a/components/form/DateField.tsx
+++ b/components/form/DateField.tsx
@@ -29,12 +29,12 @@ const DateField: FC<Props> = props => {
   };
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       <Input type="date" {...field} onChange={handleChange} {...inputProps} />
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
       {children}

--- a/components/form/NumberField.tsx
+++ b/components/form/NumberField.tsx
@@ -21,14 +21,14 @@ const NumberField: FC<Props> = props => {
   const [field, meta] = useField(name);
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       <NumberInput {...numberInputProps}>
         <NumberInputField {...field} />
       </NumberInput>
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
       {children}

--- a/components/form/RadioGroupField.tsx
+++ b/components/form/RadioGroupField.tsx
@@ -24,14 +24,14 @@ const RadioGroupField: FC<Props> = props => {
   };
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <RadioGroup id={name} {...field} onChange={handleChange} {...radioGroupProps}>
         {children}
       </RadioGroup>
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
     </FormControl>

--- a/components/form/SelectField.tsx
+++ b/components/form/SelectField.tsx
@@ -20,12 +20,12 @@ const SelectField: FC<Props> = props => {
   const [field, meta] = useField(name);
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       <Select {...field} {...selectProps} />
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
     </FormControl>

--- a/components/form/TextAreaField.tsx
+++ b/components/form/TextAreaField.tsx
@@ -20,12 +20,12 @@ const TextArea: FC<Props> = props => {
   const [field, meta] = useField(name);
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <Textarea {...textAreaProps} {...field} />
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
     </FormControl>

--- a/components/form/TextField.tsx
+++ b/components/form/TextField.tsx
@@ -23,7 +23,7 @@ const TextField: FC<Props> = props => {
   const [field, meta] = useField(name);
 
   return (
-    <FormControl isInvalid={!!meta.error && meta.touched} isRequired={required}>
+    <FormControl isInvalid={!!meta.error} isRequired={required}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       {monetaryInput ? (
         <InputGroup>
@@ -37,7 +37,7 @@ const TextField: FC<Props> = props => {
       )}
       <FormErrorMessage>
         <Text as="span" textStyle="body-regular">
-          {meta.touched && meta.error ? meta.error : null}
+          {meta.error || null}
         </Text>
       </FormErrorMessage>
       {children}

--- a/lib/physicians/validation.ts
+++ b/lib/physicians/validation.ts
@@ -82,7 +82,7 @@ export const requestPhysicianInformationSchema = object({
   firstName: string().required('Please enter a first name'),
   lastName: string().required('Please enter a last name'),
   mspNumber: string()
-    .matches(/^\d+$/, 'Must only contain numbers')
+    .matches(/^X?\d+$/, 'Must only contain numbers')
     .required('Please enter the MSP number'),
   phone: string()
     .required('Please enter a phone number')

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -83,6 +83,7 @@ export default function Login() {
                   initialValues={{ email: '' }}
                   validationSchema={loginSchema}
                   onSubmit={handleSubmit}
+                  validateOnMount
                 >
                   <Form style={{ width: '100%' }}>
                     <TextField name="email" label="Email" height="51px" />

--- a/pages/admin/request/create-new.tsx
+++ b/pages/admin/request/create-new.tsx
@@ -447,6 +447,7 @@ export default function CreateNew() {
             }}
             validationSchema={createNewRequestFormSchema}
             onSubmit={handleSubmit}
+            validateOnMount
           >
             {({ values, isValid }) => (
               <Form noValidate>

--- a/pages/admin/request/create-renewal.tsx
+++ b/pages/admin/request/create-renewal.tsx
@@ -283,6 +283,7 @@ export default function CreateRenewal() {
             }}
             validationSchema={renewalRequestFormSchema}
             onSubmit={handleSubmit}
+            validateOnMount
           >
             {({ values, isValid }) => (
               <Form noValidate>

--- a/pages/admin/request/create-replacement.tsx
+++ b/pages/admin/request/create-replacement.tsx
@@ -224,6 +224,7 @@ export default function CreateReplacement() {
             }}
             validationSchema={replacementRequestFormSchema}
             onSubmit={handleSubmit}
+            validateOnMount
           >
             {({ values, isValid }) => (
               <Form noValidate>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Show-edit-modal-error-messages-on-load-2978ae59f1c04fb2a714dda4bb4c41f5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Run validation on form mount, showing validation error messages without requiring `meta.touched` to be true
* Modify physician MSP number (internal only) to support placeholder MSP number (X#####)


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
