### PR TITLE
[Improvement] Adjust spacing of address in invoice

### DIFF
--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -214,8 +214,9 @@ const pdfDefinition = (input: {
           `${address.city} ${address.province} ${formatPostalCode(address.postalCode)}`,
         ],
         alignment: 'left',
-        margin: [40, 170, 0, 0],
+        margin: [40, 182, 0, 0],
         fontSize: 12,
+        lineHeight: 1.5,
       },
     ],
     styles: {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Invoice-generation-mailing-address-spacing-20e6cb51b3244a18bbdf1a706cf9168d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Increase top space for mailing address, increase line height


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
