### PR TITLE
[Fix] Fix APP history permit type badge

### DIFF
--- a/tools/admin/permit-holders/app-history.ts
+++ b/tools/admin/permit-holders/app-history.ts
@@ -1,30 +1,19 @@
-import {
-  Application,
-  ApplicationProcessing,
-  Invoice,
-  NewApplication,
-  Permit,
-  PermitType,
-} from '@lib/graphql/types';
+import { Application, ApplicationProcessing, Invoice, Permit } from '@lib/graphql/types';
 
 /** APP history entry record (API response) */
 export type AppHistoryRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
-  application: Pick<Application, 'id'> & {
+  application: Pick<Application, 'id' | 'permitType'> & {
     processing: Pick<ApplicationProcessing, 'documentsUrl' | 'documentsS3ObjectKey'> & {
       invoice: Pick<Invoice, 's3ObjectUrl' | 's3ObjectKey'>;
     };
-  } & (
-      | ({ type: 'NEW' } & Pick<NewApplication, 'permitType'>)
-      | { type: 'RENEWAL' | 'REPLACEMENT'; permitType: undefined }
-    );
+  };
 };
 
 /** APP history entry row in APP history card (FE) */
 export type PermitRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
-  application: Pick<Application, 'id' | 'type'> & {
+  application: Pick<Application, 'id' | 'type' | 'permitType'> & {
     processing: Pick<ApplicationProcessing, 'documentsUrl' | 'documentsS3ObjectKey'> & {
       invoice: Pick<Invoice, 's3ObjectUrl' | 's3ObjectKey'>;
     };
-    permitType: PermitType | undefined;
   };
 };

--- a/tools/admin/permit-holders/app-history.ts
+++ b/tools/admin/permit-holders/app-history.ts
@@ -2,7 +2,7 @@ import { Application, ApplicationProcessing, Invoice, Permit } from '@lib/graphq
 
 /** APP history entry record (API response) */
 export type AppHistoryRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
-  application: Pick<Application, 'id' | 'permitType'> & {
+  application: Pick<Application, 'id' | 'type' | 'permitType'> & {
     processing: Pick<ApplicationProcessing, 'documentsUrl' | 'documentsS3ObjectKey'> & {
       invoice: Pick<Invoice, 's3ObjectUrl' | 's3ObjectKey'>;
     };

--- a/tools/admin/permit-holders/view-permit-holder.ts
+++ b/tools/admin/permit-holders/view-permit-holder.ts
@@ -91,6 +91,7 @@ export const GET_APPLICANT_QUERY = gql`
         application {
           id
           type
+          permitType
           processing {
             documentsUrl
             documentsS3ObjectKey
@@ -98,9 +99,6 @@ export const GET_APPLICANT_QUERY = gql`
               s3ObjectUrl
               s3ObjectKey
             }
-          }
-          ... on NewApplication {
-            permitType
           }
         }
       }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Temporary-Permit-Holder-Past-APPs-show-Permanent-instead-of-Temporary-0a3c77770b764a2593295d4ec8feb3e7)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Include `permitType` in query for APP history


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
