### PR TITLE
[Fix] Fix expiry date for in-progress replacement applications

### DIFF
--- a/components/admin/requests/Header.tsx
+++ b/components/admin/requests/Header.tsx
@@ -55,6 +55,8 @@ export default function RequestHeader({
     expiryDateText = `Expiry date: ${formatDateYYYYMMDD(permitExpiry)}`;
   } else if (permitType === 'TEMPORARY' && !!temporaryPermitExpiry) {
     expiryDateText = `This permit will expire: ${formatDateYYYYMMDD(temporaryPermitExpiry)}`;
+  } else if (applicationType === 'REPLACEMENT' && !!permitExpiry) {
+    expiryDateText = `This permit will expire: ${formatDateYYYYMMDD(permitExpiry)}`;
   } else if (permitType === 'PERMANENT') {
     expiryDateText = `This permit will expire: ${formatDateYYYYMMDD(
       getPermanentPermitExpiryDate()

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -63,6 +63,11 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
     permit,
   } = data.application;
 
+  // Get expiry date to display
+  const mostRecentPermitExpiryDate = data.application.applicant?.mostRecentPermit?.expiryDate;
+  const permitExpiry =
+    type === 'REPLACEMENT' ? mostRecentPermitExpiryDate : permit ? permit.expiryDate : null;
+
   // Whether all application processing steps are completed
   const allStepsCompleted = !!(
     appNumber !== null &&
@@ -88,7 +93,7 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
           paidThroughShopify={paidThroughShopify}
           shopifyOrderID={shopifyConfirmationNumber || undefined}
           shopifyOrderNumber={shopifyOrderNumber || undefined}
-          permitExpiry={permit && permit.expiryDate}
+          permitExpiry={permitExpiry}
           temporaryPermitExpiry={temporaryPermitExpiry || null}
           reasonForRejection={rejectedReason || undefined}
         />

--- a/tools/admin/requests/view-request.ts
+++ b/tools/admin/requests/view-request.ts
@@ -40,6 +40,9 @@ export const GET_APPLICATION_QUERY = gql`
       }
       applicant {
         id
+        mostRecentPermit {
+          expiryDate
+        }
       }
       permit {
         expiryDate
@@ -77,7 +80,9 @@ export type GetApplicationResponse = {
     > & {
       invoice: Pick<Invoice, 'invoiceNumber' | 's3ObjectKey' | 's3ObjectUrl'>;
     };
-    applicant: Pick<Applicant, 'id'>;
+    applicant: Pick<Applicant, 'id'> & {
+      mostRecentPermit: Pick<Permit, 'expiryDate'> | null;
+    };
     temporaryPermitExpiry?: Date;
     permit: Pick<Permit, 'expiryDate'> | null;
   };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Fix-Replacement-expiry-date-display-99e6d065cf454154913c7a479a9c5a81)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* For in-progress replacement applications (not associated with a permit), use the applicant's most recent permit expiry date as the displayed expiry date of the replacement application


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
