### PR TITLE
[Fix] Fix time zone for requests and reports

### DIFF
--- a/components/admin/requests/reason-for-replacement/Card.tsx
+++ b/components/admin/requests/reason-for-replacement/Card.tsx
@@ -3,7 +3,7 @@ import { Box, Text, SimpleGrid, Button } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/LayoutCard'; // Custom Card Component
 import EditReasonForReplacementModal from '@components/admin/requests/reason-for-replacement/EditModal'; // Edit modal
 import { reasonForReplacementFormSchema } from '@lib/applications/validation';
-import { formatDateYYYYMMDD } from '@lib/utils/date';
+import { formatDateYYYYMMDDLocal } from '@lib/utils/date';
 import {
   GetReasonForReplacementRequest,
   GetReasonForReplacementResponse,
@@ -97,7 +97,7 @@ export default function ReasonForReplacementCard(props: ReplacementProps) {
         <InfoSection title={`Cause`}>{titlecase(reason)}</InfoSection>
         {lostTimestamp && (
           <InfoSection title={`Event Timestamp`}>
-            {formatDateYYYYMMDD(new Date(lostTimestamp), true)}
+            {formatDateYYYYMMDDLocal(new Date(lostTimestamp), true)}
           </InfoSection>
         )}
         {lostLocation && <InfoSection title={`Location Lost`}>{lostLocation}</InfoSection>}

--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -11,7 +11,11 @@ import {
 } from '@lib/graphql/types';
 import { SortOrder } from '@tools/types';
 import { formatFullName, formatPhoneNumber, formatPostalCode } from '@lib/utils/format'; // Formatting utils
-import { formatDateTimeYYYYMMDDHHMMSS, formatDateYYYYMMDD } from '@lib/utils/date'; // Formatting utils
+import {
+  formatDateTimeYYYYMMDDHHMMSS,
+  formatDateYYYYMMDD,
+  formatDateYYYYMMDDLocal,
+} from '@lib/utils/date'; // Formatting utils
 import { APPLICATIONS_COLUMNS, PERMIT_HOLDERS_COLUMNS } from '@tools/admin/reports';
 import { Prisma } from '@prisma/client';
 import { getSignedUrlForS3, serverUploadToS3 } from '@lib/utils/s3-utils';
@@ -264,7 +268,7 @@ export const generateApplicationsReport: Resolver<
         ...application,
         id: applicant?.id,
         dateOfBirth: dateOfBirth && formatDateYYYYMMDD(dateOfBirth),
-        applicationDate: createdAt ? formatDateYYYYMMDD(createdAt, true) : null,
+        applicationDate: createdAt ? formatDateYYYYMMDDLocal(createdAt, true) : null,
         applicantName: formatFullName(firstName, middleName, lastName),
         processingFee: `$${processingFee}`,
         donationAmount: `$${donationAmount}`,

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -19,6 +19,17 @@ export const formatDate = (date: Date, dateInput = false): string => {
  */
 export const formatDateYYYYMMDD = (d: Date, withTime = false): string => {
   const formatString = withTime ? 'YYYY-MM-DD, hh:mm a' : 'YYYY-MM-DD';
+  return moment.utc(d).format(formatString);
+};
+
+/**
+ * Format date to be in YYYY-MM-DD format and in local time zone
+ * @param {Date} date date to be formatted
+ * @param {boolean} withTime whether to include time in formatted date
+ * @returns {string} formatted date
+ */
+export const formatDateYYYYMMDDLocal = (d: Date, withTime = false): string => {
+  const formatString = withTime ? 'YYYY-MM-DD, hh:mm a' : 'YYYY-MM-DD';
   return moment(d).format(formatString);
 };
 

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -19,7 +19,7 @@ export const formatDate = (date: Date, dateInput = false): string => {
  */
 export const formatDateYYYYMMDD = (d: Date, withTime = false): string => {
   const formatString = withTime ? 'YYYY-MM-DD, hh:mm a' : 'YYYY-MM-DD';
-  return moment.utc(d).format(formatString);
+  return moment(d).format(formatString);
 };
 
 /**

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -42,7 +42,7 @@ import { ApplicationStatus, ApplicationType, PermitType } from '@lib/graphql/typ
 import useDebounce from '@tools/hooks/useDebounce'; // Debounce hook
 import { Column } from 'react-table';
 import { formatFullName } from '@lib/utils/format'; // String formatter util
-import { formatDateYYYYMMDD } from '@lib/utils/date'; // Date Formatter Util
+import { formatDateYYYYMMDDLocal } from '@lib/utils/date'; // Date Formatter Util
 import GenerateReportModal from '@components/admin/requests/reports/GenerateModal'; // Generate report modal
 import EmptyMessage from '@components/EmptyMessage';
 
@@ -82,7 +82,7 @@ const COLUMNS: Column<ApplicationRow>[] = [
     width: 240,
     sortDescFirst: true,
     Cell: ({ value }) => {
-      return <Text>{formatDateYYYYMMDD(value, true)}</Text>;
+      return <Text>{formatDateYYYYMMDDLocal(value, true)}</Text>;
     },
   },
   {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/Some-time-zones-are-still-EST-8984f93c38da4fccab00a9b510cade56)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Add new formatter to display request and report dates in local time zone instead of UTC.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* All formatted dates with an associated time (e.g., requests, reports) were replaced with the local formatter.
* All formatted dates without an associated time (e.g., date of birth) were left untouched.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
