### PR TITLE
[Feature] Add note field for permit holder’s old user ID

### DIFF
--- a/components/admin/permit-holders/Header.tsx
+++ b/components/admin/permit-holders/Header.tsx
@@ -9,6 +9,7 @@ import {
   MenuItem,
   MenuList,
   Text,
+  Spacer,
   useDisclosure,
   VStack,
   Wrap,
@@ -71,30 +72,42 @@ export default function PermitHolderHeader({
                 </Wrap>
               </HStack>
               <HStack spacing="20px">
-                <Text textStyle="caption" as="p">
-                  ID: #{id}
-                </Text>
-                <Menu>
-                  <MenuButton
-                    as={Button}
-                    rightIcon={<ChevronDownIcon />}
-                    height="30px"
-                    bg="background.gray"
-                    _hover={{ bg: 'background.grayHover' }}
-                    color="black"
-                  >
-                    <Text textStyle="caption">More Actions</Text>
-                  </MenuButton>
-                  <MenuList>
-                    <MenuItem
-                      color={status === 'ACTIVE' ? 'text.critical' : 'text.success'}
-                      textStyle="button-regular"
-                      onClick={onOpenSetPermitHolderStatusModal}
+                <Box>
+                  <Text textStyle="caption" as="p">
+                    ID: #{id}
+                  </Text>
+                </Box>
+                <Box>
+                  <Menu>
+                    <MenuButton
+                      as={Button}
+                      rightIcon={<ChevronDownIcon />}
+                      height="30px"
+                      bg="background.gray"
+                      _hover={{ bg: 'background.grayHover' }}
+                      color="black"
                     >
-                      {`Set as ${status === 'ACTIVE' ? 'Inactive' : 'Active'}`}
-                    </MenuItem>
-                  </MenuList>
-                </Menu>
+                      <Text textStyle="caption">More Actions</Text>
+                    </MenuButton>
+                    <MenuList>
+                      <MenuItem
+                        color={status === 'ACTIVE' ? 'text.critical' : 'text.success'}
+                        textStyle="button-regular"
+                        onClick={onOpenSetPermitHolderStatusModal}
+                      >
+                        {`Set as ${status === 'ACTIVE' ? 'Inactive' : 'Active'}`}
+                      </MenuItem>
+                    </MenuList>
+                  </Menu>
+                </Box>
+                <Box>
+                  {notes && (
+                    <Text noOfLines={1}>
+                      <b>Note:</b> {notes}
+                    </Text>
+                  )}
+                </Box>
+                <Spacer />
               </HStack>
             </VStack>
           </Box>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[6] Add note field for permit holder’s old user ID](https://www.notion.so/uwblueprintexecs/6-Add-note-field-for-permit-holder-s-old-user-ID-d8c455a55edf4d2d8c8a23c5a01bc485?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
