### PR TITLE
[Fix] Change renewal report to most recent expiring permits

### DIFF
--- a/lib/reports/resolvers.ts
+++ b/lib/reports/resolvers.ts
@@ -85,7 +85,7 @@ export const generatePermitHoldersReport: Resolver<
       // Fetches rcdPermitId from latest permit
       permits: {
         orderBy: {
-          createdAt: SortOrder.DESC,
+          expiryDate: SortOrder.DESC,
         },
         take: 1,
         select: {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket](https://www.notion.so/uwblueprintexecs/2-Renewal-Report-in-Excel-format-does-not-show-the-most-recent-expiring-permits-ab5f979d40784ed9b72197b07ea6fc3f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Show most recent expiring permit rather than most recent created permit in renewal report


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* N/A


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
