### PR TITLE
Add auto-refund upon reject

### DIFF
--- a/components/admin/requests/processing/RejectRequestModal.tsx
+++ b/components/admin/requests/processing/RejectRequestModal.tsx
@@ -21,7 +21,11 @@ import {
   RejectApplicationRequest,
   RejectApplicationResponse,
 } from '@tools/admin/requests/reject-request-modal';
-
+import {
+  RefundPaymentResponse,
+  RefundPaymentRequest,
+  REFUND_PAYMENT_MUTATION,
+} from '@tools/admin/requests/processing-tasks-card';
 type RejectRequestModalProps = {
   readonly applicationId: number;
   readonly children: ReactNode;
@@ -45,6 +49,16 @@ export default function RejectRequestModal({ applicationId, children }: RejectRe
   const handleRejectApplication = () => {
     rejectApplication({
       variables: { input: { id: applicationId, reason } },
+    });
+  };
+
+  const [refundPayment] = useMutation<RefundPaymentResponse, RefundPaymentRequest>(
+    REFUND_PAYMENT_MUTATION,
+    { refetchQueries: ['GetApplication'] }
+  );
+  const handleRefundPayment = () => {
+    refundPayment({
+      variables: { input: { applicationId } },
     });
   };
 
@@ -86,6 +100,7 @@ export default function RejectRequestModal({ applicationId, children }: RejectRe
             <Button
               onClick={() => {
                 handleRejectApplication();
+                handleRefundPayment();
                 onClose();
               }}
               bg="secondary.critical"


### PR DESCRIPTION
When an application is rejected, this change automatically refunds it.

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Accountant report still includes the rejected requests and charges fees/donations](https://www.notion.so/uwblueprintexecs/1-Accountant-report-still-includes-the-rejected-requests-and-charges-fees-donations-665fdf313d524c2cbf079ed4261b67f2?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
*


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* I do not think this PR is necessary as I think this might just be a communication issue of how to use the platform. When applications are rejected they are not necessarily refunded. RCD still needs to click the refunded button to show that they have completed the refund on their end. If they don’t want to have to click the refund button this PR implements that, but I think that is unwise.
Before refunding the $34324 Interac application and its $43 dollar donation (This is currently the state before and after clicking the reject on an application, but before checking off the refund task on the refunded application)

![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/1ba5b32c-8813-4b91-acc4-1dff3d70acce)

After refunding (By checking off the refund task on the rejected application) the $34324 interac application and its $43 dollar donation

![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/82a151fd-53b3-4247-b889-e02a45638d5a)


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
