### PR TITLE
Allow numbers in MSP

### DIFF
--- a/lib/applications/validation.ts
+++ b/lib/applications/validation.ts
@@ -447,7 +447,6 @@ export const applicantFacingRenewalDoctorSchema = object().shape({
       is: true,
       then: string()
         .typeError('Please enter the MSP number')
-        .matches(/^\d+$/, 'Must only contain numbers')
         .required('Please enter the MSP number'),
     }),
   doctorAddressLine1: string()

--- a/lib/physicians/validation.ts
+++ b/lib/physicians/validation.ts
@@ -81,9 +81,7 @@ export const physicianAssessmentMutationSchema = physicianAssessmentSchema.shape
 export const requestPhysicianInformationSchema = object({
   firstName: string().required('Please enter a first name'),
   lastName: string().required('Please enter a last name'),
-  mspNumber: string()
-    .matches(/^X?\d+$/, 'Must only contain numbers')
-    .required('Please enter the MSP number'),
+  mspNumber: string().required('Please enter the MSP number'),
   phone: string()
     .required('Please enter a phone number')
     .matches(phoneNumberRegex, 'Please enter a valid phone number in the format 000-000-0000'),


### PR DESCRIPTION
Doctor's MSP no longer only accepts numbers to be entered

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Doctor's MSP only accepts numbers to be entered](https://www.notion.so/uwblueprintexecs/5-Doctor-s-MSP-only-accepts-numbers-to-be-entered-bbaa5573070e4bf28349a0d1af7ecfa0?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Should all characters be allowed? Or only letters and numbers? I have currently implemented it such that anything can be entered.


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
