### PR TITLE
[Fix] No guardian on delete

### DIFF
--- a/lib/application-processing/resolvers.ts
+++ b/lib/application-processing/resolvers.ts
@@ -331,7 +331,11 @@ export const completeApplication: Resolver<
                     },
                   },
                 }
-              : {}),
+              : {
+                  guardian: {
+                    disconnect: true,
+                  },
+                }),
           },
         });
 

--- a/lib/application-processing/resolvers.ts
+++ b/lib/application-processing/resolvers.ts
@@ -321,7 +321,7 @@ export const completeApplication: Resolver<
                 },
               },
             },
-            // If guardian information given, upsert. Otherwise, delete (SET NULL)
+            // If guardian information given, upsert.
             ...(guardian
               ? {
                   guardian: {
@@ -331,7 +331,7 @@ export const completeApplication: Resolver<
                     },
                   },
                 }
-              : { guardian: { delete: true } }),
+              : {}),
           },
         });
 

--- a/tools/hooks/graphql.ts
+++ b/tools/hooks/graphql.ts
@@ -35,15 +35,12 @@ const useMutation = <
     onCompleted: data => {
       for (const key in data) {
         const result = data[key] as unknown as { ok: boolean; error?: string };
-        if ('ok' in result && 'error' in result) {
-          if (!result.ok) {
-            toast({
-              status: 'error',
-              description: result.error,
-              isClosable: true,
-            });
-          }
-        }
+        if (result.ok) continue;
+        toast({
+          status: 'error',
+          description: result.error,
+          isClosable: true,
+        });
       }
       options?.onCompleted && options.onCompleted(data);
     },


### PR DESCRIPTION
## Notion ticket link
[Unable to create a new permanent permit for an existing temporary permit user](https://www.notion.so/uwblueprintexecs/3-Unable-to-create-a-new-permanent-permit-for-an-existing-temporary-permit-user-a5904b840ed6437ab050b648305410f0)
[Unable to create a new temporary permit for an existing temporary permit user](https://www.notion.so/uwblueprintexecs/4-Unable-to-create-a-new-temporary-permit-for-an-existing-temporary-permit-user-ee5d44fa75f94672a5b669e3bca762ec)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Turns out the issue with creating permits for existing users does not have to do with permanent/temporary
* Bug is replicated when user has no guardian attached to existing permit and a new permit is created with no guardian
* Attempts to delete the guardian field when it does not exist
* Made changes to application processing resolver and error catching


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* N/A


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket