### PR TITLE
Show individual steps of the application process

### DIFF
--- a/lib/application-processing/field-resolvers.ts
+++ b/lib/application-processing/field-resolvers.ts
@@ -63,9 +63,8 @@ export const applicationProcessingAppNumberEmployeeResolver: FieldResolver<
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .appNumberEmployee();
 };
 
@@ -76,9 +75,8 @@ export const applicationProcessingAppHolepunchedEmployeeResolver: FieldResolver<
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .appHolepunchedEmployee();
 };
 
@@ -89,9 +87,8 @@ export const applicationProcessingWalletCardCreatedEmployeeResolver: FieldResolv
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .walletCardCreatedEmployee();
 };
 
@@ -102,9 +99,8 @@ export const applicationProcessingReviewRequestCompletedEmployeeResolver: FieldR
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .reviewRequestEmployee();
 };
 
@@ -115,9 +111,8 @@ export const applicationProcessingDocumentsUrlEmployeeResolver: FieldResolver<
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .documentsUrlEmployee();
 };
 
@@ -128,9 +123,8 @@ export const applicationProcessingAppMailedEmployeeResolver: FieldResolver<
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .appMailedEmployee();
 };
 
@@ -141,8 +135,7 @@ export const applicationProcessingPaymentRefundedEmployeeResolver: FieldResolver
   ApplicationProcessing & { id: number },
   Employee
 > = async (parent, _, { prisma }) => {
-  return await prisma.application
+  return await prisma.applicationProcessing
     .findUnique({ where: { id: parent.id } })
-    .applicationProcessing()
     .paymentRefundedEmployee();
 };


### PR DESCRIPTION
seems to fix it!

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The reason some task logs were showing and ome were not is because for most applications the application ID did not match the applicationProcessing ID 
![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/c9888af0-2aee-4d93-af61-f06ba628210b)
This was not a problem for applicationProcessingInvoiceResolver which always used the prisma.applicationProcessing but was for all the rest. I think this should fix the issue but it might need some further testing to see if anything is broken.



<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
