### PR TITLE
Change pdf address spacing from 1.5 to 1.4

### DIFF
--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -215,7 +215,7 @@ const pdfDefinition = (input: {
         ],
         absolutePosition: { x: 80, y: 740 },
         fontSize: 12,
-        lineHeight: 1.5,
+        lineHeight: 1.4,
       },
     ],
     styles: {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Formatting Invoice](https://www.notion.so/uwblueprintexecs/Formatting-invoice-a1082615428c464a9c159eea96c116a6)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed the pdf address spacing from 1.5 to 1.4


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Not sure if this is what RCD wants, we should double-check


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
