### PR TITLE
[Fix] Display other gender field on permit holders page

### DIFF
--- a/components/admin/permit-holders/permit-holder-information/Card.tsx
+++ b/components/admin/permit-holders/permit-holder-information/Card.tsx
@@ -139,7 +139,7 @@ export default function PermitHolderInformationCard(props: PersonalInformationPr
             Date of Birth: {formatDateYYYYMMDD(new Date(dateOfBirth))}
           </Text>
           <Text as="p" textStyle="body-regular">
-            Gender: {gender === 'OTHER' ? otherGender : titlecase(gender)}
+            Gender: {gender === 'OTHER' && otherGender ? otherGender : titlecase(gender)}
           </Text>
         </VStack>
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[22] No text on permit holders page for users that choose other gender](https://www.notion.so/uwblueprintexecs/22-No-text-on-permit-holders-page-for-users-that-choose-other-gender-ded34556b772482cbf7353fe0891bd89)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Check to see if `otherGender` has a string value associated, otherwise print `titlecase(gender)`, which should be "Other" if gender is "OTHER"
* Seems like this `otherGender` functionality was never [fully implemented](https://github.com/uwblueprint/richmond-centre-for-disability/blob/eb843737b09b1d1a61f38905fe2b8584c5ba90c7/components/admin/requests/permit-holder-information/Form.tsx#L40)


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
