### PR TITLE
[Fix] Postal Code Space Issue

### DIFF
--- a/components/admin/permit-holders/doctor-information/Card.tsx
+++ b/components/admin/permit-holders/doctor-information/Card.tsx
@@ -13,7 +13,7 @@ import {
   UpdateDoctorInformationResponse,
   UPDATE_DOCTOR_INFORMATION,
 } from '@tools/admin/permit-holders/doctor-information';
-import { formatFullName, formatPhoneNumber, stripPostalCode } from '@lib/utils/format';
+import { formatFullName, formatPhoneNumber } from '@lib/utils/format';
 import Address from '@components/admin/Address';
 import { useMemo } from 'react';
 import { requestPhysicianInformationSchema } from '@lib/physicians/validation';
@@ -43,7 +43,6 @@ export default function DoctorInformationCard(props: DoctorInformationProps) {
       UPDATE_DOCTOR_INFORMATION
     );
   const handleSave = async (doctorFormData: DoctorFormData) => {
-    doctorFormData.postalCode = stripPostalCode(doctorFormData.postalCode);
     const validatedData = await requestPhysicianInformationSchema.validate(doctorFormData);
 
     const { data } = await updateDoctorInformation({

--- a/components/admin/permit-holders/doctor-information/Card.tsx
+++ b/components/admin/permit-holders/doctor-information/Card.tsx
@@ -13,7 +13,7 @@ import {
   UpdateDoctorInformationResponse,
   UPDATE_DOCTOR_INFORMATION,
 } from '@tools/admin/permit-holders/doctor-information';
-import { formatFullName, formatPhoneNumber } from '@lib/utils/format';
+import { formatFullName, formatPhoneNumber, stripPostalCode } from '@lib/utils/format';
 import Address from '@components/admin/Address';
 import { useMemo } from 'react';
 import { requestPhysicianInformationSchema } from '@lib/physicians/validation';
@@ -43,6 +43,7 @@ export default function DoctorInformationCard(props: DoctorInformationProps) {
       UPDATE_DOCTOR_INFORMATION
     );
   const handleSave = async (doctorFormData: DoctorFormData) => {
+    doctorFormData.postalCode = stripPostalCode(doctorFormData.postalCode);
     const validatedData = await requestPhysicianInformationSchema.validate(doctorFormData);
 
     const { data } = await updateDoctorInformation({

--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -312,8 +312,8 @@ export const updateApplicantDoctorInformation: Resolver<
   const { id, mspNumber, ...data } = input;
   const { firstName, lastName, addressLine1, addressLine2, city } = input;
 
-  const phone = stripPhoneNumber(data.phone);
-  const postalCode = stripPostalCode(data.postalCode);
+  const phone = data.phone ? stripPhoneNumber(data.phone) : null;
+  const postalCode = data.postalCode ? stripPostalCode(data.postalCode) : null;
 
   try {
     await requestPhysicianInformationSchema.validate({
@@ -343,10 +343,19 @@ export const updateApplicantDoctorInformation: Resolver<
   let updatedApplicant;
 
   try {
+    const upsertData = {
+      firstName: firstName as string,
+      lastName: lastName as string,
+      phone: phone as string,
+      addressLine1: addressLine1 as string,
+      addressLine2: addressLine2 as string | null,
+      city: city as string,
+      postalCode: postalCode as string,
+    };
     const upsertPhysician = prisma.physician.upsert({
       where: { mspNumber },
-      create: { mspNumber, ...data },
-      update: data,
+      create: { mspNumber, ...upsertData },
+      update: upsertData,
     });
     const updateApplicant = prisma.applicant.update({
       where: { id },


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[12] Cannot save edited doctor’s info for permit holder if postal code has spacing](https://www.notion.so/uwblueprintexecs/12-Cannot-save-edited-doctor-s-info-for-permit-holder-if-postal-code-has-spacing-f42f0f75a30c4d64aaaa6f17d617cf38?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* No longer make the change for Physician postal code stripping in the frontend.
* Physician postal codes can have a single space in them like is intended.


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
