### PR TITLE
[Fix] Set other gender field on permit holders page

### DIFF
--- a/components/admin/requests/permit-holder-information/Card.tsx
+++ b/components/admin/requests/permit-holder-information/Card.tsx
@@ -94,6 +94,8 @@ const Card: FC<Props> = props => {
       | null;
     if (type === 'NEW') {
       const validatedData = await permitHolderInformationSchema.validate(permitHolderData);
+      // TODO: Remove this once schema is updated
+      validatedData.otherGender = '';
 
       ({ data } = await updateNewPermitHolderInformation({
         variables: { input: { id: applicationId, ...validatedData } },


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Cannot save edits to personal info section (name or gender) when processing new requests](https://www.notion.so/uwblueprintexecs/23-Cannot-save-edits-to-personal-info-section-name-or-gender-when-processing-new-requests-00a593131eb5499a8bb2e3fbbafec3bb)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `otherGender` is set to null when updating permit holder information for new applicants
* Quick fix is to set `otherGender` to an empty string on save

### Error
<img width="641" alt="other-gender-null" src="https://github.com/uwblueprint/richmond-centre-for-disability/assets/77544794/dbdf6524-3b53-4a10-b4d9-d2a081cd3b32">


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Once schema can be updated to allow `otherGender` to be null, this quick fix can be removed.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
