### PR TITLE
[Fix] Save poaFormS3ObjectKey when updating guardian information in permit holders page

### DIFF
--- a/lib/applicants/resolvers.ts
+++ b/lib/applicants/resolvers.ts
@@ -451,6 +451,7 @@ export const updateApplicantGuardianInformation: Resolver<
       addressLine2: addressLine2 as string | null,
       city: city as string,
       postalCode: postalCode as string,
+      poaFormS3ObjectKey: data.poaFormS3ObjectKey,
     };
 
     updatedApplicant = await prisma.applicant.update({


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[17] Guardian/POA file upload does not save the file](https://www.notion.so/uwblueprintexecs/17-Guardian-POA-file-upload-does-not-save-the-file-3ed5816a6e354e80b677697e16a84b78)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Update updateApplicantGuardianInformation resolver to save the `poaFormS3ObjectKey` to the database

![upload-poa-file](https://github.com/uwblueprint/richmond-centre-for-disability/assets/30205929/b94bcfad-2213-406d-b975-ae7e02657081)


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* POA file can also be added/updated when creating or updating a new application, verified that file upload is working correctly in these cases - the problem was isolated to the permit holders page
* There are some existing issues with file upload, namely that there is no validation logic enforcing unique S3 keys for guardians, this means a file can be overwritten if a file of the same name is uploaded for a different guardian. Chose to go with the quick fix first to resolve the originally reported issue, the overwriting issue is a bit less urgent given it hasn't been reported yet


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
