### PR TITLE
Don't default to permanent if falsy permitType

### DIFF
--- a/components/admin/permit-holders/app-history/Card/AppHistoryRecord.tsx
+++ b/components/admin/permit-holders/app-history/Card/AppHistoryRecord.tsx
@@ -33,7 +33,7 @@ const AppHistoryRecord: FC<Props> = ({ permit }) => {
             <Text as="h3" textStyle="heading">
               Permit {rcdPermitId}
             </Text>
-            <PermitTypeBadge variant={permitType || 'PERMANENT'} />
+            <PermitTypeBadge variant={permitType} />
           </HStack>
           <HStack spacing="20px">
             <Text as="p" textStyle="body-regular">


### PR DESCRIPTION
The permit type field should never be falsy, but at times javascript eludes understanding

## Notion ticket link
[[16] For new temporary permit holders, under their Past APPs section, it lists them as having a permanent permit despite their recent permit request being a temporary one](https://www.notion.so/uwblueprintexecs/16-For-new-temporary-permit-holders-under-their-Past-APPs-section-it-lists-them-as-having-a-perma-8e37e85eb41740cb93d17e72a153f432)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* I have still been unable to replicate this bug on my end, however I think it may be worth asking rcd if this change has any effect on their end.


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
