### PR TITLE
[Feature] Create setEmployeeAsActive GraphQL endpoint

### DIFF
--- a/lib/employees/resolvers.ts
+++ b/lib/employees/resolvers.ts
@@ -224,18 +224,18 @@ export const setEmployeeAsActive: Resolver<
   MutationSetEmployeeAsActiveArgs,
   SetEmployeeAsActiveResult
 > = async (_, args, { prisma }) => {
-  const id = args.input.id;
+  const email = args.input.email;
 
   let updatedEmployee;
   try {
     updatedEmployee = await prisma.employee.update({
-      where: { id },
+      where: { email },
       data: { active: true },
     });
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError) {
       if (err.code === DBErrorCode.RecordNotFound) {
-        throw new EmployeeNotFoundError(`Employee with ID ${id} not found`);
+        throw new EmployeeNotFoundError(`Employee with email ${email} not found`);
       }
     }
   }

--- a/lib/employees/schema.ts
+++ b/lib/employees/schema.ts
@@ -57,4 +57,13 @@ export default gql`
     result: [Employee!]!
     totalCount: Int!
   }
+
+  input SetEmployeeAsActiveInput {
+    id: Int!
+  }
+
+  type SetEmployeeAsActiveResult {
+    ok: Boolean!
+    employee: Employee!
+  }
 `;

--- a/lib/employees/schema.ts
+++ b/lib/employees/schema.ts
@@ -59,7 +59,7 @@ export default gql`
   }
 
   input SetEmployeeAsActiveInput {
-    id: Int!
+    email: String!
   }
 
   type SetEmployeeAsActiveResult {

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -6,6 +6,7 @@ import {
   updateEmployee,
   employee,
   deleteEmployee,
+  setEmployeeAsActive,
 } from '@lib/employees/resolvers'; // Employee resolvers
 import {
   applicant,
@@ -233,6 +234,7 @@ const resolvers = {
     createEmployee: authorize(createEmployee),
     updateEmployee: authorize(updateEmployee),
     deleteEmployee: authorize(deleteEmployee),
+    setEmployeeAsActive: authorize(setEmployeeAsActive),
   },
   Date: dateScalar,
   Applicant: {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -116,6 +116,7 @@ export default gql`
     createEmployee(input: CreateEmployeeInput!): CreateEmployeeResult!
     updateEmployee(input: UpdateEmployeeInput!): UpdateEmployeeResult!
     deleteEmployee(input: DeleteEmployeeInput!): DeleteEmployeeResult!
+    setEmployeeAsActive(input: SetEmployeeAsActiveInput!): SetEmployeeAsActiveResult!
   }
 
   # Scalars

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -74,16 +74,6 @@ export type ApplicantsResult = {
   totalCount: Scalars['Int'];
 };
 
-export type DeleteApplicationInput = {
-  id: Scalars['Int'];
-};
-
-export type DeleteApplicationResult = {
-  __typename?: 'DeleteApplicationResult';
-  ok: Scalars['Boolean'];
-  error: Maybe<Scalars['String']>;
-};
-
 export type Application = {
   id: Scalars['Int'];
   firstName: Scalars['String'];
@@ -470,6 +460,16 @@ export type DeleteApplicantResult = {
   error: Maybe<Scalars['String']>;
 };
 
+export type DeleteApplicationInput = {
+  id: Scalars['Int'];
+};
+
+export type DeleteApplicationResult = {
+  __typename?: 'DeleteApplicationResult';
+  ok: Scalars['Boolean'];
+  error: Maybe<Scalars['String']>;
+};
+
 export type DeleteEmployeeInput = {
   id: Scalars['Int'];
 };
@@ -628,6 +628,7 @@ export type Mutation = {
   createEmployee: CreateEmployeeResult;
   updateEmployee: UpdateEmployeeResult;
   deleteEmployee: DeleteEmployeeResult;
+  setEmployeeAsActive: SetEmployeeAsActiveResult;
 };
 
 
@@ -731,6 +732,11 @@ export type MutationUpdateApplicationPhysicianAssessmentArgs = {
 };
 
 
+export type MutationDeleteApplicationArgs = {
+  input: DeleteApplicationInput;
+};
+
+
 export type MutationApproveApplicationArgs = {
   input: ApproveApplicationInput;
 };
@@ -800,8 +806,9 @@ export type MutationDeleteEmployeeArgs = {
   input: DeleteEmployeeInput;
 };
 
-export type MutationDeleteApplicationArgs = {
-  input: DeleteApplicationInput;
+
+export type MutationSetEmployeeAsActiveArgs = {
+  input: SetEmployeeAsActiveInput;
 };
 
 export type NewApplication = Application & {
@@ -1196,6 +1203,16 @@ export type SetApplicantAsInactiveResult = {
   __typename?: 'SetApplicantAsInactiveResult';
   ok: Scalars['Boolean'];
   error: Maybe<Scalars['String']>;
+};
+
+export type SetEmployeeAsActiveInput = {
+  id: Scalars['Int'];
+};
+
+export type SetEmployeeAsActiveResult = {
+  __typename?: 'SetEmployeeAsActiveResult';
+  ok: Scalars['Boolean'];
+  employee: Employee;
 };
 
 export type ShopifyPaymentStatus =

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1206,7 +1206,7 @@ export type SetApplicantAsInactiveResult = {
 };
 
 export type SetEmployeeAsActiveInput = {
-  id: Scalars['Int'];
+  email: Scalars['String'];
 };
 
 export type SetEmployeeAsActiveResult = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[18][PROD] Issue adding new admin](https://www.notion.so/uwblueprintexecs/18-PROD-Issue-adding-new-admin-a308710ea97d419f9339d65ea5102d41)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Create new GraphQL endpoint to set an employee to active state
* Meant only for internal use right now, will not expose on UI

```
rcd=# select * from employees where id = 16;
 id | first_name | last_name |               email                |       email_verified       | role  | active |         created_at         |          updated_at
----+------------+-----------+------------------------------------+----------------------------+-------+--------+----------------------------+-------------------------------
 16 | Sherry     | Li        | sherryli+employee2@uwblueprint.org | 2023-10-02 07:14:32.818+00 | ADMIN | f      | 2023-10-02 07:07:51.834+00 | 2023-10-03 02:10:56.007522+00 
(1 row)
```
![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/30205929/9a651448-b9eb-4374-9b46-d5c43906e796)

```
rcd=# select * from employees where id = 16;
 id | first_name | last_name |               email                |       email_verified       | role  | active |         created_at         |          updated_at
----+------------+-----------+------------------------------------+----------------------------+-------+--------+----------------------------+-------------------------------
 16 | Sherry     | Li        | sherryli+employee2@uwblueprint.org | 2023-10-02 07:14:32.818+00 | ADMIN | t      | 2023-10-02 07:07:51.834+00 | 2023-10-09 06:50:56.119863+00 
(1 row)
```



<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* N/A


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
