### PR TITLE
[Fix] Make replacement requests clearer

### DIFF
--- a/components/admin/requests/reason-for-replacement/Form.tsx
+++ b/components/admin/requests/reason-for-replacement/Form.tsx
@@ -36,8 +36,22 @@ export default function ReasonForReplacementForm({
       <Box paddingBottom="24px">
         <RadioGroupField name="reasonForReplacement.reason" label="Reason" required>
           <Stack>
-            <Radio value={'LOST'}>{'Lost'}</Radio>
-            <Radio value={'STOLEN'}>{'Stolen'}</Radio>
+            <Radio
+              value={'LOST'}
+              onChange={() => {
+                setFieldValue('paymentInformation.processingFee', '31');
+              }}
+            >
+              {'Lost'}
+            </Radio>
+            <Radio
+              value={'STOLEN'}
+              onChange={() => {
+                setFieldValue('paymentInformation.processingFee', '31');
+              }}
+            >
+              {'Stolen'}
+            </Radio>
             <Radio
               value={'OTHER'}
               onChange={() => {

--- a/components/admin/requests/reason-for-replacement/Form.tsx
+++ b/components/admin/requests/reason-for-replacement/Form.tsx
@@ -38,7 +38,14 @@ export default function ReasonForReplacementForm({
           <Stack>
             <Radio value={'LOST'}>{'Lost'}</Radio>
             <Radio value={'STOLEN'}>{'Stolen'}</Radio>
-            <Radio value={'OTHER'}>{'Mail Lost'}</Radio>
+            <Radio
+              value={'OTHER'}
+              onChange={() => {
+                setFieldValue('paymentInformation.processingFee', '0');
+              }}
+            >
+              {'Mail Lost'}
+            </Radio>
           </Stack>
         </RadioGroupField>
       </Box>

--- a/components/admin/requests/reason-for-replacement/Form.tsx
+++ b/components/admin/requests/reason-for-replacement/Form.tsx
@@ -38,7 +38,7 @@ export default function ReasonForReplacementForm({
           <Stack>
             <Radio value={'LOST'}>{'Lost'}</Radio>
             <Radio value={'STOLEN'}>{'Stolen'}</Radio>
-            <Radio value={'OTHER'}>{'Other'}</Radio>
+            <Radio value={'OTHER'}>{'Mail Lost'}</Radio>
           </Stack>
         </RadioGroupField>
       </Box>

--- a/pages/admin/request/create-replacement.tsx
+++ b/pages/admin/request/create-replacement.tsx
@@ -69,6 +69,8 @@ export default function CreateReplacement() {
 
   const toast = useToast();
   const router = useRouter();
+  const ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS = INITIAL_PAYMENT_DETAILS;
+  ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS.processingFee = '0';
 
   // Get applicant autofill information
   const [getApplicant] = useLazyQuery<GetSelectedApplicantResponse, GetSelectedApplicantRequest>(
@@ -219,7 +221,7 @@ export default function CreateReplacement() {
                 type: 'REPLACEMENT',
                 receiveEmailUpdates: false,
               },
-              paymentInformation: INITIAL_PAYMENT_DETAILS,
+              paymentInformation: ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS,
               reasonForReplacement: INITIAL_REASON_FOR_REPLACEMENT,
             }}
             validationSchema={replacementRequestFormSchema}

--- a/pages/admin/request/create-replacement.tsx
+++ b/pages/admin/request/create-replacement.tsx
@@ -69,8 +69,6 @@ export default function CreateReplacement() {
 
   const toast = useToast();
   const router = useRouter();
-  const ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS = INITIAL_PAYMENT_DETAILS;
-  ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS.processingFee = '0';
 
   // Get applicant autofill information
   const [getApplicant] = useLazyQuery<GetSelectedApplicantResponse, GetSelectedApplicantRequest>(
@@ -221,7 +219,7 @@ export default function CreateReplacement() {
                 type: 'REPLACEMENT',
                 receiveEmailUpdates: false,
               },
-              paymentInformation: ZERO_REPLACEMENT_FEE_PAYMENT_DETAILS,
+              paymentInformation: INITIAL_PAYMENT_DETAILS,
               reasonForReplacement: INITIAL_REASON_FOR_REPLACEMENT,
             }}
             validationSchema={replacementRequestFormSchema}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[24] Make replacement requests clearer](https://www.notion.so/uwblueprintexecs/24-Make-replacement-requests-clearer-f8b6511d86584315beea24380247fab0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Renamed the reason of replacement from "others" to "mail lost".
* Set a default permit fee of $0 without any specified payment method.

![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/5ecab1ef-8259-45f4-9eda-a5ef6baf54dd)

## Checklist
- [ x ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ x ] I have run the appropriate linter(s)
- [ x ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
