### PR TITLE
[Improvement] Update donation receipt spacing

### DIFF
--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -404,57 +404,74 @@ const donationPdfDefinition = (input: {
         pageBreak: 'before',
         text: [
           { text: 'RICHMOND CENTRE FOR DISABILITY', style: 'header' },
-          '\n\n',
+          '\n',
           {
             text: `Official Donation Receipt for Income Tax Purposes - ${dateIssued.getFullYear()}`,
-            style: 'subheaderDonation',
+            style: 'subheader',
           },
         ],
       },
+
       {
         columns: [
           {
-            table: {
-              heights: 20,
-              body: [
-                [
-                  { text: 'Tax Receipt #:' },
-                  `PPD_${dateIssued.getFullYear()}${dateIssued.getMonth()}${dateIssued.getDate()}_${appNumber}`,
-                ],
-                [
-                  { text: 'Donated by:' },
-                  {
-                    text: [
-                      `${applicantName}\n`,
-                      `${address.addressLine2 ? `${address.addressLine2} - ` : ''}${
-                        address.addressLine1
-                      }\n`,
-                      `${address.city} ${address.province} ${formatPostalCode(address.postalCode)}`,
+            stack: [
+              {
+                table: {
+                  heights: 18,
+                  body: [
+                    [
+                      { text: 'Tax Receipt #:' },
+                      `PPD_${dateIssued.getFullYear()}${dateIssued.getMonth()}${dateIssued.getDate()}_${appNumber}`,
                     ],
-                    fontSize: 12,
-                    lineHeight: 1.5,
-                  },
-                ],
-                [{ text: '' }, ''],
-                [{ text: '' }, ''],
-                [{ text: '' }, ''],
-                [{ text: 'Email:' }, nonNullEmail],
-                [{ text: 'Date Receipt Issued:' }, formatDateYYYYMMDD(dateIssued)],
-                [{ text: 'Location Receipt Issued:' }, 'Richmond, BC'],
-                [{ text: 'Authorized Signature:' }, { image: 'signature', width: 150 }],
-              ],
-            },
-            layout: 'noBorders',
-            margin: [0, 0, 20, 0],
+                    [
+                      { text: 'Donated by:' },
+                      {
+                        text: [
+                          `${applicantName}\n`,
+                          `${address.addressLine2 ? `${address.addressLine2} - ` : ''}${
+                            address.addressLine1
+                          }\n`,
+                          `${address.city} ${address.province} ${formatPostalCode(
+                            address.postalCode
+                          )}`,
+                        ],
+                        lineHeight: 1.4,
+                      },
+                    ],
+                  ],
+                },
+                layout: 'noBorders',
+                margin: [0, 0, 0, 40],
+              },
+              {
+                text: [`Email: ${nonNullEmail}`],
+                margin: [0, 0, 0, 8],
+              },
+              {
+                table: {
+                  heights: 18,
+                  body: [
+                    [{ text: 'Date Receipt Issued:' }, formatDateYYYYMMDD(dateIssued)],
+                    [{ text: 'Location Receipt Issued:' }, 'Richmond, BC'],
+                  ],
+                },
+                margin: [0, 0, 0, 15],
+                layout: 'noBorders',
+              },
+              { image: 'signature', width: 200, margin: [0, 0, 0, 5] },
+              { text: 'Authorized Signature:' },
+            ],
           },
+
           {
             table: {
-              heights: 20,
+              heights: 18,
               body: [
                 [{ text: 'Date Donation Received:' }, formatDateYYYYMMDD(dateDonationRecevied)],
                 [{ text: 'Donor Number:' }, `P${appNumber}`],
                 [{ text: 'Total Amount:' }, `$${donationAmount.toString()}`],
-                [{ text: 'Value of Product / Services:\n' }, ''],
+                [{ text: 'Value of Product / Services:\n\n' }, ''],
                 [
                   { text: 'Eligible Amount of Donation for Tax Purposes:' },
                   `$${donationAmount.toString()}`,
@@ -469,15 +486,15 @@ const donationPdfDefinition = (input: {
                       'Address of Appraiser:\n\n',
                     ],
                   },
-                  { image: 'stamp', width: 85 },
+                  { image: 'stamp', width: 80 },
                 ],
               ],
             },
             layout: 'noBorders',
-            margin: [20, 0, 0, 0],
+            margin: [15, 0, 0, 0],
           },
         ],
-        margin: [0, 35, 0, 25],
+        margin: [0, 25, 0, 0],
       },
       {
         text: [
@@ -498,36 +515,32 @@ const donationPdfDefinition = (input: {
           'Website:www.rcdrichmond.org\n',
         ],
         margin: [0, 15, 0, 0],
-        fontSize: 12,
       },
     ]),
     styles: {
       header: {
-        fontSize: 28,
+        fontSize: 25.5,
         bold: true,
         alignment: 'center',
+        lineHeight: 1.5,
       },
       tableHeader: {
         bold: true,
         alignment: 'center',
       },
       subheader: {
-        fontSize: 20,
-        bold: false,
-        alignment: 'center',
-      },
-      subheaderDonation: {
-        fontSize: 19,
+        fontSize: 17.5,
         alignment: 'center',
       },
       footer: {
-        fontSize: 8,
+        fontSize: 7.5,
         alignment: 'center',
       },
     },
     defaultStyle: {
       font: 'Helvetica',
-      lineHeight: 1.4,
+      fontSize: 11,
+      lineHeight: 1.2,
     },
     images: {
       rcd: 'public/assets/logo.png',

--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -454,7 +454,7 @@ const donationPdfDefinition = (input: {
                 [{ text: 'Date Donation Received:' }, formatDateYYYYMMDD(dateDonationRecevied)],
                 [{ text: 'Donor Number:' }, `P${appNumber}`],
                 [{ text: 'Total Amount:' }, `$${donationAmount.toString()}`],
-                [{ text: 'Value of Product / Services:' }, ''],
+                [{ text: 'Value of Product / Services:\n' }, ''],
                 [
                   { text: 'Eligible Amount of Donation for Tax Purposes:' },
                   `$${donationAmount.toString()}`,
@@ -481,14 +481,14 @@ const donationPdfDefinition = (input: {
       },
       {
         text: [
-          `Dear ${applicantName}\n\n`,
+          `Dear ${applicantName}\n\n\n`,
           'On behalf of the Richmond Centre for Disability (RCD), we would like to extend our sincere and\n',
           'heartfelt thanks and appreciation for your donation. Please find your official tax receipt enclosed.\n\n',
           'Through RCD services and support, we have seen the lives of people with disabilities and their\n',
           'families changed for the better. Your generosity does make a difference in the delivery of much\n',
           'coveted services to people with disabilities. The work being undertaken through the RCD is only\n',
-          'possible because of caring people like you.\n\n',
-          'Thank you again for your valued support.\n\n',
+          'possible because of caring people like you.\n\n\n',
+          'Thank you again for your valued support.\n\n\n',
           'Sincerely,\n\n\n',
           'RICHMOND CENTRE FOR DISABILITY\n',
           '(Charity Number: 88832-8432-RR0001)\n',
@@ -527,6 +527,7 @@ const donationPdfDefinition = (input: {
     },
     defaultStyle: {
       font: 'Helvetica',
+      lineHeight: 1.4,
     },
     images: {
       rcd: 'public/assets/logo.png',


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add spacing to tax receipt](https://www.notion.so/uwblueprintexecs/Add-spacing-to-tax-receipt-3ed828a803714dabbb0109e16e399ccb)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated the donation receipt to match the provided example

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* This ticket is actually not complete and should be updated once database migration is allowed. This is because the example donation receipt and permit receipt that RCD provided are of different sizes (Letter vs A4 respectively) and pdfmake doesn't allow us to have 2 pages in the same that are different sizes https://github.com/bpampuch/pdfmake/issues/325. This is important because as mentioned in https://github.com/uwblueprint/richmond-centre-for-disability/pull/311 we are only able to export one pdf without changing the schema, and so we simply concatenate the donation and permit receipt into one pdf if the donation exceeds $20 This pdf should contain one Letter sized page and one A4 sized page, but we are unable to do so. Resultantly, the spacing on the donation receipt should be `pageSize: 'LETTER',
    pageMargins: [70, 50],` but is currently A4. This should be changed when we are able to make database schema changes. Any thoughts or suggestions would be much appreciated.

This is the goal PDF:
![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/6381b9c8-3ef7-448c-9812-8dd0dd47b222)


This would be the produces pdf **if** it was letter sized
![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/5e293a4d-cfe9-4498-8b8c-6aa43a415e95)


This is the actually produced PDF:
![image](https://github.com/uwblueprint/richmond-centre-for-disability/assets/24593519/80850b68-6521-414e-a60a-0816e9c2c464)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
