### PR TITLE
[Fix] Adjust schema to evaluate date at validation time

### DIFF
--- a/lib/physicians/validation.ts
+++ b/lib/physicians/validation.ts
@@ -1,18 +1,20 @@
 import { phoneNumberRegex, postalCodeRegex } from '@lib/utils/validation';
 import { MobilityAid, PatientCondition, PermitType } from '@prisma/client';
-import { date, mixed, object, string, array, number } from 'yup';
+import { date, lazy, mixed, object, string, array, number } from 'yup';
 
 /**
  * Validation schema for physician assessment form
  */
 export const physicianAssessmentSchema = object({
   disability: string().required('Please enter a disabling condition'),
-  disabilityCertificationDate: date()
-    .transform((_value, originalValue) => {
-      return new Date(originalValue);
-    })
-    .max(new Date(), 'Date must be in the past')
-    .required('Please enter a valid certification date'),
+  disabilityCertificationDate: lazy(() =>
+    date()
+      .transform((_value, originalValue) => {
+        return new Date(originalValue);
+      })
+      .max(new Date(), 'Date must be in the past')
+      .required('Please enter a valid certification date')
+  ),
   patientCondition: array(
     mixed<PatientCondition>()
       .oneOf(Object.values(PatientCondition))


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Physician certification date](https://www.notion.so/uwblueprintexecs/25-Physician-certification-date-12294a50d9e045b3bb0e9a17dfaa9e9a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changes validation schema for physician certification date to dynamically compute current date with `new Date()` on each validation attempt


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Unable to replicate issue exactly, can only assume this happens in a very rare instance where the request page is left open and not completed


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
