### PR TITLE
Adding the .yarn folder to gitignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.yarn*
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
Yarn after version 2.0.0 creates a .yarn directory for caching and metadata. This PR ignores that.