### PR TITLE
[Fix] Fix replacement request otherGender and lostTimestamp form validations

### DIFF
--- a/components/admin/requests/reason-for-replacement/Form.tsx
+++ b/components/admin/requests/reason-for-replacement/Form.tsx
@@ -13,9 +13,10 @@ import NumberField from '@components/form/NumberField';
 import RadioGroupField from '@components/form/RadioGroupField';
 import TextArea from '@components/form/TextAreaField';
 import TextField from '@components/form/TextField';
-import { formatDate } from '@lib/utils/date'; // Date formatter util
+import { formatDateYYYYMMDDLocal } from '@lib/utils/date'; // Date formatter util
 import { ReasonForReplacementFormData } from '@tools/admin/requests/reason-for-replacement';
 import { useFormikContext } from 'formik';
+import moment from 'moment';
 
 type ReasonForReplacementProps = {
   readonly reasonForReplacement: ReasonForReplacementFormData;
@@ -75,7 +76,10 @@ export default function ReasonForReplacementForm({
                 required
                 value={
                   reasonForReplacement.lostTimestamp
-                    ? formatDate(new Date(reasonForReplacement.lostTimestamp), true)
+                    ? // lostTimestamp is the date in the LOCAL TIMEZONE, in YYYY-MM-DD format
+                      // use moment to get Date object in local timezone as
+                      // Date constructor defaults to UTC when given YYYY-MM-DD string
+                      formatDateYYYYMMDDLocal(moment(reasonForReplacement.lostTimestamp).toDate())
                     : ''
                 }
               />
@@ -91,18 +95,21 @@ export default function ReasonForReplacementForm({
               <Input
                 type="time"
                 value={
-                  new Date(reasonForReplacement.lostTimestamp).toLocaleTimeString('en-US', {
+                  moment(reasonForReplacement.lostTimestamp).toDate().toLocaleTimeString('en-US', {
                     hour12: false,
                     hour: '2-digit',
                     minute: '2-digit',
                   }) || ''
                 }
                 onChange={event => {
-                  const updatedlostTimestamp = new Date(reasonForReplacement.lostTimestamp);
-                  updatedlostTimestamp.setHours(parseInt(event.target.value.substring(0, 2)));
-                  updatedlostTimestamp.setMinutes(parseInt(event.target.value.substring(3, 5)));
+                  const updatedlostTimestamp = moment(reasonForReplacement.lostTimestamp);
+                  updatedlostTimestamp.set('hour', parseInt(event.target.value.substring(0, 2)));
+                  updatedlostTimestamp.set('minute', parseInt(event.target.value.substring(3, 5)));
 
-                  setFieldValue('reasonForReplacement.lostTimestamp', updatedlostTimestamp);
+                  setFieldValue(
+                    'reasonForReplacement.lostTimestamp',
+                    updatedlostTimestamp.toDate()
+                  );
                 }}
               />
               <FormHelperText color="text.secondary">{'Example: HH:MM AM/PM'}</FormHelperText>

--- a/lib/applicants/validation.ts
+++ b/lib/applicants/validation.ts
@@ -23,7 +23,11 @@ export const requestPermitHolderInformationSchema = object({
       then: mixed<Gender>().oneOf(Object.values(Gender)).required('Please select a gender'),
       otherwise: mixed<Gender>().oneOf(Object.values(Gender)).optional(),
     }),
-  otherGender: string().nullable().default(null),
+  otherGender: string().when('type', {
+    is: 'NEW',
+    then: string().nullable().default(null),
+    otherwise: string().optional(),
+  }),
   email: string().email('Please enter a valid email address').nullable().default(null),
   phone: string()
     .required('Please enter a valid phone number')

--- a/lib/applications/resolvers.ts
+++ b/lib/applications/resolvers.ts
@@ -1192,7 +1192,7 @@ export const updateNewApplicationGeneralInformation: Resolver<
   const { input } = args;
 
   try {
-    await requestPermitHolderInformationMutationSchema.validate(input);
+    await requestPermitHolderInformationMutationSchema.validate({ type: 'NEW', ...input });
   } catch (err) {
     if (err instanceof ValidationError) {
       return {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[26] Replacement request date](https://www.notion.so/uwblueprintexecs/26-Replacement-request-date-05dd117cf6954da3ad303483bbb16a99)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Contains 2 fixes, please review the commits individually:
* 7a47b9572cfcecd9002a5b0f5e2cf6f665d3afe5: reverts validation schema change from #327 to fix the `Field \"otherGender\" is not defined by type \"CreateReplacementApplicationInput` error seen in staging
  * `otherGender` is not part of the GraphQL schema for replacement and renewal requests and thus should be marked optional in the validation
  * when marked as nullable with default null, a null `otherGender` field is passed for these types of requests and were getting rejected by the backend
  * the reason why `nullable().default(null)` did not seem to work for new requests prior to #327 is because the request type was not passed into the validation
 * 838f5b0ef5760d4a0fd4f2fa21a63a3831aaedce: fixes the timezone issue in the replacement request lost timestamp
   * `lostTimestamp` value stored in the frontend state is a Date object constructed from a YYYY-MM-DD string - *the date constructor defaults to UTC in this case*
   * This UTC timestamp is stored in the database
   * On the read path, the value is displayed in local time
   * For example, say 2023-11-26 is inputted, which is intended to be in PST. This gets stored as 2023-11-26 00:00 UTC in the database. When displayed on the UI, it shows as 2023-11-24 16:00 PST

To prevent such timezone issues in the future, we should review all reads and writes of dates in the application. The requirement is that DB values should always be in UTC, while client-side values should always be in local timezone. Ideally, we centralize conversion to UTC when writing from the client, and conversion to local time when reading from the DB.

(please excuse my computer being unresponsive)
![edit-replacement-request](https://github.com/uwblueprint/richmond-centre-for-disability/assets/30205929/d5c66b23-b01d-42b4-9f7f-ead5d7a4f004)
![create-replacement-request](https://github.com/uwblueprint/richmond-centre-for-disability/assets/30205929/35c0bd62-4a2d-4745-bdba-d3c90bd09726)

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* N/A


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
