### PR TITLE
[Improvement] Clarify lowercase extension requirement for POA form upload

### DIFF
--- a/components/admin/requests/guardian-information/PoaFormUploadField.tsx
+++ b/components/admin/requests/guardian-information/PoaFormUploadField.tsx
@@ -63,7 +63,9 @@ export const PoaFormUploadField: FC<Props> = ({
         {'Upload POA File'}
       </Text>
       <Text color="text.secondary">
-        {'Only ONE file can be added. Files must be .pdf and can be a maximum of 5MB in size.'}{' '}
+        {
+          'Only ONE file can be added. Files must have .pdf extension (lowercase) and can be a maximum of 5MB in size.'
+        }{' '}
       </Text>
       {(file || initialFileUrl) && (
         <>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[POA upload bug](https://www.notion.so/uwblueprintexecs/POA-upload-bug-3b092778a8bd44c2856e639e4c4baeb3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Update copy to clarify that only lowercase pdf extension will be accepted


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* S3 access policy is applied to case-sensitive resource names
* Rather than risking future edge cases by changing the policy, simply communicate the expectation of lowercase to users


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
