### PR TITLE
[Improvement] Change helper text for date of birth

### DIFF
--- a/components/applicant/renewals/IdentityVerification.tsx
+++ b/components/applicant/renewals/IdentityVerification.tsx
@@ -167,10 +167,10 @@ const IdentityVerification: FC = () => {
                 <Box marginBottom={{ sm: '40px', md: '20px' }} textAlign={'left'}>
                   <DateField name="dateOfBirth" label="Date of Birth" width="184px">
                     <FormHelperText>
-                      <Text>Please enter your date of birth in YYYY-MM-DD format.</Text>
                       <Text>
-                        For example, if you were born on 20th August 1950, you would enter
-                        1950-08-20.
+                        If you are on a mobile device, please use the date picker to select your
+                        date of birth. You can click on the year and month at the top of the pop-up
+                        calendar to change them.
                       </Text>
                     </FormHelperText>
                   </DateField>

--- a/components/applicant/renewals/IdentityVerification.tsx
+++ b/components/applicant/renewals/IdentityVerification.tsx
@@ -167,11 +167,9 @@ const IdentityVerification: FC = () => {
                 <Box marginBottom={{ sm: '40px', md: '20px' }} textAlign={'left'}>
                   <DateField name="dateOfBirth" label="Date of Birth" width="184px">
                     <FormHelperText>
-                      <Text>
-                        If you are on a mobile device, please use the date picker to select your
-                        date of birth. You can click on the year and month at the top of the pop-up
-                        calendar to change them.
-                      </Text>
+                      {
+                        'If you are on a mobile device, please use the date picker to select your date of birth. You can click on the year and month at the top of the pop-up calendar to change them.'
+                      }
                     </FormHelperText>
                   </DateField>
                 </Box>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Date of birth helper text](https://www.notion.so/uwblueprintexecs/Date-of-birth-helper-text-7d8a5328ea34443592ba7e0e2985dbfe)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Edit DOB helper text to avoid confusion for those using the mobile date picker
* Mention that the year can be changed by clicking the year for Android users

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
