### PR TITLE
[Fix] Fix formatting of date in donation tax receipt number

### DIFF
--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -467,7 +467,9 @@ const donationPdfDefinition = (input: {
                   body: [
                     [
                       { text: 'Tax Receipt #:' },
-                      `PPD_${dateIssued.getFullYear()}${dateIssued.getMonth()}${dateIssued.getDate()}_${appNumber}`,
+                      `PPD_${dateIssued.getFullYear()}` +
+                        `${('0' + (dateIssued.getMonth() + 1)).slice(-2)}` +
+                        `${dateIssued.getDate()}_${appNumber}`,
                     ],
                     [
                       { text: 'Donated by:' },

--- a/lib/invoices/utils.ts
+++ b/lib/invoices/utils.ts
@@ -425,6 +425,10 @@ const donationPdfDefinition = (input: {
     nonNullEmail,
   } = input;
 
+  const zeroPad = (num: number) => {
+    return ('0' + num.toString()).slice(-2);
+  };
+
   return {
     footer: function (currentPage: number, pageCount: number) {
       return currentPage == pageCount
@@ -468,8 +472,8 @@ const donationPdfDefinition = (input: {
                     [
                       { text: 'Tax Receipt #:' },
                       `PPD_${dateIssued.getFullYear()}` +
-                        `${('0' + (dateIssued.getMonth() + 1)).slice(-2)}` +
-                        `${dateIssued.getDate()}_${appNumber}`,
+                        `${zeroPad(dateIssued.getMonth() + 1)}` +
+                        `${zeroPad(dateIssued.getDate())}_${appNumber}`,
                     ],
                     [
                       { text: 'Donated by:' },


### PR DESCRIPTION
## Notion ticket link
[Donation receipt date issue in file name](https://www.notion.so/uwblueprintexecs/Donation-receipt-date-issue-in-file-name-4d35d47c13754c0486a4f7429d2d3d7a?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
There was an issue with the donation receipt name where it was expected to come in a specified format but the receipt names were consistently off within the date section of the name (`PPD_2024012_31631` instead of `PPD_20240112_31631`). 

From close observation, we can see that the issue is that the month value in the date following the YYYMMDD format is zero-indexed and not zero-padded for single digit values, ie. January is 0 instead of 01. This fix applies one-indexing and zero-padding. 

UPDATE: DD (day of the month) should be formatted to be zero padded as well.

<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes

<img width="1508" alt="image" src="https://github.com/uwblueprint/richmond-centre-for-disability/assets/53355975/a4b06018-f400-4bf9-8f03-954e5081352c">

## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
