### PR TITLE
[Fix] Add AMEX as a second payment option

### DIFF
--- a/components/admin/requests/payment-information/Form.tsx
+++ b/components/admin/requests/payment-information/Form.tsx
@@ -74,6 +74,7 @@ export default function PaymentDetailsForm({ paymentInformation }: PaymentDetail
                 label="Second payment method"
               >
                 <Stack>
+                  <Radio value={'AMEX' as PaymentType}>{'American Express'}</Radio>
                   <Radio value={'MASTERCARD' as PaymentType}>{'Mastercard'}</Radio>
                   <Radio value={'VISA' as PaymentType}>{'Visa'}</Radio>
                   <Radio value={'DEBIT' as PaymentType}>{'Debit'}</Radio>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[AMEX Second Payment](https://www.notion.so/uwblueprintexecs/AMEX-Second-Payment-ee9b39e2ad5846b29b8af9a4f14fd508)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* AMEX was not previously shown as on the form as a second payment option, backend logic should already be correctly implemented


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Testing plan
1. Add a second payment method to a request.
2. Select AMEX as the option.
3. Approve the request.

The steps are outlined in the video below:
<video src=https://github.com/uwblueprint/richmond-centre-for-disability/assets/77544794/42791b26-90d3-494d-bb37-38d8184d0908>


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
