### PR TITLE
move generate report button to reports tab

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -21,7 +21,6 @@ import {
   Wrap,
   Tooltip,
   HStack,
-  useDisclosure,
 } from '@chakra-ui/react'; // Chakra UI
 import { ChevronDownIcon, SearchIcon, AddIcon } from '@chakra-ui/icons'; // Chakra UI Icons
 import Layout from '@components/admin/Layout'; // Layout component
@@ -43,7 +42,6 @@ import useDebounce from '@tools/hooks/useDebounce'; // Debounce hook
 import { Column } from 'react-table';
 import { formatFullName } from '@lib/utils/format'; // String formatter util
 import { formatDateYYYYMMDDLocal } from '@lib/utils/date'; // Date Formatter Util
-import GenerateReportModal from '@components/admin/requests/reports/GenerateModal'; // Generate report modal
 import EmptyMessage from '@components/EmptyMessage';
 
 // Placeholder columns
@@ -129,13 +127,6 @@ const Requests: NextPage = () => {
   // Router
   const router = useRouter();
 
-  //Generate report modal
-  const {
-    isOpen: isGenerateReportModalOpen,
-    onOpen: onOpenGenerateReportModal,
-    onClose: onCloseGenerateReportModal,
-  } = useDisclosure();
-
   // Filters
   const [statusFilter, setStatusFilter] = useState<ApplicationStatus | null>('PENDING');
   const [permitTypeFilter, setPermitTypeFilter] = useState<PermitType | null>(null);
@@ -212,9 +203,6 @@ const Requests: NextPage = () => {
         <Flex justifyContent="space-between" alignItems="center" marginBottom="32px">
           <Text textStyle="display-xlarge">Requests</Text>
           <HStack spacing="12px">
-            <Button height="48px" variant="outline" onClick={onOpenGenerateReportModal}>
-              Generate a Report
-            </Button>
             <Menu>
               <MenuButton
                 as={Button}
@@ -417,10 +405,6 @@ const Requests: NextPage = () => {
           </Box>
         </Box>
       </GridItem>
-      <GenerateReportModal
-        isOpen={isGenerateReportModalOpen}
-        onClose={onCloseGenerateReportModal}
-      />
     </Layout>
   );
 };

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -1,6 +1,16 @@
 import { GetServerSideProps } from 'next'; // Get server side props
 import { getSession } from 'next-auth/client'; // Session management
-import { Text, GridItem, Box, Flex, Input, Button, Spinner, useToast } from '@chakra-ui/react'; // Chakra UI
+import {
+  Text,
+  GridItem,
+  Box,
+  Flex,
+  Input,
+  Button,
+  Spinner,
+  useToast,
+  useDisclosure,
+} from '@chakra-ui/react'; // Chakra UI
 import Layout from '@components/admin/Layout'; // Layout component
 import { authorize } from '@tools/authorization'; // Page authorization
 import { DownloadIcon } from '@chakra-ui/icons'; // Chakra UI icons
@@ -12,9 +22,16 @@ import {
   GenerateAccountantReportResponse,
 } from '@tools/admin/permit-holders/graphql/generate-report';
 import EmptyMessage from '@components/EmptyMessage';
+import GenerateReportModal from '@components/admin/requests/reports/GenerateModal'; // Generate report modal
 
 // Internal home page
 export default function Reports() {
+  //Generate report modal
+  const {
+    isOpen: isGenerateReportModalOpen,
+    onOpen: onOpenGenerateReportModal,
+    onClose: onCloseGenerateReportModal,
+  } = useDisclosure();
   // const { dateRange, addDayToDateRange, dateRangeString } = useDateRangePicker();
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
@@ -61,6 +78,9 @@ export default function Reports() {
       <GridItem colSpan={12}>
         <Flex justifyContent="space-between" alignItems="center" marginBottom="32px">
           <Text textStyle="display-xlarge">Accountant Reports</Text>
+          <Button height="48px" variant="outline" onClick={onOpenGenerateReportModal}>
+            Generate a Report
+          </Button>
         </Flex>
         <Box
           border="1px solid"
@@ -139,6 +159,10 @@ export default function Reports() {
           </Box>
         </Box>
       </GridItem>
+      <GenerateReportModal
+        isOpen={isGenerateReportModalOpen}
+        onClose={onCloseGenerateReportModal}
+      />
     </Layout>
   );
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Move the ability to generate application reports from the Request page to the Reports tab](https://www.notion.so/uwblueprintexecs/aa20981f03614ff5a1b2ee2f78aba4cc?v=63e8bea779664acbb10b1ea094e0fdcc&p=5e4db096e41d482facfae986f611fa22&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Accounting admins will only need to see and access the generate report button so it's moved from the request tab to report tab


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* report tab page should have generate report button
* request page should just have create request button


## Checklist
- [X] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
