### PR TITLE
[Fix] Fix names being clipped in table cell content

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -60,7 +60,7 @@ const COLUMNS: Column<ApplicationRow>[] = [
               maxWidth="280"
               whiteSpace="nowrap"
               textOverflow="ellipsis"
-              overflow="hidden"
+              overflow="clip visible"
               mb="4px"
             >
               {name}

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -187,7 +187,7 @@ const PermitHolders: NextPage = () => {
                   maxWidth="180"
                   whiteSpace="nowrap"
                   textOverflow="ellipsis"
-                  overflow="hidden"
+                  overflow="clip visible"
                   mb="4px"
                 >
                   {name}

--- a/prisma/dev-seed-utils/employees.ts
+++ b/prisma/dev-seed-utils/employees.ts
@@ -107,7 +107,7 @@ const employees = [
   {
     firstName: 'Jennifer',
     lastName: 'Chen',
-    email: 'jenn.chenn93+employee@gmail.com',
+    email: 'jenniferchen+employee@uwblueprint.org',
   },
 ];
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Some letters in names are cut off for those listed under requests and permit holders (ie. 'g', 'q', 'y').](https://www.notion.so/uwblueprintexecs/RCD-Some-letters-in-names-are-cut-off-for-those-listed-under-requests-and-permit-holders-ie-g--ec59bdf999ae4d6f9cf63305cfe1bad8?pvs=4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set `overflow-y: visible` in table rows to avoid having names with tall letters (g, q, y) being cut-off
* Update the email being used for my "employee" account


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Can be verified by checking the requests/permit holders tables and checking that names with letters g/q/y are no longer cut off (seed data does not include one by default I believe)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
