### PR TITLE
[Fix] Force network call for accountant report download

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/pages/admin/reports.tsx
+++ b/pages/admin/reports.tsx
@@ -25,6 +25,7 @@ export default function Reports() {
     GenerateAccountantReportResponse,
     GenerateAccountantReportRequest
   >(GENERATE_ACCOUNTANT_REPORT_QUERY, {
+    fetchPolicy: 'network-only',
     onCompleted: data => {
       if (data.generateAccountantReport.ok && !!data.generateAccountantReport.url) {
         const link = document.createElement('a');


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Accountant reports with the same start/end date cannot be redownloaded](https://www.notion.so/uwblueprintexecs/RCD-Accountant-reports-with-the-same-start-end-date-cannot-be-redownloaded-e5f09d8cb99e4f0784e38a187b69ecd0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
S3 URL for the generated file expires after 10 seconds (second argument to `getSignedUrlForS3`). Since the Apollo client caches results of all GraphQL queries by default, repeated downloads with the same start and end dates return the same S3 URL, which would be expired. The solution is to force a network call when generating the accountant report in order to always get a fresh URL.
https://github.com/uwblueprint/richmond-centre-for-disability/blob/a9231a39bcf418bea6ebdb6b7a5498aa354ee098/lib/reports/resolvers.ts#L722


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
Also added VS Code setting to use workspace version of Typescript


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
