### PR TITLE
[enhancement] Track application status to return to original tab in admin view

### DIFF
--- a/components/admin/requests/Header.tsx
+++ b/components/admin/requests/Header.tsx
@@ -25,6 +25,7 @@ import { ApplicationStatus, ApplicationType, PermitType } from '@lib/graphql/typ
 import { titlecase } from '@tools/string';
 import { formatDateYYYYMMDD, formatDateYYYYMMDDLocal } from '@lib/utils/date';
 import { getPermanentPermitExpiryDate } from '@lib/utils/permit-expiry';
+import { useEffect, useState } from 'react'; // React
 
 type RequestHeaderProps = {
   readonly id: number;
@@ -87,6 +88,22 @@ export default function RequestHeader({
 
   const router = useRouter();
 
+  const [backLink, setBackLink] = useState('/admin');
+  const generateBackLink = () => {
+    let status;
+    const routerQuery = router.query;
+    if (routerQuery === undefined || routerQuery.origin === undefined) {
+      status = applicationStatus;
+    } else {
+      status = routerQuery.origin;
+    }
+    setBackLink(`/admin?tab=${status}`);
+  };
+
+  useEffect(() => {
+    generateBackLink();
+  }, []);
+
   // Delete application modal state
   const {
     isOpen: isDeleteApplicationModalOpen,
@@ -96,12 +113,13 @@ export default function RequestHeader({
 
   return (
     <Box textAlign="left">
-      <NextLink href="/admin" passHref>
+      <NextLink href={backLink} passHref>
         <Text textStyle="button-semibold" textColor="primary" as="a">
           <ChevronLeftIcon />
           All requests
         </Text>
       </NextLink>
+
       <VStack alignItems="stretch">
         <Flex marginTop={5} alignItems="baseline" justifyContent="space-between">
           <Box>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -71,7 +71,7 @@ export const getTabIndex = (routerQuery: RouterQuery): number => {
   }
 };
 
-const tabIndexToStatus: { [key: number]: string } = {
+const tabIndexToStatus: { [key: number]: ApplicationStatus | 'ALL' } = {
   0: 'ALL',
   1: 'PENDING',
   2: 'IN_PROGRESS',


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[RCD] Resuming on the previous page](https://www.notion.so/uwblueprintexecs/RCD-Resuming-on-the-previous-page-9de56dfe2f4d4cbbb0b321d6fa04322f?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Pass application status in router query to keep track of which tab user originated from
* Return to original tab when user clicks `← All Requests`


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Default when navigating to `/admin` is to show the `Pending` applications
* If the user navigates to a request specifically (i.e. without `?origin=`) and then clicks  `← All Requests`, it will bring them back to the same tab as the application's status
  * I couldn't bring the user back to the same tab as the application status in all scenarios due to the `All` tab

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
