### PR TITLE
Update permit form links

### DIFF
--- a/components/applicant/FAQs.tsx
+++ b/components/applicant/FAQs.tsx
@@ -200,7 +200,7 @@ const OVERVIEW_FAQs: ReadonlyArray<{ question: string; answer: ReactNode | strin
           event that you find the lost permit you will return it to our office as the permit is no
           longer valid. Any permit holder using a permit that has been reported lost is at risk of a
           ticket or even towing of vehicle as this permit is no longer valid.{' '}
-          <NewTabLink href="https://www.rcdrichmond.org/Parking/PermitReplacementDeclarationForm_2022%20v.pdf">
+          <NewTabLink href="https://www.rcdrichmond.org/Parking/Permit_Replacement_Declaration_Form_Fillable_2024v.pdf">
             Click here
           </NewTabLink>{' '}
           to download the Replacement Declaration Form.
@@ -220,7 +220,7 @@ const OVERVIEW_FAQs: ReadonlyArray<{ question: string; answer: ReactNode | strin
         <p>
           The police will also give you an incident or case number to include with your request for
           a Replacement Permit.{' '}
-          <NewTabLink href="https://www.rcdrichmond.org/Parking/PermitReplacementDeclarationForm_2022%20v.pdf">
+          <NewTabLink href="https://www.rcdrichmond.org/Parking/Permit_Replacement_Declaration_Form_Fillable_2024v.pdf">
             Click here
           </NewTabLink>{' '}
           to download the Replacement Declaration Form.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -127,7 +127,7 @@ export default function Landing() {
           </Box>
           <VStack width="100%" alignItems={{ sm: 'center', lg: 'flex-start' }} spacing="32px">
             <a
-              href="https://www.rcdrichmond.org/Parking/Parking_Permit_Application_Form_Fillable_2023v.pdf"
+              href="https://www.rcdrichmond.org/Parking/Parking_Permit_Application_Form_Fillable_2024v.pdf"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -146,7 +146,7 @@ export default function Landing() {
               </Button>
             </a>
             <a
-              href="https://www.rcdrichmond.org/Parking/Permit_Replacement_Declaration_Form_Fillable_2023v.pdf"
+              href="https://www.rcdrichmond.org/Parking/Permit_Replacement_Declaration_Form_Fillable_2024v.pdf"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Use the 2024 links for the permit replacement and application forms

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update forms on RCD website](https://www.notion.so/uwblueprintexecs/RCD-Update-forms-on-RCD-website-981476e69c8f48b6aea006dc21d4c1fb)