### PR TITLE
[Improvement] Add pagination controls to top of requests/permit holders tables

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -408,6 +408,14 @@ const Requests: NextPage = () => {
             </Flex>
             {requestsData.length > 0 ? (
               <>
+                <Flex justifyContent="flex-end">
+                  <Pagination
+                    pageNumber={pageNumber}
+                    pageSize={PAGE_SIZE}
+                    totalCount={recordsCount}
+                    onPageChange={setPageNumber}
+                  />
+                </Flex>
                 <Table
                   columns={COLUMNS}
                   data={requestsData}

--- a/pages/admin/permit-holders.tsx
+++ b/pages/admin/permit-holders.tsx
@@ -494,6 +494,14 @@ const PermitHolders: NextPage = () => {
             </VStack>
             {permitHolderData && permitHolderData.length > 0 ? (
               <>
+                <Flex justifyContent="flex-end">
+                  <Pagination
+                    pageNumber={pageNumber}
+                    pageSize={PAGE_SIZE}
+                    totalCount={recordsCount}
+                    onPageChange={setPageNumber}
+                  />
+                </Flex>
                 <Table
                   columns={COLUMNS}
                   data={permitHolderData || []}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add page scroll to top of permit holders and requests pages](https://www.notion.so/uwblueprintexecs/RCD-Add-page-scroll-to-top-of-permit-holders-and-requests-pages-64d806a816314c24948385a7f4113bf5?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add ability to switch page to the top of requests/permit holders tables


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
