### PR TITLE
[Improvement] Sort permit past applications

### DIFF
--- a/components/admin/permit-holders/app-history/Card/index.tsx
+++ b/components/admin/permit-holders/app-history/Card/index.tsx
@@ -2,7 +2,6 @@ import { StackDivider, VStack } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/LayoutCard'; // Custom Card Component
 import { PermitRecord } from '@tools/admin/permit-holders/app-history';
 import AppHistoryRecord from '@components/admin/permit-holders/app-history/Card/AppHistoryRecord';
-import { Permit } from '@lib/graphql/types';
 
 type Props = {
   readonly appHistory: ReadonlyArray<PermitRecord>;
@@ -21,7 +20,7 @@ export default function AppHistoryCard({ appHistory }: Props) {
       >
         {appHistory
           .slice()
-          .sort(function (a: Permit, b: Permit) {
+          .sort(function (a: PermitRecord, b: PermitRecord) {
             const aCreated = a.application.createdAt;
             const bCreated = b.application.createdAt;
             return aCreated < bCreated ? 1 : aCreated > bCreated ? -1 : 0;

--- a/components/admin/permit-holders/app-history/Card/index.tsx
+++ b/components/admin/permit-holders/app-history/Card/index.tsx
@@ -2,6 +2,7 @@ import { StackDivider, VStack } from '@chakra-ui/react'; // Chakra UI
 import PermitHolderInfoCard from '@components/admin/LayoutCard'; // Custom Card Component
 import { PermitRecord } from '@tools/admin/permit-holders/app-history';
 import AppHistoryRecord from '@components/admin/permit-holders/app-history/Card/AppHistoryRecord';
+import { Permit } from '@lib/graphql/types';
 
 type Props = {
   readonly appHistory: ReadonlyArray<PermitRecord>;
@@ -18,9 +19,16 @@ export default function AppHistoryCard({ appHistory }: Props) {
         spacing="16px"
         divider={<StackDivider borderColor="border.secondary" />}
       >
-        {appHistory.map(permit => (
-          <AppHistoryRecord key={permit.application.id} permit={permit} />
-        ))}
+        {appHistory
+          .slice()
+          .sort(function (a: Permit, b: Permit) {
+            const aCreated = a.application.createdAt;
+            const bCreated = b.application.createdAt;
+            return aCreated < bCreated ? 1 : aCreated > bCreated ? -1 : 0;
+          })
+          .map(permit => (
+            <AppHistoryRecord key={permit.application.id} permit={permit} />
+          ))}
       </VStack>
     </PermitHolderInfoCard>
   );

--- a/tools/admin/permit-holders/app-history.ts
+++ b/tools/admin/permit-holders/app-history.ts
@@ -2,7 +2,7 @@ import { Application, ApplicationProcessing, Invoice, Permit } from '@lib/graphq
 
 /** APP history entry record (API response) */
 export type AppHistoryRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
-  application: Pick<Application, 'id' | 'type' | 'permitType'> & {
+  application: Pick<Application, 'id' | 'type' | 'permitType' | 'createdAt'> & {
     processing: Pick<ApplicationProcessing, 'documentsUrl' | 'documentsS3ObjectKey'> & {
       invoice: Pick<Invoice, 's3ObjectUrl' | 's3ObjectKey'>;
     };
@@ -11,7 +11,7 @@ export type AppHistoryRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
 
 /** APP history entry row in APP history card (FE) */
 export type PermitRecord = Pick<Permit, 'rcdPermitId' | 'expiryDate'> & {
-  application: Pick<Application, 'id' | 'type' | 'permitType'> & {
+  application: Pick<Application, 'id' | 'type' | 'permitType' | 'createdAt'> & {
     processing: Pick<ApplicationProcessing, 'documentsUrl' | 'documentsS3ObjectKey'> & {
       invoice: Pick<Invoice, 's3ObjectUrl' | 's3ObjectKey'>;
     };

--- a/tools/admin/permit-holders/view-permit-holder.ts
+++ b/tools/admin/permit-holders/view-permit-holder.ts
@@ -92,6 +92,7 @@ export const GET_APPLICANT_QUERY = gql`
           id
           type
           permitType
+          createdAt
           processing {
             documentsUrl
             documentsS3ObjectKey


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Reorder permit listings to show the most recent permit requests at the top](https://www.notion.so/uwblueprintexecs/RCD-Permit-Holders-Reorder-permit-listings-to-show-the-most-recent-permit-requests-at-the-top-of--10810f3fb1dc80d2b8c5cab56f12ca6d?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Sort past applications by creation timestamp in permit holder page


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* Did we want to sort by another dimension (updates? by type?)


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
