### PR TITLE
[Improvement] Remove completed request deletion

### DIFF
--- a/components/admin/requests/Header.tsx
+++ b/components/admin/requests/Header.tsx
@@ -26,6 +26,7 @@ import { titlecase } from '@tools/string';
 import { formatDateYYYYMMDD, formatDateYYYYMMDDLocal } from '@lib/utils/date';
 import { getPermanentPermitExpiryDate } from '@lib/utils/permit-expiry';
 import { useEffect, useState } from 'react'; // React
+import { CurrentApplication } from '@tools/admin/permit-holders/current-application';
 
 type RequestHeaderProps = {
   readonly id: number;
@@ -39,6 +40,7 @@ type RequestHeaderProps = {
   readonly permitExpiry: Date | null;
   readonly temporaryPermitExpiry: Date | null;
   readonly reasonForRejection?: string;
+  readonly mostRecentApplication: CurrentApplication | null;
 };
 
 /**
@@ -67,6 +69,7 @@ export default function RequestHeader({
   permitExpiry,
   temporaryPermitExpiry,
   reasonForRejection,
+  mostRecentApplication,
 }: RequestHeaderProps) {
   const displayShopifyUrl = paidThroughShopify && shopifyOrderID && shopifyOrderNumber;
   const shopifyOrderUrl = `https://${process.env.NEXT_PUBLIC_SHOPIFY_DOMAIN}/admin/orders/${shopifyOrderID}`;
@@ -149,13 +152,15 @@ export default function RequestHeader({
                   <Text textStyle="caption">More Actions</Text>
                 </MenuButton>
                 <MenuList>
-                  <MenuItem
-                    color="text.critical"
-                    textStyle="button-regular"
-                    onClick={onOpenDeleteApplicationModal}
-                  >
-                    {'Delete Request'}
-                  </MenuItem>
+                  {mostRecentApplication?.processing?.status == 'COMPLETED' ? null : (
+                    <MenuItem
+                      color="text.critical"
+                      textStyle="button-regular"
+                      onClick={onOpenDeleteApplicationModal}
+                    >
+                      {'Delete Request'}
+                    </MenuItem>
+                  )}
                 </MenuList>
               </Menu>
             </HStack>

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -19,6 +19,7 @@ import {
 } from '@tools/admin/requests/view-request'; // Request page GraphQL queries
 import ReasonForReplacementCard from '@components/admin/requests/reason-for-replacement/Card';
 import GuardianInformationCard from '@components/admin/requests/guardian-information/Card';
+import { CurrentApplication } from '@tools/admin/permit-holders/current-application';
 
 type Props = {
   readonly id: string;
@@ -65,6 +66,8 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
 
   // Get expiry date to display
   const mostRecentPermitExpiryDate = data.application.applicant?.mostRecentPermit?.expiryDate;
+  const mostRecentApplication: CurrentApplication | null =
+    data.application.applicant?.mostRecentApplication;
   const permitExpiry =
     type === 'REPLACEMENT' ? mostRecentPermitExpiryDate : permit ? permit.expiryDate : null;
 
@@ -97,6 +100,7 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
           permitExpiry={permitExpiry}
           temporaryPermitExpiry={temporaryPermitExpiry || null}
           reasonForRejection={rejectedReason || undefined}
+          mostRecentApplication={mostRecentApplication}
         />
       </GridItem>
       <GridItem colStart={1} colSpan={5} textAlign="left">

--- a/tools/admin/requests/view-request.ts
+++ b/tools/admin/requests/view-request.ts
@@ -7,6 +7,7 @@ import {
   QueryApplicationArgs,
   Permit,
 } from '@lib/graphql/types';
+import { CurrentApplication } from '@tools/admin/permit-holders/current-application';
 
 // Queries an Application by ID along with the associated permit, replacement, applicationProcessing, and applicant
 export const GET_APPLICATION_QUERY = gql`
@@ -42,6 +43,11 @@ export const GET_APPLICATION_QUERY = gql`
         id
         mostRecentPermit {
           expiryDate
+        }
+        mostRecentApplication {
+          processing {
+            status
+          }
         }
       }
       permit {
@@ -82,6 +88,7 @@ export type GetApplicationResponse = {
     };
     applicant: Pick<Applicant, 'id'> & {
       mostRecentPermit: Pick<Permit, 'expiryDate'> | null;
+      mostRecentApplication: CurrentApplication | null;
     };
     temporaryPermitExpiry?: Date;
     permit: Pick<Permit, 'expiryDate'> | null;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Modify user deletion in requests page](https://www.notion.so/uwblueprintexecs/RCD-Modify-user-deletion-in-requests-page-14a10f3fb1dc80928224fbc5954adae8?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* I removed the option to delete a request that has been completed.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
