### PR TITLE
[Feature] Add editable page numbers

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,5 +1,6 @@
-import { HStack, Text, IconButton } from '@chakra-ui/react'; // Chakra UI
+import { HStack, Text, IconButton, Input } from '@chakra-ui/react'; // Chakra UI
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons'; // Chakra UI Icons
+import { useState } from 'react';
 
 type Props = {
   readonly pageSize: number; // Number of items per page
@@ -22,12 +23,15 @@ export default function Pagination(props: Props) {
   const lowerBound = totalCount === 0 ? 0 : pageNumber * pageSize + 1; // Lower bound of current page (item #)
   const upperBound = isLastPage ? totalCount : (pageNumber + 1) * pageSize; // Upper bound of current page (item #)
 
+  const [inputValue, setInputValue] = useState<string | number>(pageNumber + 1);
+
   /**
    * Go to the next page if possible, and invoke callback if defined
    */
   const goToNextPage = () => {
     if (!isLastPage) {
       onPageChange(pageNumber + 1);
+      setInputValue(pageNumber + 2);
     }
   };
 
@@ -37,6 +41,34 @@ export default function Pagination(props: Props) {
   const goToPreviousPage = () => {
     if (!isFirstPage) {
       onPageChange(pageNumber - 1);
+      setInputValue(pageNumber);
+    }
+  };
+
+  /**
+   * Handle direct page number input
+   */
+  const handlePageInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '') {
+      setInputValue(value); // Allow empty string for cleared input
+    } else {
+      const numericValue = Number(value);
+      if (!isNaN(numericValue) && numericValue > 0 && numericValue <= totalPages) {
+        setInputValue(numericValue);
+      }
+    }
+  };
+
+  /**
+   * Navigate to the page number entered in the input field
+   */
+  const goToPage = () => {
+    const targetPage = Number(inputValue) - 1;
+    if (!isNaN(targetPage) && targetPage >= 0 && targetPage < totalPages) {
+      onPageChange(targetPage);
+    } else {
+      setInputValue(pageNumber + 1); // Reset input to the current page if invalid
     }
   };
 
@@ -68,6 +100,19 @@ export default function Pagination(props: Props) {
           aria-label="previous page"
           disabled={isFirstPage}
           onClick={goToPreviousPage}
+        />
+        <Input
+          value={inputValue}
+          width="50px"
+          height="24px"
+          textAlign="center"
+          onChange={handlePageInput}
+          onBlur={goToPage}
+          onKeyPress={e => {
+            if (e.key === 'Enter') {
+              goToPage();
+            }
+          }}
         />
         <IconButton
           icon={<ChevronRightIcon />}

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -23,10 +23,12 @@ export default function Pagination(props: Props) {
   const lowerBound = totalCount === 0 ? 0 : pageNumber * pageSize + 1; // Lower bound of current page (item #)
   const upperBound = isLastPage ? totalCount : (pageNumber + 1) * pageSize; // Upper bound of current page (item #)
 
-  const [inputValue, setInputValue] = useState<string | number>(pageNumber + 1);
+  const [inputValue, setInputValue] = useState<string | number>(pageNumber + 1); // Display page number as 1-based index
 
   /**
    * Go to the next page if possible, and invoke callback if defined
+   * `pageNumber + 1` moves to the next page (zero-based index)
+   * `pageNumber + 2` updates the input field to reflect the 1-based page number
    */
   const goToNextPage = () => {
     if (!isLastPage) {
@@ -37,6 +39,8 @@ export default function Pagination(props: Props) {
 
   /**
    * Go to the previous page if possible, and invoke callback if defined
+   * `pageNumber - 1` moves to the previous page (zero-based index)
+   * `pageNumber` updates the input field to reflect the 1-based page number
    */
   const goToPreviousPage = () => {
     if (!isFirstPage) {
@@ -62,6 +66,7 @@ export default function Pagination(props: Props) {
 
   /**
    * Navigate to the page number entered in the input field
+   * Convert the 1-based user input into zero-based index
    */
   const goToPage = () => {
     const targetPage = Number(inputValue) - 1;
@@ -84,12 +89,9 @@ export default function Pagination(props: Props) {
         <Text as="p" textStyle="xsmall" display="inline">
           {totalCount !== 0 ? `${lowerBound}-${upperBound}` : 0}
         </Text>
-        <Text
-          as="p"
-          textStyle="xsmall"
-          display="inline"
-          color="texticon.secondary"
-        >{`of ${totalCount}`}</Text>
+        <Text as="p" textStyle="xsmall" display="inline" color="texticon.secondary">
+          {`of ${totalCount}`}
+        </Text>
       </HStack>
       <HStack spacing="0">
         <IconButton
@@ -114,6 +116,9 @@ export default function Pagination(props: Props) {
             }
           }}
         />
+        <Text as="p" textStyle="xsmall" display="inline" marginX="4px">
+          {` / ${totalPages}`}
+        </Text>
         <IconButton
           icon={<ChevronRightIcon />}
           height="24px"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Permit holder and request page scroll enhancement](https://www.notion.so/uwblueprintexecs/RCD-Permit-holder-and-request-page-scroll-enhancement-14a10f3fb1dc80c48b4ec77a5cc94f46?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Adds a text input field to the Pagination component so a page can be specified by typing
* I chose to do the validation upon keyboard input rather than upon hitting of the enter key. I thought this might be less confusing for the user.


https://github.com/user-attachments/assets/f0da7f1f-9624-4052-ab2d-80e44d2723b1



## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
