### PR TITLE
[Fix] Fixed Finanical Report Header Order

### DIFF
--- a/tools/admin/reports.ts
+++ b/tools/admin/reports.ts
@@ -25,14 +25,14 @@ export const APPLICATIONS_COLUMNS: Array<{
     reportColumnId: 'applicantName',
   },
   {
-    name: 'Applicant DoB',
-    value: 'APPLICANT_DATE_OF_BIRTH',
-    reportColumnId: 'dateOfBirth',
-  },
-  {
     name: 'APP Number',
     value: 'APP_NUMBER',
     reportColumnId: 'rcdPermitId',
+  },
+  {
+    name: 'Applicant DoB',
+    value: 'APPLICANT_DATE_OF_BIRTH',
+    reportColumnId: 'dateOfBirth',
   },
   {
     name: 'Phone Number',
@@ -50,11 +50,6 @@ export const APPLICATIONS_COLUMNS: Array<{
     ],
   },
   {
-    name: 'Donation Amount',
-    value: 'DONATION_AMOUNT',
-    reportColumnId: 'donationAmount',
-  },
-  {
     name: 'Payment Method',
     value: 'PAYMENT_METHOD',
     reportColumnId: 'paymentMethod',
@@ -65,9 +60,9 @@ export const APPLICATIONS_COLUMNS: Array<{
     reportColumnId: 'processingFee',
   },
   {
-    name: 'Second Donation Amount',
-    value: 'SECOND_DONATION_AMOUNT',
-    reportColumnId: 'secondDonationAmount',
+    name: 'Donation Amount',
+    value: 'DONATION_AMOUNT',
+    reportColumnId: 'donationAmount',
   },
   {
     name: 'Second Payment Method',
@@ -80,14 +75,19 @@ export const APPLICATIONS_COLUMNS: Array<{
     reportColumnId: 'secondProcessingFee',
   },
   {
-    name: 'Application Date',
-    value: 'APPLICATION_DATE',
-    reportColumnId: 'applicationDate',
+    name: 'Second Donation Amount',
+    value: 'SECOND_DONATION_AMOUNT',
+    reportColumnId: 'secondDonationAmount',
   },
   {
     name: 'Total Amount',
     value: 'TOTAL_AMOUNT',
     reportColumnId: 'totalAmount',
+  },
+  {
+    name: 'Application Date',
+    value: 'APPLICATION_DATE',
+    reportColumnId: 'applicationDate',
   },
   {
     name: 'Invoice Receipt #',


### PR DESCRIPTION
## Notion ticket link
Change accountant report csv header order(https://www.notion.so/uwblueprintexecs/Change-accountant-report-csv-header-order-f4dd57e9ad67418698f8bf48e9a22844)


## Implementation description
Changed the order of the account report csv to better reflect the needs of the accounting department.


## Notes
* Some headings had different names compared to the titles mentioned in the email. All names were left in their original form.


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
