### PR TITLE
[Improvement] Track page number to return to original page in admin view

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,6 +1,6 @@
 import { HStack, Text, IconButton, Input } from '@chakra-ui/react'; // Chakra UI
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons'; // Chakra UI Icons
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type Props = {
   readonly pageSize: number; // Number of items per page
@@ -24,6 +24,10 @@ export default function Pagination(props: Props) {
   const upperBound = isLastPage ? totalCount : (pageNumber + 1) * pageSize; // Upper bound of current page (item #)
 
   const [inputValue, setInputValue] = useState<string | number>(pageNumber + 1); // Display page number as 1-based index
+
+  useEffect(() => {
+    setInputValue(pageNumber + 1);
+  }, [pageNumber]);
 
   /**
    * Go to the next page if possible, and invoke callback if defined

--- a/components/admin/requests/Header.tsx
+++ b/components/admin/requests/Header.tsx
@@ -93,14 +93,10 @@ export default function RequestHeader({
 
   const [backLink, setBackLink] = useState('/admin');
   const generateBackLink = () => {
-    let status;
     const routerQuery = router.query;
-    if (routerQuery === undefined || routerQuery.origin === undefined) {
-      status = applicationStatus;
-    } else {
-      status = routerQuery.origin;
-    }
-    setBackLink(`/admin?tab=${status}`);
+    const status = typeof routerQuery.tab === 'string' ? routerQuery.tab : applicationStatus;
+    const page = typeof routerQuery.page === 'string' ? routerQuery.page : '0';
+    setBackLink(`/admin?tab=${status}&page=${page}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[RCD] Resume on the previous tab after viewing user profile](https://www.notion.so/uwblueprintexecs/RCD-Resume-on-the-previous-tab-after-viewing-user-profile-14a10f3fb1dc80929bbdc2fa219828e2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add ability to continue from previous page after clicking `← All Requests`
* Fix bug with paginations numbers not aligning


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
