### PR TITLE
Enhance GraphQL logging; make Apollo SSR-safe

### DIFF
--- a/lib/graphql/middleware/logging.ts
+++ b/lib/graphql/middleware/logging.ts
@@ -11,28 +11,47 @@ const middleware: IMiddleware = async (resolve, root, args, context, info) => {
 
   const resolverName = info.fieldName;
   const operationName = info.operation.name?.value;
+  const operationLabel = operationName || resolverName;
+  const startTime = Date.now();
+  const logContext = {
+    resolver: resolverName,
+    operation: operationLabel,
+  };
 
   logger.info(
     {
-      resolver: resolverName,
-      operation: operationName,
-      ...(logger.level === 'info' && { args }),
+      ...logContext,
+      ...(logger.level === 'debug' && { args }),
     },
-    `START: ${operationName}`
+    `START: ${operationLabel}`
   );
 
-  const result = await resolve(root, args, context, info);
+  try {
+    const result = await resolve(root, args, context, info);
 
-  logger.info(
-    {
-      resolver: resolverName,
-      operation: operationName,
-      ...(logger.level === 'info' && { result }),
-    },
-    `FINISH: ${operationName}`
-  );
+    logger.info(
+      {
+        ...logContext,
+        durationMs: Date.now() - startTime,
+      },
+      `FINISH: ${operationLabel}`
+    );
 
-  return result;
+    return result;
+  } catch (error) {
+    logger.error(
+      {
+        ...logContext,
+        durationMs: Date.now() - startTime,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : error,
+      },
+      `ERROR: ${operationLabel}`
+    );
+    throw error;
+  }
 };
 
 export default middleware;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,23 +1,42 @@
 import { AppProps } from 'next/app'; // Next types
 import { ChakraProvider } from '@chakra-ui/react'; // ChakraProvider
-import { ApolloClient, InMemoryCache } from '@apollo/client'; // Apollo client
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client'; // Apollo client
 import { ApolloProvider } from '@apollo/client/react'; // Apollo provider
 import { appWithTranslation } from 'next-i18next'; // HOC for adding translation to _app
 import { Provider } from 'next-auth/client'; // Next Auth provider
+import { useState } from 'react';
 import RenewalFlow from '@containers/RenewalFlow'; // Renewal flow state
 
 import theme from '@tools/theme'; // Design system theme config
 import '@fontsource/noto-sans/400.css'; // Noto sans normal
 import '@fontsource/noto-sans/700.css'; // Noto sans bold
 
-const apolloClient = new ApolloClient({
-  uri: '/api/graphql',
-  cache: new InMemoryCache({
-    addTypename: false,
-  }),
-});
+let browserApolloClient: ApolloClient<NormalizedCacheObject> | null = null;
+
+const createApolloClient = () =>
+  new ApolloClient({
+    uri: '/api/graphql',
+    ssrMode: typeof window === 'undefined',
+    cache: new InMemoryCache({
+      addTypename: false,
+    }),
+  });
+
+const getApolloClient = () => {
+  if (typeof window === 'undefined') {
+    return createApolloClient();
+  }
+
+  if (browserApolloClient === null) {
+    browserApolloClient = createApolloClient();
+  }
+
+  return browserApolloClient;
+};
 
 function App({ Component, pageProps }: AppProps) {
+  const [apolloClient] = useState(() => getApolloClient());
+
   return (
     <Provider session={pageProps.session}>
       <RenewalFlow.Provider>


### PR DESCRIPTION
Improve GraphQL middleware logging by adding an operation label fallback, startTime/durationMs, and a shared logContext. Args are now emitted only at debug level; resolver execution is wrapped in try/catch to log structured errors (name, message, stack) on failure and to record duration on finish.

Make Apollo client SSR-safe in _app: add createApolloClient/getApolloClient helpers, cache a browser-only client instance, enable ssrMode on the server, and initialize the client via useState to avoid sharing a single client across requests.

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/ac7b1f636a214a0cbf45f6b76f899b54?v=5414ee5fc5974f149921e192d6eb29b8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- Catch all section that could be used to draw attention to anything the reviewers should keep in mind, substantial parts of your PR, anything you'd like a second opinion on, things that will be fixed in the future, or things that were left out -->
## Notes
* 


## Checklist
- [ ] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket
