### PR TITLE
[Improvement] Hide Additional Information section

### DIFF
--- a/components/admin/permit-holders/current-application/Card/index.tsx
+++ b/components/admin/permit-holders/current-application/Card/index.tsx
@@ -8,7 +8,8 @@ import { FC, useMemo } from 'react';
 import Header from '@components/admin/permit-holders/current-application/Card/Header';
 import AttachedFilesSection from '@components/admin/permit-holders/current-application/Card/AttachedFilesSection';
 import MedicalInformationSection from '@components/admin/permit-holders/current-application/Card/MedicalInformationSection';
-import AdditionalInformationSection from '@components/admin/permit-holders/current-application/Card/AdditionalInformationSection';
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalInformationSection from '@components/admin/permit-holders/current-application/Card/AdditionalInformationSection';
 
 type Props = {
   readonly application: CurrentApplication;
@@ -52,9 +53,11 @@ const CurrentApplicationCard: FC<Props> = ({ application, applicantMedicalInform
       <VStack width="100%" align="stretch" spacing="24px">
         <AttachedFilesSection application={application} />
         <MedicalInformationSection medicalInformation={medicalInformation} />
+        {/* HIDDEN [RCD] Remove Additional Information Section:
         {(type === 'NEW' || type === 'RENEWAL') && (
           <AdditionalInformationSection application={application} />
         )}
+        */}
       </VStack>
     </PermitHolderInfoCard>
   );

--- a/components/admin/requests/processing/ReviewInformationStep.tsx
+++ b/components/admin/requests/processing/ReviewInformationStep.tsx
@@ -9,7 +9,8 @@ import DoctorInformationCard from '@components/admin/requests/doctor-information
 import PaymentInformationCard from '@components/admin/requests/payment-information/Card'; // Payment information card
 import PersonalInformationCard from '@components/admin/requests/permit-holder-information/Card'; // Personal information card
 import ReasonForReplacementCard from '@components/admin/requests/reason-for-replacement/Card';
-import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card';
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card';
 import GuardianInformationCard from '@components/admin/requests/guardian-information/Card';
 import UndoReviewRequestModal from '@components/admin/requests/processing/UndoReviewRequestModal';
 
@@ -69,7 +70,9 @@ export default function ReviewInformationStep({
           <>
             <PersonalInformationCard applicationId={applicationId} editDisabled isSubsection />
             <DoctorInformationCard applicationId={applicationId} editDisabled isSubsection />
+            {/* HIDDEN [RCD] Remove Additional Information Section:
             <AdditionalInformationCard applicationId={applicationId} editDisabled isSubsection />
+            */}
             <GuardianInformationCard applicationId={applicationId} editDisabled isSubsection />
             <PaymentInformationCard applicationId={applicationId} editDisabled isSubsection />
           </>
@@ -79,7 +82,9 @@ export default function ReviewInformationStep({
           <>
             <PersonalInformationCard applicationId={applicationId} editDisabled isSubsection />
             <DoctorInformationCard applicationId={applicationId} editDisabled isSubsection />
+            {/* HIDDEN [RCD] Remove Additional Information Section:
             <AdditionalInformationCard applicationId={applicationId} editDisabled isSubsection />
+            */}
             <PaymentInformationCard applicationId={applicationId} editDisabled isSubsection />
           </>
         );

--- a/components/applicant/renewals/RenewalForm/ReviewSection.tsx
+++ b/components/applicant/renewals/RenewalForm/ReviewSection.tsx
@@ -9,8 +9,9 @@ import {
 } from '@lib/utils/format';
 import { FC } from 'react';
 import ReviewRequestField from '@components/applicant/renewals/RenewalForm/ReviewRequestField';
-import { titlecase } from '@tools/string';
-import { RequiresWiderParkingSpaceReason } from '@lib/graphql/types';
+// HIDDEN [RCD] Remove Additional Information Section:
+// import { titlecase } from '@tools/string';
+// import { RequiresWiderParkingSpaceReason } from '@lib/graphql/types';
 
 const ReviewSection: FC = () => {
   const { goToStep } = RenewalFlow.useContainer();
@@ -21,7 +22,8 @@ const ReviewSection: FC = () => {
     personalAddressInformation,
     contactInformation,
     doctorInformation,
-    additionalInformation,
+    // HIDDEN [RCD] Remove Additional Information Section:
+    // additionalInformation,
     donationAmount,
   } = RenewalForm.useContainer();
 
@@ -151,7 +153,7 @@ const ReviewSection: FC = () => {
       </VStack>
       <Divider />
 
-      {/* Additional information section */}
+      {/* HIDDEN [RCD] Remove Additional Information Section:
       <VStack align="flex-start">
         <Flex minWidth={{ md: '640px' }} justifyContent="space-between">
           <Text as="h3" textStyle="heading">{`Additional Information`}</Text>
@@ -204,14 +206,18 @@ const ReviewSection: FC = () => {
         </VStack>
       </VStack>
       <Divider />
+      */}
 
       {/* Donation section */}
+      {/* HIDDEN [RCD] Remove Additional Information Section: donation step
+          shifted from index 4 to 3 because Additional Information step is
+          hidden. */}
       <VStack align="flex-start">
         <Flex minWidth={{ md: '640px' }} justifyContent="space-between">
           <Text as="h3" textStyle="heading">{`Donation`}</Text>
           <Button
             variant="outline"
-            onClick={() => goToStep(4)}
+            onClick={() => goToStep(3)}
             display={{ sm: 'none', md: 'initial' }}
           >{`Edit`}</Button>
         </Flex>
@@ -220,7 +226,7 @@ const ReviewSection: FC = () => {
         </VStack>
         <Button
           variant="outline"
-          onClick={() => goToStep(4)}
+          onClick={() => goToStep(3)}
           display={{ md: 'none' }}
         >{`Edit`}</Button>
       </VStack>

--- a/components/applicant/renewals/RenewalForm/index.tsx
+++ b/components/applicant/renewals/RenewalForm/index.tsx
@@ -26,7 +26,8 @@ import RenewalFormContainer from '@containers/RenewalForm';
 import PersonalAddressSection from './PersonalAddressSection';
 import ContactInformationSection from './ContactInformationSection';
 import DoctorInformationSection from './DoctorInformationSection';
-import AdditionalInformationSection from './AdditionalInformationSection';
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalInformationSection from './AdditionalInformationSection';
 import DonationSection from './DonationSection';
 import ReviewSection from './ReviewSection';
 
@@ -184,9 +185,11 @@ const RenewalForm: FC = () => {
         <Step label={`Doctor's Information`}>
           <DoctorInformationSection />
         </Step>
+        {/* HIDDEN [RCD] Remove Additional Information Section:
         <Step label="Additional Information">
           <AdditionalInformationSection />
         </Step>
+        */}
         <Step label="Donation">
           <DonationSection />
         </Step>

--- a/containers/RenewalFlow.ts
+++ b/containers/RenewalFlow.ts
@@ -4,7 +4,9 @@ import { useEffect, useState } from 'react';
 import { createContainer } from 'unstated-next'; // Unstated Next
 
 /** Review step number */
-const REVIEW_STEP = 5;
+// HIDDEN [RCD] Remove Additional Information Section: was 5; shifted to 4
+// because the Additional Information step is hidden in RenewalForm/index.tsx.
+const REVIEW_STEP = 4;
 
 /**
  * Hook for managing the state of the overall applicant renewal request flow

--- a/pages/admin/request/[id].tsx
+++ b/pages/admin/request/[id].tsx
@@ -9,7 +9,8 @@ import PaymentInformationCard from '@components/admin/requests/payment-informati
 import PersonalInformationCard from '@components/admin/requests/permit-holder-information/Card'; // Personal information card
 import ProcessingTasksCard from '@components/admin/requests/processing/TasksCard'; // Processing tasks card
 import PhysicianAssessmentCard from '@components/admin/requests/physician-assessment/Card'; // Physician assessment card
-import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card'; // Additional Information card
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalInformationCard from '@components/admin/requests/additional-questions/Card'; // Additional Information card
 import { authorize } from '@tools/authorization'; // Page authorization
 import { useQuery } from '@tools/hooks/graphql'; // Apollo Client hooks
 import {
@@ -140,12 +141,14 @@ const Request: NextPage<Props> = ({ id: idString }: Props) => {
               editDisabled={reviewRequestCompleted || isRejected}
             />
           )}
+          {/* HIDDEN [RCD] Remove Additional Information Section:
           {type !== 'REPLACEMENT' && (
             <AdditionalInformationCard
               applicationId={id}
               editDisabled={reviewRequestCompleted || isRejected}
             />
           )}
+          */}
           <PaymentInformationCard
             applicationId={id}
             editDisabled={paidThroughShopify || reviewRequestCompleted}

--- a/pages/admin/request/create-new.tsx
+++ b/pages/admin/request/create-new.tsx
@@ -24,7 +24,8 @@ import PermitHolderInformationForm from '@components/admin/requests/permit-holde
 import PhysicianAssessmentForm from '@components/admin/requests/physician-assessment/Form';
 import DoctorInformationForm from '@components/admin/requests/doctor-information/Form';
 import GuardianInformationForm from '@components/admin/requests/guardian-information/Form';
-import AdditionalQuestionsForm from '@components/admin/requests/additional-questions/Form';
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalQuestionsForm from '@components/admin/requests/additional-questions/Form';
 import PaymentDetailsForm from '@components/admin/requests/payment-information/Form';
 import BackToSearchModal from '@components/admin/requests/create/BackToSearchModal';
 import CancelCreateRequestModal from '@components/admin/requests/create/CancelModal';
@@ -514,6 +515,7 @@ export default function CreateNew() {
                       onUploadFile={setGuardianPOAFile}
                     />
                   </Box>
+                  {/* HIDDEN [RCD] Remove Additional Information Section:
                   <Box
                     w="100%"
                     p="40px"
@@ -528,6 +530,7 @@ export default function CreateNew() {
                     </Text>
                     <AdditionalQuestionsForm additionalInformation={values.additionalInformation} />
                   </Box>
+                  */}
                   <Box
                     w="100%"
                     p="40px"

--- a/pages/admin/request/create-renewal.tsx
+++ b/pages/admin/request/create-renewal.tsx
@@ -3,7 +3,8 @@ import { Text, Box, Flex, Stack, Button, GridItem, useToast } from '@chakra-ui/r
 import { useState } from 'react'; // React
 import PermitHolderInformationForm from '@components/admin/requests/permit-holder-information/Form'; //Permit holder information form
 import DoctorInformationForm from '@components/admin/requests/doctor-information/Form'; //Doctor information form
-import AdditionalQuestionsForm from '@components/admin/requests/additional-questions/Form'; //Additional questions form
+// HIDDEN [RCD] Remove Additional Information Section:
+// import AdditionalQuestionsForm from '@components/admin/requests/additional-questions/Form'; //Additional questions form
 import PaymentDetailsForm from '@components/admin/requests/payment-information/Form'; //Payment details form
 import { PaymentInformationFormData } from '@tools/admin/requests/payment-information';
 import Link from 'next/link'; // Link
@@ -347,7 +348,7 @@ export default function CreateRenewal() {
                     </Box>
                   </Box>
                 </GridItem>
-                {/* Additional Quesitons Form */}
+                {/* HIDDEN [RCD] Remove Additional Information Section:
                 <GridItem paddingTop="32px">
                   <Box
                     border="1px solid"
@@ -365,6 +366,7 @@ export default function CreateRenewal() {
                     <AdditionalQuestionsForm additionalInformation={values.additionalInformation} />
                   </Box>
                 </GridItem>
+                */}
                 {/* Payment Details Form */}
                 <GridItem paddingTop="32px" paddingBottom="68px">
                   <Box

--- a/tools/admin/requests/create-new.ts
+++ b/tools/admin/requests/create-new.ts
@@ -182,11 +182,15 @@ export const INITIAL_GUARDIAN_INFORMATION: GuardianInformation = {
   poaFormS3ObjectUrl: '',
 };
 
-// Initial data for additional questions in application forms
+// Initial data for additional questions in application forms.
+// HIDDEN [RCD] Remove Additional Information Section: section UI is hidden in
+// admin create-new/create-renewal pages, so the booleans default to false to
+// keep the Formik schema valid without user input. Restore nulls when the UI
+// is brought back.
 export const INITIAL_ADDITIONAL_QUESTIONS: AdditionalInformationFormData = {
-  usesAccessibleConvertedVan: null,
+  usesAccessibleConvertedVan: false,
   accessibleConvertedVanLoadingMethod: null,
-  requiresWiderParkingSpace: null,
+  requiresWiderParkingSpace: false,
   requiresWiderParkingSpaceReason: null,
   otherRequiresWiderParkingSpaceReason: null,
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[RCD] (New) (Good First Issue) Remove Additional Information Section](https://app.notion.com/p/uwblueprintexecs/RCD-New-Good-First-Issue-Remove-Additional-Information-Section-36d10f3fb1dc806ab82ecc5ed816806b?v=63e8bea779664acbb10b1ea094e0fdcc&source=copy_link)

The ticket notes the converted-van / wider-parking questions have been largely unused by the Parking Permit team, and recommends hiding rather than fully removing.

## Implementation description
* The Additional Information UI is commented out — not deleted — with greppable `HIDDEN [RCD]` markers so the section can be restored by reversing the diff. Backend (Prisma schema, GraphQL types/resolvers, validation schemas, mutations, dev seed) is left untouched: existing records keep their data, the API still accepts the fields, and edit-modal/form components remain available for whenever the section is brought back.
* Hidden surfaces (6 render sites):
  * Admin request detail page — `pages/admin/request/[id].tsx`
  * "Review Request Information" modal (NEW + RENEWAL) — `components/admin/requests/processing/ReviewInformationStep.tsx`
  * Permit holder "Current APP Request" card — `components/admin/permit-holders/current-application/Card/index.tsx`
  * Admin create-new APP form — `pages/admin/request/create-new.tsx`
  * Admin create-renewal form — `pages/admin/request/create-renewal.tsx`
  * Applicant renewal flow step + review section — `components/applicant/renewals/RenewalForm/index.tsx`, `ReviewSection.tsx`
* Side adjustments needed so the now-invisible fields don't block form submission:
  * `tools/admin/requests/create-new.ts`: `INITIAL_ADDITIONAL_QUESTIONS` booleans default to `false` (was `null`) so `additionalQuestionsSchema` in the admin create forms validates without user input.
  * `containers/RenewalFlow.ts`: `REVIEW_STEP` shifted from `5` → `4` to account for the dropped step.
  * `components/applicant/renewals/RenewalForm/ReviewSection.tsx`: donation `goToStep(4)` → `goToStep(3)` for the same reason.
* The applicant `RenewalForm` container already initializes `additionalInformation` with `false`/`null` defaults, and those values are still spread into the renewal mutation input — so submissions match the existing schema with no backend change required.

## Before
<img width="1208" height="1134" alt="image" src="https://github.com/user-attachments/assets/99df10af-2d12-4f45-ac0f-39df2149edb5" />

## After
<img width="1215" height="1157" alt="image" src="https://github.com/user-attachments/assets/5eb3d1a7-45a0-4cae-9743-62dcea872778" />

<img width="1106" height="1160" alt="image" src="https://github.com/user-attachments/assets/47159aa3-c957-46bf-b9a7-4f5899b8242e" />

## Notes
* No DB migration. Existing rows keep their converted-van/wider-parking values; new submissions write the defaults (`false`/`null`).
* To restore the section, grep for `HIDDEN [RCD]` and reverse the comments. The two index shifts (`REVIEW_STEP`, donation `goToStep`) and the `INITIAL_ADDITIONAL_QUESTIONS` boolean defaults are also flagged with the same marker.
* Verified locally: `yarn type-check`, `yarn lint:eslint`, `yarn lint:prettier` all pass.
* Did not test the UI in the browser — opening this as a draft so reviewers can sanity-check the renewal flow step indices and the admin create forms' "Create request" button enables correctly.

## Checklist
- [x] My PR name is descriptive, is in imperative tense and starts with one of the following: `[Feature]`,`[Improvement]` or `[Fix]`,
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the RCD team on GitHub, or specific people who are associated with this ticket